### PR TITLE
apply UA based on domain

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		4BB88B4A25B7B690006F6B06 /* SequenceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB88B4925B7B690006F6B06 /* SequenceExtensions.swift */; };
 		4BB88B5025B7BA2B006F6B06 /* TabInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB88B4F25B7BA2B006F6B06 /* TabInstrumentation.swift */; };
 		4BB88B5B25B7BA50006F6B06 /* Instruments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB88B5A25B7BA50006F6B06 /* Instruments.swift */; };
+		8546DE6225C03056000CA5E1 /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8546DE6125C03056000CA5E1 /* UserAgentTests.swift */; };
 		8553FF52257523760029327F /* FileDownloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8553FF51257523760029327F /* FileDownloadTests.swift */; };
 		8556A602256BDDD30092FA9D /* HTML5DownloadUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8556A601256BDDD30092FA9D /* HTML5DownloadUserScript.swift */; };
 		8556A60E256C15DD0092FA9D /* FileDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8556A60D256C15DD0092FA9D /* FileDownload.swift */; };
@@ -230,6 +231,7 @@
 		4BB88B4925B7B690006F6B06 /* SequenceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensions.swift; sourceTree = "<group>"; };
 		4BB88B4F25B7BA2B006F6B06 /* TabInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabInstrumentation.swift; sourceTree = "<group>"; };
 		4BB88B5A25B7BA50006F6B06 /* Instruments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instruments.swift; sourceTree = "<group>"; };
+		8546DE6125C03056000CA5E1 /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		8553FF51257523760029327F /* FileDownloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloadTests.swift; sourceTree = "<group>"; };
 		8556A601256BDDD30092FA9D /* HTML5DownloadUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTML5DownloadUserScript.swift; sourceTree = "<group>"; };
 		8556A60D256C15DD0092FA9D /* FileDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownload.swift; sourceTree = "<group>"; };
@@ -907,6 +909,7 @@
 			isa = PBXGroup;
 			children = (
 				AAC9C01424CAFBCE00AD1325 /* TabTests.swift */,
+				8546DE6125C03056000CA5E1 /* UserAgentTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1373,6 +1376,7 @@
 				4BA1A6DE258C100A00F6F690 /* FileStoreTests.swift in Sources */,
 				AAC9C01C24CB594C00AD1325 /* TabViewModelTests.swift in Sources */,
 				4B11060525903E570039B979 /* CoreDataEncryptionTesting.xcdatamodeld in Sources */,
+				8546DE6225C03056000CA5E1 /* UserAgentTests.swift in Sources */,
 				4B82E9C125B6A1CD00656FE7 /* TrackerDataManagerTests.swift in Sources */,
 				AA63745224C9BBE100AB2AC4 /* SuggestionsAPIMock.swift in Sources */,
 				142879DC24CE1185005419BB /* SuggestionsViewModelTests.swift in Sources */,

--- a/DuckDuckGo/BrowserTab/Model/Tab.swift
+++ b/DuckDuckGo/BrowserTab/Model/Tab.swift
@@ -110,7 +110,6 @@ class Tab: NSObject {
     private func setupWebView() {
         webView.navigationDelegate = self
         webView.allowsBackForwardNavigationGestures = true
-        webView.customUserAgent = UserAgent.safari
     }
 
     // MARK: - Favicon
@@ -242,6 +241,8 @@ extension Tab: WKNavigationDelegate {
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
 
+        updateUserAgentForDomain(navigationAction.request.url?.host)
+
         if navigationAction.isTargetingMainFrame() {
             lastMainFrameRequest = navigationAction.request
             currentDownload = nil
@@ -286,6 +287,11 @@ extension Tab: WKNavigationDelegate {
         let policy = navigationResponsePolicyForDownloads(navigationResponse)
         decisionHandler(policy)
 
+    }
+
+    private func updateUserAgentForDomain(_ host: String?) {
+        let domain = host ?? ""
+        webView.customUserAgent = UserAgent.forDomain(domain)
     }
 
     private func navigationResponsePolicyForDownloads(_ navigationResponse: WKNavigationResponse) -> WKNavigationResponsePolicy {

--- a/DuckDuckGo/BrowserTab/Model/UserAgent.swift
+++ b/DuckDuckGo/BrowserTab/Model/UserAgent.swift
@@ -20,8 +20,15 @@ import Foundation
 
 class UserAgent {
 
-    static var safari: String {
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15"
+    static let safari = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15"
+    static let chrome = "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36"
+
+    static let domainUserAgents = [
+        "docs.google.com": UserAgent.chrome
+    ]
+
+    static func forDomain(_ domain: String) -> String {
+        return Self.domainUserAgents[domain, default: UserAgent.safari]
     }
 
 }

--- a/Unit Tests/BrowserTab/Model/UserAgentTests.swift
+++ b/Unit Tests/BrowserTab/Model/UserAgentTests.swift
@@ -1,0 +1,32 @@
+//
+//  UserAgentTests.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+class UserAgentTests: XCTestCase {
+
+    func test_default_user_agent_is_safari() {
+        XCTAssertEqual(UserAgent.safari, UserAgent.forDomain("example.com"))
+    }
+
+    func test_when_domain_is_google_docs_then_user_agent_is_chrome() {
+        XCTAssertEqual(UserAgent.chrome, UserAgent.forDomain("docs.google.com"))
+    }
+    
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1199533787460799
Tech Design URL:
CC:

**Description**:

Apply a UA based on the domain.  Specifically, for now, use Chrome's UA for docs.google.com else the page crashes as it appears to use different JavaScript.

**Steps to test this PR**:
1. Visit the sheets link in the above asana task - it should load and not show any errors or incompatibly warnings.
1. Visit other pages and check they load as expected
1. Search for "user agent" on DDG and confirm the UA looks like Safari


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
