### PR TITLE
When bookmark is created, favicon is picked from favicon cache

### DIFF
--- a/DuckDuckGo/Homepage/View/AddEditFavoriteViewController.swift
+++ b/DuckDuckGo/Homepage/View/AddEditFavoriteViewController.swift
@@ -69,7 +69,7 @@ final class AddEditFavoriteViewController: NSViewController {
             if let bookmark = bookmarkManager.getBookmark(for: newUrl) {
                 update(bookmark: bookmark, newTitle: newTitle)
             } else {
-                bookmarkManager.makeBookmark(for: newUrl, title: newTitle, favicon: nil, isFavorite: true)
+                bookmarkManager.makeBookmark(for: newUrl, title: newTitle, isFavorite: true)
             }
         }
         view.window?.close()

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -219,7 +219,6 @@ final class AddressBarButtonsViewController: NSViewController {
         if bookmark == nil {
             bookmark = bookmarkManager.makeBookmark(for: url,
                                                     title: selectedTabViewModel.title,
-                                                    favicon: selectedTabViewModel.favicon,
                                                     isFavorite: false)
             updateBookmarkButtonImage(isUrlBookmarked: bookmark != nil)
         }

--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -663,7 +663,7 @@ extension TabBarViewController: TabBarViewItemDelegate {
         }
 
         if !bookmarkManager.isUrlBookmarked(url: url) {
-            bookmarkManager.makeBookmark(for: url, title: tabViewModel.title, favicon: tabViewModel.favicon, isFavorite: false)
+            bookmarkManager.makeBookmark(for: url, title: tabViewModel.title, isFavorite: false)
         }
     }
 

--- a/Unit Tests/Bookmarks/Model/LocalBookmarkManagerTests.swift
+++ b/Unit Tests/Bookmarks/Model/LocalBookmarkManagerTests.swift
@@ -32,7 +32,7 @@ final class LocalBookmarkManagerTests: XCTestCase {
         let faviconServiceMock = FaviconServiceMock()
         let bookmarkManager = LocalBookmarkManager(bookmarkStore: bookmarkStoreMock, faviconService: faviconServiceMock)
 
-        XCTAssertNil(bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Test", favicon: nil, isFavorite: false))
+        XCTAssertNil(bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Test", isFavorite: false))
         XCTAssertNil(bookmarkManager.updateUrl(of: Bookmark.aBookmark, to: URL.duckDuckGoAutocomplete))
     }
 
@@ -68,7 +68,7 @@ final class LocalBookmarkManagerTests: XCTestCase {
 
         let objectId = NSManagedObjectID()
         bookmarkStoreMock.managedObjectId = objectId
-        let bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", favicon: nil, isFavorite: false)!
+        let bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", isFavorite: false)!
 
         XCTAssert(bookmarkManager.isUrlBookmarked(url: bookmark.url))
         XCTAssert(bookmarkManager.getBookmark(for: bookmark.url)?.managedObjectId == objectId)
@@ -79,7 +79,7 @@ final class LocalBookmarkManagerTests: XCTestCase {
         let (bookmarkManager, bookmarkStoreMock) = LocalBookmarkManager.aManager
 
         bookmarkStoreMock.saveSuccess = false
-        let bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", favicon: nil, isFavorite: false)!
+        let bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", isFavorite: false)!
 
         XCTAssertFalse(bookmarkManager.isUrlBookmarked(url: bookmark.url))
         XCTAssert(bookmarkStoreMock.saveCalled)
@@ -90,9 +90,9 @@ final class LocalBookmarkManagerTests: XCTestCase {
 
         let objectId = NSManagedObjectID()
         bookmarkStoreMock.managedObjectId = objectId
-        _ = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", favicon: nil, isFavorite: false)!
+        _ = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", isFavorite: false)!
 
-        XCTAssertNil(bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", favicon: nil, isFavorite: false))
+        XCTAssertNil(bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", isFavorite: false))
     }
 
     func testWhenBookmarkIsRemoved_ThenManagerRemovesItFromStore() {
@@ -100,7 +100,7 @@ final class LocalBookmarkManagerTests: XCTestCase {
 
         let objectId = NSManagedObjectID()
         bookmarkStoreMock.managedObjectId = objectId
-        let bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", favicon: nil, isFavorite: false)!
+        let bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", isFavorite: false)!
 
         bookmarkManager.remove(bookmark: bookmark)
 
@@ -114,7 +114,7 @@ final class LocalBookmarkManagerTests: XCTestCase {
 
         let objectId = NSManagedObjectID()
         bookmarkStoreMock.managedObjectId = objectId
-        let bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", favicon: nil, isFavorite: false)!
+        let bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", isFavorite: false)!
 
         bookmarkStoreMock.removeSuccess = false
         bookmarkStoreMock.removeError = BookmarkManagerError.somethingReallyBad
@@ -150,7 +150,7 @@ final class LocalBookmarkManagerTests: XCTestCase {
 
         let objectId = NSManagedObjectID()
         bookmarkStoreMock.managedObjectId = objectId
-        var bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", favicon: nil, isFavorite: false)!
+        var bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", isFavorite: false)!
 
         bookmark.isFavorite = !bookmark.isFavorite
         bookmarkManager.update(bookmark: bookmark)
@@ -164,7 +164,7 @@ final class LocalBookmarkManagerTests: XCTestCase {
 
         let objectId = NSManagedObjectID()
         bookmarkStoreMock.managedObjectId = objectId
-        var bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", favicon: nil, isFavorite: false)!
+        var bookmark = bookmarkManager.makeBookmark(for: URL.duckDuckGo, title: "Title", isFavorite: false)!
 
         bookmark.isFavorite = !bookmark.isFavorite
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200118384144384/f

**Description**:
When high quality favicon was already cached and user added a favorite bookmark on homepage, the favicon wasn’t refreshed. The reason was favicon service didn’t post any update since the high quality favicon is already cached.

**Steps to test this PR**:
1. Make sure twitter.com is not in bookmarks
2. Visit twitter.com
3. Close tab
4. Go to Homepage and manually add twitter.com as favorite
5. Visit twitter.com
6. Go back to Homepage - favicon must be refreshed

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**