### PR TITLE
Memory leak fixed

### DIFF
--- a/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -45,7 +45,11 @@ final class TabCollectionViewModel: NSObject {
             updateSelectedTabViewModel()
         }
     }
-    @Published private(set) var selectedTabViewModel: TabViewModel?
+    @Published private(set) var selectedTabViewModel: TabViewModel? {
+        didSet {
+            previouslySelectedTabViewModel = oldValue
+        }
+    }
     private weak var previouslySelectedTabViewModel: TabViewModel?
 
     @Published private(set) var canInsertLastRemovedTab: Bool = false
@@ -61,7 +65,6 @@ final class TabCollectionViewModel: NSObject {
 
         subscribeToTabs()
         subscribeToLastRemovedTab()
-        subscribeToSelectedTabViewModel()
 
         if tabCollection.tabs.isEmpty {
             appendNewTab()
@@ -316,14 +319,6 @@ final class TabCollectionViewModel: NSObject {
         tabCollection.$lastRemovedTabCache.receive(on: DispatchQueue.main).sink { [weak self] _ in
             self?.updateCanInsertLastRemovedTab()
         } .store(in: &cancellables)
-    }
-
-    private func subscribeToSelectedTabViewModel() {
-        $selectedTabViewModel
-            .scan((nil, nil)) { return ($0.1, $1) }
-            .sink { [weak self] (previouslySelectedTabViewModel, _) in
-                self?.previouslySelectedTabViewModel = previouslySelectedTabViewModel
-            }.store(in: &cancellables)
     }
 
     private func removeTabViewModels(_ removed: Set<Tab>) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1200300006780048/f
CC:

**Description**:
TabViewModel released immediately from TabCollectionViewModel after its tab is closed. Prevents video/audio from playing after the closing.

**Steps to test this PR**:
1. Open empty tab + a new tab with youtube.com and start a video
2. Close the youtube tab and make sure no audio is playing


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**