### PR TITLE
Add copied links to the pasteboard directly

### DIFF
--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -210,6 +210,14 @@ extension BrowserTabViewController: LinkMenuItemSelectors {
         self.tab(tab, requestedFileDownload: FileDownload(request: URLRequest(url: url), suggestedName: nil))
     }
 
+    func copyLink(_ sender: NSMenuItem) {
+        guard let url = contextMenuLink as NSURL? else { return }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.declareTypes([.URL], owner: nil)
+        url.write(to: pasteboard)
+    }
+
 }
 
 extension BrowserTabViewController: ImageMenuItemSelectors {

--- a/DuckDuckGo/BrowserTab/View/MenuItemSelectors.swift
+++ b/DuckDuckGo/BrowserTab/View/MenuItemSelectors.swift
@@ -23,6 +23,7 @@ import Cocoa
     func openLinkInNewTab(_ sender: NSMenuItem)
     func openLinkInNewWindow(_ sender: NSMenuItem)
     func downloadLinkedFile(_ sender: NSMenuItem)
+    func copyLink(_ sender: NSMenuItem)
 
 }
 

--- a/DuckDuckGo/BrowserTab/View/WebView.swift
+++ b/DuckDuckGo/BrowserTab/View/WebView.swift
@@ -27,6 +27,7 @@ class WebView: WKWebView {
         "WKMenuItemIdentifierOpenLink": #selector(LinkMenuItemSelectors.openLinkInNewTab(_:)),
         "WKMenuItemIdentifierOpenLinkInNewWindow": #selector(LinkMenuItemSelectors.openLinkInNewWindow(_:)),
         "WKMenuItemIdentifierDownloadLinkedFile": #selector(LinkMenuItemSelectors.downloadLinkedFile(_:)),
+        "WKMenuItemIdentifierCopyLink": #selector(LinkMenuItemSelectors.copyLink(_:)),
 
         // Images
         "WKMenuItemIdentifierOpenImageInNewWindow": #selector(ImageMenuItemSelectors.openImageInNewWindow(_:)),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1199951991736477
Tech Design URL:
CC:

**Description**:

This PR fixes an issue where the `Copy Link` context item in the browser was copying the text, not the underlying URL.

The solution here is to grab the context menu URL and then write it to the Pasteboard directly.

**Steps to test this PR**:
1. Select some text and copy it with Command+C, to make sure it still works
1. Right click some links and click Copy Link, checking that they are copied correctly
1. Right click an embedded Asana link and select Copy Link, to ensure that the underlying link is what's copied

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**