### PR TITLE
fix url entry breakage

### DIFF
--- a/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -111,8 +111,8 @@ extension URL {
            user == nil { return true }
 
         // This effectively allows external URLs to be entered by the user.
-		// Without this check single word entries get treated like domains.
-		return URL.NavigationalScheme(rawValue: scheme) == nil
+        // Without this check single word entries get treated like domains.
+        return URL.NavigationalScheme(rawValue: scheme) == nil
     }
 
     // MARK: - DuckDuckGo

--- a/Unit Tests/Common/URLExtensionTests.swift
+++ b/Unit Tests/Common/URLExtensionTests.swift
@@ -25,7 +25,7 @@ class URLExtensionTests: XCTestCase {
     func test_external_urls_are_valid() {
         XCTAssertTrue("mailto://user@host.tld".url!.isValid)
         XCTAssertTrue("sms://+44776424232323".url!.isValid)
-		XCTAssertTrue("ftp://example.com".url!.isValid)
+        XCTAssertTrue("ftp://example.com".url!.isValid)
     }
 
     func test_navigational_urls_are_valid() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:

Fixes a bug introduced in the open external URL PR.

**Steps to test this PR**:
1. Enter a single word in to the address bar and hit enter, a search should be performed.
1. Enter a supported external URL into the address bar and hit enter, e.g. sms://+44123123123 , the app should be prompted, clicking cancel will search
1. Enter an unsupported external URL into the address and hit enter, e.g. test://whatever, the app should search by default
1. Run the unit tests, they should all pass

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**