### PR TITLE
Fix warnings added in SwiftLint 0.42

### DIFF
--- a/DuckDuckGo/Common/Extensions/URLRequestExtension.swift
+++ b/DuckDuckGo/Common/Extensions/URLRequestExtension.swift
@@ -26,7 +26,7 @@ extension URLRequest {
         case userAgent = "User-Agent"
     }
 
-    //Note: Change the user agent to macOS version before the release
+    // Note: Change the user agent to macOS version before the release
     static func defaultRequest(with url: URL) -> URLRequest {
         var request = URLRequest(url: url)
         request.setValue("gzip;q=1.0, compress;q=0.5",

--- a/DuckDuckGo/Common/View/MouseOverView.swift
+++ b/DuckDuckGo/Common/View/MouseOverView.swift
@@ -81,7 +81,7 @@ class MouseOverView: NSView {
         updateIsMouseOver()
     }
 
-    //swiftlint:disable legacy_nsgeometry_functions
+    // swiftlint:disable legacy_nsgeometry_functions
     private func updateIsMouseOver() {
         guard let window = window else {
             return
@@ -94,6 +94,6 @@ class MouseOverView: NSView {
             isMouseOver = false
         }
     }
-    //swiftlint:enable legacy_nsgeometry_functions
+    // swiftlint:enable legacy_nsgeometry_functions
 
 }

--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -20,7 +20,7 @@ import Cocoa
 import Combine
 import os.log
 
-//swiftlint:disable type_body_length
+// swiftlint:disable type_body_length
 
 class AddressBarTextField: NSTextField {
 
@@ -447,4 +447,4 @@ extension AddressBarTextField: SuggestionsViewControllerDelegate {
 
 }
 
-//swiftlint:enable type_body_length
+// swiftlint:enable type_body_length

--- a/Unit Tests/Suggestions/Model/SuggestionsTests.swift
+++ b/Unit Tests/Suggestions/Model/SuggestionsTests.swift
@@ -59,9 +59,9 @@ extension SuggestionsAPIResult {
         """
         let data = json.data(using: .utf8)!
 
-        //swiftlint:disable force_try
+        // swiftlint:disable force_try
         return try! JSONDecoder().decode(SuggestionsAPIResult.self, from: data)
-        //swiftlint:enable force_try
+        // swiftlint:enable force_try
     }
 
 }


### PR DESCRIPTION
This is a quick PR to fix some warnings that show up in the most recent SwiftLint version, which I noticed when testing #17. 🙂 This is similar to changes added to the iOS app to fix the same issue: https://github.com/duckduckgo/iOS/pull/803 
