### PR TITLE
Fix a retain cycle causing Tabs to not be deallocated

### DIFF
--- a/DuckDuckGo/BrowserTab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/BrowserTab/ViewModel/TabViewModel.swift
@@ -80,7 +80,10 @@ class TabViewModel {
     }
 
     private func subscribeToTabError() {
-        tab.$hasError.receive(on: DispatchQueue.main).assign(to: \.isErrorViewVisible, on: self).store(in: &cancellables)
+        tab.$hasError.receive(on: DispatchQueue.main).sink { [weak self] _ in
+            guard let self = self else { return }
+            self.isErrorViewVisible = self.tab.hasError
+        } .store(in: &cancellables)
     }
 
     private func updateCanReload() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1193060753475688/1198730132756653
CC: @tomasstrba 

**Description**:

This PR fixes an issue where Tab instances weren't being deallocated, so their associated web views were still active and could even continue playing AV content after a tab was closed.

This came about by me trying to get too fancy with Combine. There might be a cleaner way to do this using `Binding`, but this PR updates the approach to be consistent with other Combine usage for now.

**Steps to test this PR**:
1. Open a few tabs in the browser and load a webpage in each
1. Close the tabs
1. Open the Xcode memory debugger and check that there aren't any rogue `Tab` instances present

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
