### PR TITLE
Fix a threading crash

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/UserContentController.swift
+++ b/DuckDuckGo/BrowserTab/Model/UserContentController.swift
@@ -33,7 +33,7 @@ final class UserContentController: WKUserContentController {
     }
 
     func installContentBlockingRules(publisher: AnyPublisher<WKContentRuleList?, Never>) {
-        blockingRulesUpdatedCancellable = publisher.sink { [weak self] rules in
+        blockingRulesUpdatedCancellable = publisher.receive(on: RunLoop.main).sink { [weak self] rules in
             dispatchPrecondition(condition: .onQueue(.main))
 
             guard let self = self,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1200317705579351/f
Tech Design URL:
CC:

**Description**:

This PR fixes a GCD assertion that was tripping when asserting that we were on the main thread when we actually weren't.

The fix is a simple `receive(on:)` addition.

**Steps to test this PR**:
1. Test that `installContentBlockingRules` in `UserContentController` is getting called and is always on the main thread. I don't have any instructions for forcing this to happen unfortunately, I had this happen organically locally and was how I fixed it.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**