### PR TITLE
Use temporary unprotected sites list and decrease update frequency

### DIFF
--- a/DuckDuckGo/Configuration/ConfigurationManager.swift
+++ b/DuckDuckGo/Configuration/ConfigurationManager.swift
@@ -36,7 +36,7 @@ final class ConfigurationManager {
 #if DEBUG
         static let refreshPeriodSeconds = 60.0 * 2 // 2 minutes when in debug mode
 #else
-        static let refreshPeriodSeconds = 60.0 * 60 * 12 // 12 hours
+        static let refreshPeriodSeconds = 60.0 * 30 // 30 minutes
 #endif
         static let retryDelaySeconds = 60.0 * 60 * 1 // 1 hour delay before checking again if something went wrong last time
         static let refreshCheckIntervalSeconds = 60.0 // Check if we need a refresh every minute


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:

Temporary unprotected sites list was not being used and update frequency was too long.

**Steps to test this PR**:
1. Search for delta (or another site on the list)
1. Open the web inspector
1. Navigate to delta.com 
1. No blocking messages should be visible in the JS console
1. Navigate to cnn.com 
1. Content blocking messages should be visible in the JS console


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**