### PR TITLE
Fix Main Menu items validation

### DIFF
--- a/DuckDuckGo/Main/View/Launch.storyboard
+++ b/DuckDuckGo/Main/View/Launch.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -567,7 +567,7 @@ CQ
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
                                     <items>
-                                        <menuItem title="DuckDuckGo Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                        <menuItem title="DuckDuckGo Help" hidden="YES" enabled="NO" keyEquivalent="?" id="FKE-Sm-Kum">
                                             <connections>
                                                 <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
                                             </connections>

--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -91,6 +91,19 @@ extension AppDelegate {
         WindowsManager.openNewWindow(with: tab)
     }
 
+    @IBAction func showManageBookmarks(_ sender: Any?) {
+        let tabCollection = TabCollection(tabs: [Tab(tabType: .bookmarks)])
+        let tabCollectionViewModel = TabCollectionViewModel(tabCollection: tabCollection)
+        Pixel.fire(.manageBookmarks(source: .mainMenu))
+        WindowsManager.openNewWindow(with: tabCollectionViewModel)
+    }
+
+    @IBAction func openPreferences(_ sender: Any?) {
+        let tabCollection = TabCollection(tabs: [Tab(tabType: .preferences)])
+        let tabCollectionViewModel = TabCollectionViewModel(tabCollection: tabCollection)
+        WindowsManager.openNewWindow(with: tabCollectionViewModel)
+    }
+
 }
 
 extension MainViewController {
@@ -400,10 +413,25 @@ extension MainViewController: NSMenuItemValidation {
             return tabCollectionViewModel.tabCollection.tabs.count > 1
 
         default:
-            return menuItem.isEnabled
+            return true
         }
     }
     // swiftlint:enable cyclomatic_complexity
+
+}
+
+extension AppDelegate: NSMenuItemValidation {
+
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        switch menuItem.action {
+        // Close all windows
+        case #selector(AppDelegate.closeAllWindows(_:)):
+            return !WindowControllersManager.shared.mainWindowControllers.isEmpty
+
+        default:
+            return true
+        }
+    }
 
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1200500106693901
Tech Design URL:
CC: @tomasstrba @samsymons 

**Description**:
This PR fixes Window Menu items validation:
- Merge All Windows disabled when there's only one window
- Switch to Next/Prev Tabs items disabled when there's only one Tab
- Move Window to (another) Display system Menu Item Enabled
- File Menu items validation: New Tab enabled when window open, Close All Windows disabled when no windows
- Show Preferences enabled when no windows
- Manage Bookmarks enabled when no windows
- Hidden "Show Help" menu as it was showing error

**Steps to test this PR**:
1. Validate Menu Items are working correctly and get correct enabled/disabled state depending on how many tabs/windows are open



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**