### PR TITLE
remove AppDelegate.shared

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -2221,7 +2221,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://dub.duckduckgo.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 0.1.0;
 			};
 		};

--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -23,12 +23,6 @@ import os.log
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
-    static var shared: AppDelegate {
-        // swiftlint:disable force_cast
-        return (NSApp.delegate as! AppDelegate)
-        // swiftlint:enable force_cast
-    }
-
     private var isRunningTests: Bool {
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }

--- a/DuckDuckGo/NavigationBar/View/Base.lproj/NavigationBar.storyboard
+++ b/DuckDuckGo/NavigationBar/View/Base.lproj/NavigationBar.storyboard
@@ -155,7 +155,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <action selector="feedbackButtonAction:" target="o2v-eH-jTI" id="MY7-rh-qCW"/>
+                                    <action selector="openFeedback:" target="wkT-Td-n7D" id="1IP-IF-SD9"/>
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="XBe-xO-dXj" userLabel="Share Button" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">

--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -117,13 +117,7 @@ class NavigationBarViewController: NSViewController {
         sharing.show(relativeTo: .zero, of: sender, preferredEdge: .minY)
     }
 
-#if FEEDBACK
-
-    @IBAction func feedbackButtonAction(_ sender: NSButton) {
-        AppDelegate.shared.openFeedback(sender)
-    }
-
-#else
+#if !FEEDBACK
 
     private func removeFeedback() {
         feedbackButton.removeFromSuperview()

--- a/DuckDuckGo/NavigationBar/View/OptionsButtonMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/OptionsButtonMenu.swift
@@ -56,7 +56,6 @@ class OptionsButtonMenu: NSMenu {
         let openFeedbackMenuItem = NSMenuItem(title: "Send Feedback",
                                               action: #selector(AppDelegate.openFeedback(_:)),
                                          keyEquivalent: "")
-        openFeedbackMenuItem.target = AppDelegate.shared
         openFeedbackMenuItem.image = NSImage(named: "Feedback")
         addItem(openFeedbackMenuItem)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: -
Tech Design URL: -
CC: @samsymons @brindy 

**Description**:
This PR is tended to remove AppDelegate.shared var by using Responder Chain to handle menu/button action (see my comment in https://github.com/more-duckduckgo-org/macos-browser/pull/55), reducing coupling. 

**Steps to test this PR**:
1. Use Send Feedback menu item to open Feedback url from different windows
2. Use Send Feedback toolbar button to open Feedback url from different windows


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**