### PR TITLE
Issues with pasting a URL into the address bar resolved

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -644,6 +644,15 @@ extension AddressBarTextField: NSTextViewDelegate {
 
 final class AddressBarTextEditor: NSTextView {
 
+    override func paste(_ sender: Any?) {
+        // Fixes an issue when url-name instead of url is pasted
+        if let urlString = NSPasteboard.general.string(forType: .URL) {
+            string = urlString
+        } else {
+            super.paste(sender)
+        }
+    }
+
     override func selectionRange(forProposedRange proposedCharRange: NSRange, granularity: NSSelectionGranularity) -> NSRange {
         guard let delegate = delegate as? AddressBarTextField else {
             os_log("AddressBarTextEditor: unexpected kind of delegate")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200550438978275/f

**Description**:
After user copied a link from Outlook and pasted into the address bar, the link's name instead of the URL was pasted.

**Steps to test this PR**:
1. Copy link from Outlook (make sure to choose a link with name - for example 'View it on GitHub’)
1. Paste into the address bar and make sure the URL is pasted instead of the name ('View it on GitHub’)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**