### PR TITLE
Directory for the data persistance set to original

### DIFF
--- a/DuckDuckGo/Common/Database/Database.swift
+++ b/DuckDuckGo/Common/Database/Database.swift
@@ -112,6 +112,7 @@ extension NSManagedObjectContext {
 private class DDGPersistentContainer: NSPersistentContainer {
 
     override class func defaultDirectoryURL() -> URL {
-        return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-    } 
+        return URL.sandboxApplicationSupportURL
+    }
+
 }

--- a/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -21,6 +21,14 @@ import os.log
 
 extension URL {
 
+    // MARK: - Local
+
+    static var sandboxApplicationSupportURL: URL {
+        let sandboxPathComponent = "Containers/\(Bundle.main.bundleIdentifier!)/Data/Library/Application Support/"
+        let libraryURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!
+        return libraryURL.appendingPathComponent(sandboxPathComponent)
+    }
+
     // MARK: - Factory
 
     static func makeSearchUrl(from searchQuery: String) -> URL? {

--- a/DuckDuckGo/Common/FileSystem/FileStore.swift
+++ b/DuckDuckGo/Common/FileSystem/FileStore.swift
@@ -80,8 +80,8 @@ final class FileStore: FileStoring {
     }
 
     func persistenceLocation(for fileName: String) -> URL {
-        let applicationSupportPath = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        return applicationSupportPath!.appendingPathComponent(fileName)
+        let applicationSupportPath = URL.sandboxApplicationSupportURL
+        return applicationSupportPath.appendingPathComponent(fileName)
     }
 
 }

--- a/DuckDuckGo/Configuration/ConfigurationStoring.swift
+++ b/DuckDuckGo/Configuration/ConfigurationStoring.swift
@@ -133,9 +133,7 @@ final class DefaultConfigurationStorage: ConfigurationStoring {
     func fileUrl(for config: ConfigurationLocation) -> URL {
         let fm = FileManager.default
 
-        guard let dir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            fatalError("Could  not find application support directory")
-        }
+        let dir = URL.sandboxApplicationSupportURL
         let subDir = dir.appendingPathComponent("Configuration")
 
         var isDir: ObjCBool = false

--- a/DuckDuckGo/Smarter Encryption/Store/HTTPSUpgradeStore.swift
+++ b/DuckDuckGo/Smarter Encryption/Store/HTTPSUpgradeStore.swift
@@ -37,8 +37,7 @@ final class HTTPSUpgradePersistence: HTTPSUpgradeStore {
     
     private struct Resource {
         static var bloomFilter: URL {
-            let path = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            return path!.appendingPathComponent("HttpsBloomFilter.bin")
+            return URL.sandboxApplicationSupportURL.appendingPathComponent("HttpsBloomFilter.bin")
         }
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1200486622544299/f

**Description**:
Changing the data persisance to the original path - ~/Library/Containers/com.duckduckgo.macos.browser/Data/Library/Application\ Support/ 

**Steps to test this PR**:
1. Quit your installed browser
2. In Xcode, switch to the Release configuration and run the browser.
3. Make sure your browser state, bookmarks and history is present


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**