### PR TITLE
Fix of first responder

### DIFF
--- a/DuckDuckGo/Homepage/View/HomepageViewController.swift
+++ b/DuckDuckGo/Homepage/View/HomepageViewController.swift
@@ -105,6 +105,12 @@ final class HomepageViewController: NSViewController {
         displayDefaultBrowserPromptIfNeeded()
     }
 
+    override func mouseDown(with event: NSEvent) {
+        super.mouseDown(with: event)
+
+        view.window?.makeFirstResponder(nil)
+    }
+
     func layoutDefaultBrowserPromptView() {
         defaultBrowserPromptView.delegate = self
         defaultBrowserPromptView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1200042924618020/f

**Description**:
Sometimes, clicking on homepage didn’t change the first responder and address bar stayed focused. I added an explicit setting to nil that resolved the issue.

**Steps to test this PR**:
1. Open Homepage. Address bar should be the first responder
2. Click anywhere on homepage and make sure address bar is not first responder anymore.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**