### PR TITLE
Opening urls colides with session restoration

### DIFF
--- a/DuckDuckGo/Main/View/MainWindowController.swift
+++ b/DuckDuckGo/Main/View/MainWindowController.swift
@@ -83,7 +83,16 @@ final class MainWindowController: NSWindowController {
     }
 
     override func showWindow(_ sender: Any?) {
-        window!.makeKeyAndOrderFront(sender)
+        window?.makeKeyAndOrderFront(sender)
+        register()
+    }
+
+    func orderWindowBack(_ sender: Any?) {
+        window?.orderBack(sender)
+        register()
+    }
+
+    private func register() {
         WindowControllersManager.shared.register(self)
     }
 

--- a/DuckDuckGo/State Restoration/WindowManager+StateRestoration.swift
+++ b/DuckDuckGo/State Restoration/WindowManager+StateRestoration.swift
@@ -31,17 +31,21 @@ extension WindowsManager {
     }
 
     private class func restoreWindows(from state: WindowManagerStateRestoration) {
-        var keyWindow: NSWindow?
+        let isOriginalKeyWindowPresent = Self.windows.contains(where: {$0.isKeyWindow})
+
+        var newKeyWindow: NSWindow?
         for (idx, item) in state.windows.enumerated() {
-            guard let window = self.openNewWindow(with: item.model) else { continue }
+            guard let window = self.openNewWindow(with: item.model, showWindow: false) else { continue }
             window.setContentSize(item.frame.size)
             window.setFrameOrigin(item.frame.origin)
 
             if idx == state.keyWindowIndex {
-                keyWindow = window
+                newKeyWindow = window
             }
         }
-        keyWindow?.makeKeyAndOrderFront(self)
+        if !isOriginalKeyWindowPresent {
+            newKeyWindow?.makeKeyAndOrderFront(self)
+        }
 
         if !state.windows.isEmpty {
             NSApp.activate(ignoringOtherApps: true)

--- a/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -28,6 +28,11 @@ final class WindowControllersManager {
     weak var lastKeyMainWindowController: MainWindowController?
 
     func register(_ windowController: MainWindowController) {
+        guard !mainWindowControllers.contains(windowController) else {
+            assertionFailure("Window controller already registered")
+            return
+        }
+
         mainWindowControllers.append(windowController)
     }
 

--- a/DuckDuckGo/Windows/View/WindowsManager.swift
+++ b/DuckDuckGo/Windows/View/WindowsManager.swift
@@ -34,13 +34,19 @@ final class WindowsManager {
     }
 
     @discardableResult
-    class func openNewWindow(with tabCollectionViewModel: TabCollectionViewModel? = nil, droppingPoint: NSPoint? = nil) -> NSWindow? {
+    class func openNewWindow(with tabCollectionViewModel: TabCollectionViewModel? = nil,
+                             droppingPoint: NSPoint? = nil,
+                             showWindow: Bool = true) -> NSWindow? {
         let mainWindowController = makeNewWindow(tabCollectionViewModel: tabCollectionViewModel)
 
         if let droppingPoint = droppingPoint {
             mainWindowController.window?.setFrameOrigin(droppingPoint: droppingPoint)
         }
-        mainWindowController.showWindow(self)
+        if showWindow {
+            mainWindowController.showWindow(self)
+        } else {
+            mainWindowController.orderWindowBack(self)
+        }
 
         return mainWindowController.window
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1199985163299515/f

**Description**:
Windows that are open after the session restoration don't collide with the window open by the UrlEventListener

**Steps to test this PR**:
Prepare
1. Archive, export the app and replace with your current installation.
2. Make sure the browser is set as default

Test Case
1. Add bunch of windows and tabs
2. Quit the app (so the windows session is persisted)
2. Add wikipedia.org to a note in Notes.app
2. Click on the link
3. Make sure windows restored from the saved session are displayed below the new window with the wikipedia.org tab

Additional
1. Verify session restoration works as before



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**