### PR TITLE
Remove redundant `public` keywords

### DIFF
--- a/DuckDuckGo/Common/Database/Database.swift
+++ b/DuckDuckGo/Common/Database/Database.swift
@@ -19,18 +19,18 @@
 import Foundation
 import CoreData
 
-public class Database {
+class Database {
     
     fileprivate struct Constants {
         static let databaseName = "Database"
     }
     
-    public static let shared = Database()
+    static let shared = Database()
 
     private let semaphore = DispatchSemaphore(value: 0)
     private let container: NSPersistentContainer
     
-    public var model: NSManagedObjectModel {
+    var model: NSManagedObjectModel {
         return container.managedObjectModel
     }
     
@@ -46,7 +46,7 @@ public class Database {
         container = DDGPersistentContainer(name: name, managedObjectModel: model)
     }
     
-    public func loadStore(migrationHandler: @escaping (NSManagedObjectContext) -> Void = { _ in }) {
+    func loadStore(migrationHandler: @escaping (NSManagedObjectContext) -> Void = { _ in }) {
         container.loadPersistentStores { _, error in
             if let error = error {
                 fatalError("Could not load DB: \(error.localizedDescription)")
@@ -62,7 +62,7 @@ public class Database {
         }
     }
     
-    public func makeContext(concurrencyType: NSManagedObjectContextConcurrencyType, name: String? = nil) -> NSManagedObjectContext {
+    func makeContext(concurrencyType: NSManagedObjectContextConcurrencyType, name: String? = nil) -> NSManagedObjectContext {
         semaphore.wait()
         let context = NSManagedObjectContext(concurrencyType: concurrencyType)
         context.persistentStoreCoordinator = container.persistentStoreCoordinator
@@ -75,19 +75,19 @@ public class Database {
 
 extension NSManagedObjectContext {
     
-    public func deleteAll(entities: [NSManagedObject] = []) {
+    func deleteAll(entities: [NSManagedObject] = []) {
         for entity in entities {
             delete(entity)
         }
     }
     
-    public func deleteAll<T: NSManagedObject>(matching request: NSFetchRequest<T>) {
+    func deleteAll<T: NSManagedObject>(matching request: NSFetchRequest<T>) {
             if let result = try? fetch(request) {
                 deleteAll(entities: result)
             }
     }
     
-    public func deleteAll(entityDescriptions: [NSEntityDescription] = []) {
+    func deleteAll(entityDescriptions: [NSEntityDescription] = []) {
         for entityDescription in entityDescriptions {
             let request = NSFetchRequest<NSManagedObject>()
             request.entity = entityDescription
@@ -99,7 +99,7 @@ extension NSManagedObjectContext {
 
 private class DDGPersistentContainer: NSPersistentContainer {
 
-    override public class func defaultDirectoryURL() -> URL {
+    override class func defaultDirectoryURL() -> URL {
         return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
     } 
 }

--- a/DuckDuckGo/Common/FileSystem/FileStore.swift
+++ b/DuckDuckGo/Common/FileSystem/FileStore.swift
@@ -25,7 +25,7 @@ protocol FileStoring {
     func hasData(for fileName: String) -> Bool
 }
 
-public class FileStore: FileStoring {
+class FileStore: FileStoring {
 
     private let encryptionKey: SymmetricKey?
 

--- a/DuckDuckGo/Common/Utilities/Instruments.swift
+++ b/DuckDuckGo/Common/Utilities/Instruments.swift
@@ -19,9 +19,9 @@
 import Foundation
 import os.signpost
 
-public class Instruments {
+class Instruments {
 
-    public enum TimedEvent: String {
+    enum TimedEvent: String {
         case fetchingContentBlockerData
 
         case loadingDisconnectMeStore
@@ -34,11 +34,11 @@ public class Instruments {
         case injectScripts
     }
 
-    static public let shared = Instruments()
+    static let shared = Instruments()
 
     static var eventsLog = OSLog(subsystem: "com.duckduckgo.instrumentation", category: "Events")
 
-    public func startTimedEvent(_ event: TimedEvent, info: String? = nil) -> Any? {
+    func startTimedEvent(_ event: TimedEvent, info: String? = nil) -> Any? {
         let id = OSSignpostID(log: Instruments.eventsLog)
 
         os_signpost(.begin,
@@ -49,7 +49,7 @@ public class Instruments {
         return id
     }
 
-    public func endTimedEvent(for spid: Any?, result: String? = nil) {
+    func endTimedEvent(for spid: Any?, result: String? = nil) {
         if let id = spid as? OSSignpostID {
             os_signpost(.end,
                         log: Instruments.eventsLog,

--- a/DuckDuckGo/Common/Utilities/TabInstrumentation.swift
+++ b/DuckDuckGo/Common/Utilities/TabInstrumentation.swift
@@ -19,7 +19,7 @@
 import Foundation
 import os.signpost
 
-public class TabInstrumentation {
+class TabInstrumentation {
 
     static let tabsLog = OSLog(subsystem: "com.duckduckgo.instrumentation",
                                category: "TabInstrumentation")
@@ -30,22 +30,22 @@ public class TabInstrumentation {
     private var currentURL: String?
     private var currentTabIdentifier: UInt64
 
-    public init() {
+    init() {
         type(of: self).tabMaxIdentifier += 1
         currentTabIdentifier = type(of: self).tabMaxIdentifier
     }
 
     private var tabInitSPID: Any?
 
-    public func willPrepareWebView() {
+    func willPrepareWebView() {
         tabInitSPID = Instruments.shared.startTimedEvent(.tabInitialisation, info: "Tab-\(currentTabIdentifier)")
     }
 
-    public func didPrepareWebView() {
+    func didPrepareWebView() {
         Instruments.shared.endTimedEvent(for: tabInitSPID)
     }
 
-    public func willLoad(url: URL) {
+    func willLoad(url: URL) {
         currentURL = url.absoluteString
 
         let id = OSSignpostID(log: type(of: self).tabsLog)
@@ -58,7 +58,7 @@ public class TabInstrumentation {
 
     }
 
-    public func didLoadURL() {
+    func didLoadURL() {
 
         if let id = siteLoadingSPID as? OSSignpostID {
             os_signpost(.end,
@@ -71,15 +71,15 @@ public class TabInstrumentation {
 
     // MARK: - JS events
 
-    public func request(url: String, allowedIn timeInMs: Double) {
+    func request(url: String, allowedIn timeInMs: Double) {
         request(url: url, isTracker: false, blocked: false, in: timeInMs)
     }
 
-    public func tracker(url: String, allowedIn timeInMs: Double, reason: String?) {
+    func tracker(url: String, allowedIn timeInMs: Double, reason: String?) {
         request(url: url, isTracker: true, blocked: false, reason: reason ?? "?", in: timeInMs)
     }
 
-    public func tracker(url: String, blockedIn timeInMs: Double) {
+    func tracker(url: String, blockedIn timeInMs: Double) {
         request(url: url, isTracker: true, blocked: true, in: timeInMs)
     }
 
@@ -96,7 +96,7 @@ public class TabInstrumentation {
                "[%@] Request: %@ - %@ - %@ (%@) in %llu", currentURL, url, requestType, status, reason, timeInNS)
     }
 
-    public func jsEvent(name: String, executedIn timeInMs: Double) {
+    func jsEvent(name: String, executedIn timeInMs: Double) {
 
         let currentURL = self.currentURL ?? "unknown"
         // 0 is treated as 1ms

--- a/DuckDuckGo/Common/View/ColorView.swift
+++ b/DuckDuckGo/Common/View/ColorView.swift
@@ -26,13 +26,13 @@ class ColorView: NSView {
         setupView()
     }
 
-    public override init(frame frameRect: NSRect) {
+    override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
 
         setupView()
     }
 
-    @IBInspectable public var backgroundColor: NSColor? = NSColor.clear {
+    @IBInspectable var backgroundColor: NSColor? = NSColor.clear {
         didSet {
             layer?.backgroundColor = backgroundColor?.cgColor
         }

--- a/DuckDuckGo/Common/View/GradientView.swift
+++ b/DuckDuckGo/Common/View/GradientView.swift
@@ -26,7 +26,7 @@ class GradientView: NSView {
         setupView()
     }
 
-    public override init(frame frameRect: NSRect) {
+    override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
 
         setupView()

--- a/DuckDuckGo/ContentBlocker/ContentBlockerRulesManager.swift
+++ b/DuckDuckGo/ContentBlocker/ContentBlockerRulesManager.swift
@@ -21,15 +21,15 @@ import WebKit
 import os.log
 import TrackerRadarKit
 
-public class ContentBlockerRulesManager {
+class ContentBlockerRulesManager {
 
-    public static let shared = ContentBlockerRulesManager()
+    static let shared = ContentBlockerRulesManager()
 
-    public var blockingRules: WKContentRuleList?
+    var blockingRules: WKContentRuleList?
 
     private init() {}
 
-    public func compileRules(completion: ((WKContentRuleList?) -> Void)?) {
+    func compileRules(completion: ((WKContentRuleList?) -> Void)?) {
         guard let trackerData = TrackerDataManager.shared.trackerData else {
             completion?(nil)
             return

--- a/DuckDuckGo/ContentBlocker/DetectedTracker.swift
+++ b/DuckDuckGo/ContentBlocker/DetectedTracker.swift
@@ -20,25 +20,25 @@ import Foundation
 import TrackerRadarKit
 
 // Populated with relevant info at the point of detection.
-public struct DetectedTracker {
+struct DetectedTracker {
 
-    public let url: String
-    public let knownTracker: KnownTracker?
-    public let entity: Entity?
-    public let blocked: Bool
+    let url: String
+    let knownTracker: KnownTracker?
+    let entity: Entity?
+    let blocked: Bool
 
-    public init(url: String, knownTracker: KnownTracker?, entity: Entity?, blocked: Bool) {
+    init(url: String, knownTracker: KnownTracker?, entity: Entity?, blocked: Bool) {
         self.url = url
         self.knownTracker = knownTracker
         self.entity = entity
         self.blocked = blocked
     }
 
-    public var domain: String? {
+    var domain: String? {
         return URL(string: url)?.host
     }
 
-    public var networkNameForDisplay: String {
+    var networkNameForDisplay: String {
         return entity?.displayName ?? domain ?? url
     }
 
@@ -46,12 +46,12 @@ public struct DetectedTracker {
 
 extension DetectedTracker: Hashable, Equatable {
 
-    public static func == (lhs: DetectedTracker, rhs: DetectedTracker) -> Bool {
+    static func == (lhs: DetectedTracker, rhs: DetectedTracker) -> Bool {
         return ((lhs.entity != nil || rhs.entity != nil) && lhs.entity?.displayName == rhs.entity?.displayName)
             && lhs.domain ?? "" == rhs.domain ?? ""
     }
 
-    public func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.entity?.displayName)
         hasher.combine(self.domain)
     }

--- a/DuckDuckGo/ContentBlocker/TrackerDataManager.swift
+++ b/DuckDuckGo/ContentBlocker/TrackerDataManager.swift
@@ -19,11 +19,11 @@
 import Foundation
 import TrackerRadarKit
 
-public class TrackerDataManager {
+class TrackerDataManager {
 
     struct Constants {
-        public static let embeddedDataSetETag = "7c0a71eb049748b86e8590353141a90f"
-        public static let embeddedDataSetSHA = "rIBc/qpKYsUxT6+oceMEnF/IUgBCz0tcWMOQWW/waac="
+        static let embeddedDataSetETag = "7c0a71eb049748b86e8590353141a90f"
+        static let embeddedDataSetSHA = "rIBc/qpKYsUxT6+oceMEnF/IUgBCz0tcWMOQWW/waac="
     }
 
     enum DataSet {
@@ -36,15 +36,15 @@ public class TrackerDataManager {
 
     static let shared = TrackerDataManager()
 
-    private(set) public var trackerData: TrackerData! {
+    private(set) var trackerData: TrackerData! {
         didSet {
             let encodedData = try? JSONEncoder().encode(trackerData)
             encodedTrackerData = String(data: encodedData!, encoding: .utf8)!
         }
     }
 
-    private(set) public var encodedTrackerData: String!
-    private(set) public var etag: String?
+    private(set) var encodedTrackerData: String!
+    private(set) var etag: String?
 
     init(trackerData: TrackerData) {
         self.trackerData = trackerData

--- a/DuckDuckGo/Smarter Encryption/Domain/HTTPSBloomFilterSpecification.swift
+++ b/DuckDuckGo/Smarter Encryption/Domain/HTTPSBloomFilterSpecification.swift
@@ -18,13 +18,13 @@
 
 import Foundation
 
-public struct HTTPSBloomFilterSpecification: Equatable, Decodable {
+struct HTTPSBloomFilterSpecification: Equatable, Decodable {
     let bitCount: Int
     let errorRate: Double
     let totalEntries: Int
     let sha256: String
     
-    static public func == (lhs: HTTPSBloomFilterSpecification, rhs: HTTPSBloomFilterSpecification) -> Bool {
+    static func == (lhs: HTTPSBloomFilterSpecification, rhs: HTTPSBloomFilterSpecification) -> Bool {
         return lhs.bitCount == rhs.bitCount && lhs.errorRate == rhs.errorRate && lhs.totalEntries == rhs.totalEntries && lhs.sha256 == rhs.sha256
     }
     

--- a/DuckDuckGo/Smarter Encryption/HTTPSUpgrade.swift
+++ b/DuckDuckGo/Smarter Encryption/HTTPSUpgrade.swift
@@ -19,10 +19,10 @@
 import Foundation
 import os.log
 
-public class HTTPSUpgrade {
+class HTTPSUpgrade {
 
-    public typealias UpgradeCheckCompletion = (Bool) -> Void
-    public static let shared = HTTPSUpgrade()
+    typealias UpgradeCheckCompletion = (Bool) -> Void
+    static let shared = HTTPSUpgrade()
     
     private let dataReloadLock = NSLock()
     private let store: HTTPSUpgradeStore
@@ -32,7 +32,7 @@ public class HTTPSUpgrade {
         self.store = store
     }
 
-    public func isUpgradeable(url: URL, completion: @escaping UpgradeCheckCompletion) {
+    func isUpgradeable(url: URL, completion: @escaping UpgradeCheckCompletion) {
         
         guard url.scheme == URL.Scheme.http.rawValue else {
             completion(false)
@@ -66,13 +66,13 @@ public class HTTPSUpgrade {
         dataReloadLock.unlock()
     }
     
-    public func loadDataAsync() {
+    func loadDataAsync() {
         DispatchQueue.global(qos: .background).async {
             self.loadData()
         }
     }
     
-    public func loadData() {
+    func loadData() {
         if !dataReloadLock.try() {
             os_log("Reload already in progress", type: .debug)
             return

--- a/DuckDuckGo/Smarter Encryption/Store/HTTPSUpgradeStore.swift
+++ b/DuckDuckGo/Smarter Encryption/Store/HTTPSUpgradeStore.swift
@@ -20,7 +20,7 @@ import Foundation
 import CoreData
 import os.log
 
-public protocol HTTPSUpgradeStore {
+protocol HTTPSUpgradeStore {
     
     func bloomFilter() -> BloomFilterWrapper?
     
@@ -33,7 +33,7 @@ public protocol HTTPSUpgradeStore {
     @discardableResult func persistExcludedDomains(_ domains: [String]) -> Bool
 }
 
-public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
+class HTTPSUpgradePersistence: HTTPSUpgradeStore {
     
     private struct Resource {
         static var bloomFilter: URL {
@@ -60,7 +60,7 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
         return (try? Resource.bloomFilter.checkResourceIsReachable()) ?? false
     }
     
-    public func bloomFilter() -> BloomFilterWrapper? {
+    func bloomFilter() -> BloomFilterWrapper? {
         let storedSpecification = hasBloomFilterData ? bloomFilterSpecification() : loadEmbeddedData()?.specification
         guard let specification = storedSpecification else { return nil }
         return BloomFilterWrapper(fromPath: Resource.bloomFilter.path,
@@ -68,7 +68,7 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
                                   andTotalItems: Int32(specification.totalEntries))
     }
     
-    public func bloomFilterSpecification() -> HTTPSBloomFilterSpecification? {
+    func bloomFilterSpecification() -> HTTPSBloomFilterSpecification? {
         var specification: HTTPSBloomFilterSpecification?
         context.performAndWait {
             let request: NSFetchRequest<HTTPSStoredBloomFilterSpecification> = HTTPSStoredBloomFilterSpecification.fetchRequest()
@@ -95,7 +95,7 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
         return EmbeddedBloomData(specification: specification, bloomFilter: bloomData, excludedDomains: excludedDomains.data)
     }
     
-    @discardableResult public func persistBloomFilter(specification: HTTPSBloomFilterSpecification, data: Data) -> Bool {
+    @discardableResult func persistBloomFilter(specification: HTTPSBloomFilterSpecification, data: Data) -> Bool {
         guard data.sha256 == specification.sha256 else { return false }
         guard persistBloomFilter(data: data) else { return false }
         persistBloomFilterSpecification(specification)
@@ -146,7 +146,7 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
         }
     }
     
-    public func shouldExcludeDomain(_ domain: String) -> Bool {
+    func shouldExcludeDomain(_ domain: String) -> Bool {
         var result = false
         context.performAndWait {
             let request: NSFetchRequest<HTTPSExcludedDomain> = HTTPSExcludedDomain.fetchRequest()
@@ -157,7 +157,7 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
         return result
     }
     
-    @discardableResult public func persistExcludedDomains(_ domains: [String]) -> Bool {
+    @discardableResult func persistExcludedDomains(_ domains: [String]) -> Bool {
         var result = true
         context.performAndWait {
             deleteExcludedDomains()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1199673890207874
CC: @tomasstrba 

**Description**:

This PR cleans up redundant `public` access control specifiers.

**Steps to test this PR**:
1. Test the app compiles
1. Test the the test suite compiles

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
