### PR TITLE
Javascript alert image changed

### DIFF
--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -356,8 +356,11 @@ extension BrowserTabViewController: WKUIDelegate {
 
 fileprivate extension NSAlert {
 
+    static var cautionImage = NSImage(named: "NSCaution")
+
     static func javascriptAlert(with message: String) -> NSAlert {
         let alert = NSAlert()
+        alert.icon = Self.cautionImage
         alert.messageText = message
         alert.addButton(withTitle: UserText.ok)
         return alert
@@ -365,6 +368,7 @@ fileprivate extension NSAlert {
 
     static func javascriptConfirmation(with message: String) -> NSAlert {
         let alert = NSAlert()
+        alert.icon = Self.cautionImage
         alert.messageText = message
         alert.addButton(withTitle: UserText.ok)
         alert.addButton(withTitle: UserText.cancel)
@@ -373,6 +377,7 @@ fileprivate extension NSAlert {
 
     static func javascriptTextInput(prompt: String, defaultText: String?) -> NSAlert {
         let alert = NSAlert()
+        alert.icon = Self.cautionImage
         alert.messageText = prompt
         alert.addButton(withTitle: UserText.ok)
         alert.addButton(withTitle: UserText.cancel)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1199873116922123/f

**Description**:
This PR changes DuckDuckGo logo in Javascript alerts to a caution system image.

_Note: I tried to remove the image completely because that’s how other browsers display alerts. Unfortunatelly, when I set empty NSImage as icon, NSAlert still leaves lots of space for the icon and the view looks broken. We plan to redo all of the alerts to custom views in the future. Until then, this is the quick fix_

**Steps to test this PR**:
1. Try [Javascript pop up boxes](https://www.w3schools.com/js/js_popup.asp) and make sure there is no DuckDuckGo icon on them


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
