### PR TITLE
URLs from URLListener are shown on the new tab

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -119,7 +119,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     static func handleURL(_ url: URL) {
         Pixel.fire(.appLaunch(launch: url.isFileURL ? .openFile : .openURL))
 
-        WindowControllersManager.shared.show(url: url)
+        WindowControllersManager.shared.show(url: url, newTab: true)
     }
 
     private func applyPreferredTheme() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200542044970090/f
CC: @samsymons 

**Description**:
When the browser is set as default,  links from Messages (or other apps) should be opened on a new tab instead of the current one.

**Steps to test this PR**:
1. Archive, export, install
2. Open links from other apps and make sure all of them are opened


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**