### PR TITLE
fix Failed to connect outlet.. error message (again)

### DIFF
--- a/DuckDuckGo/Homepage/View/HomepageCollectionViewItem.xib
+++ b/DuckDuckGo/Homepage/View/HomepageCollectionViewItem.xib
@@ -7,11 +7,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner">
-            <connections>
-                <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
-            </connections>
-        </customObject>
+        <customObject id="-2" userLabel="File's Owner"/>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/inbox/1199237043628108/1199933642678463/1199933646465063
Tech Design URL:
CC: @tomasstrba

Description:
The PR fixes error message printed in the log (again -- now from the HomepageCollectionViewItem):
[Nib Loading] Failed to connect (view) outlet from (NSObject) to (NSView): missing setter or instance variable

Steps to test this PR:

Open New Tab
Check the log
make sure New Tab items are working correctly