### PR TITLE
Search with DuckDuckGo in context menu fixed

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/ContextMenuUserScript.swift
+++ b/DuckDuckGo/BrowserTab/Model/ContextMenuUserScript.swift
@@ -21,7 +21,11 @@ import BrowserServicesKit
 
 protocol ContextMenuDelegate: AnyObject {
 
-    func contextMenu(forUserScript script: ContextMenuUserScript, willShowAt position: NSPoint, image: URL?, link: URL?)
+    func contextMenu(forUserScript script: ContextMenuUserScript,
+                     willShowAt position: NSPoint,
+                     image: URL?,
+                     link: URL?,
+                     selectedText: String?)
 
 }
 
@@ -44,6 +48,7 @@ final class ContextMenuUserScript: NSObject, StaticUserScript {
 
         var image: URL?
         var link: URL?
+        let selectedText = dict["selectedText"] as? String
 
         guard let elements = dict["elements"] as? [[String: String]] else { return }
         elements.forEach { dict in
@@ -61,7 +66,11 @@ final class ContextMenuUserScript: NSObject, StaticUserScript {
             }
         }
 
-        delegate?.contextMenu(forUserScript: self, willShowAt: point, image: image, link: link)
+        delegate?.contextMenu(forUserScript: self,
+                              willShowAt: point,
+                              image: image,
+                              link: link,
+                              selectedText: selectedText)
     }
 
     private func point(from dict: [String: Any]) -> NSPoint? {
@@ -100,7 +109,8 @@ final class ContextMenuUserScript: NSObject, StaticUserScript {
                 "y": e.clientY
             },
             "elements": [
-            ]
+            ],
+            "selectedText": window.getSelection().toString()
         };
 
         if (e.srcElement.tagName === "A") {

--- a/DuckDuckGo/BrowserTab/Model/Tab.swift
+++ b/DuckDuckGo/BrowserTab/Model/Tab.swift
@@ -25,7 +25,7 @@ import BrowserServicesKit
 protocol TabDelegate: FileDownloadManagerDelegate {
     func tabDidStartNavigation(_ tab: Tab)
     func tab(_ tab: Tab, requestedNewTab url: URL?, selected: Bool)
-    func tab(_ tab: Tab, willShowContextMenuAt position: NSPoint, image: URL?, link: URL?)
+    func tab(_ tab: Tab, willShowContextMenuAt position: NSPoint, image: URL?, link: URL?, selectedText: String?)
     func tab(_ tab: Tab, detectedLogin host: String)
 	func tab(_ tab: Tab, requestedOpenExternalURL url: URL, forUserEnteredURL: Bool)
     func tab(_ tab: Tab, requestedSaveCredentials credentials: SecureVaultModels.WebsiteCredentials)
@@ -437,8 +437,12 @@ extension Tab: PageObserverUserScriptDelegate {
 
 extension Tab: ContextMenuDelegate {
 
-    func contextMenu(forUserScript script: ContextMenuUserScript, willShowAt position: NSPoint, image: URL?, link: URL?) {
-        delegate?.tab(self, willShowContextMenuAt: position, image: image, link: link)
+    func contextMenu(forUserScript script: ContextMenuUserScript,
+                     willShowAt position: NSPoint,
+                     image: URL?,
+                     link: URL?,
+                     selectedText: String?) {
+        delegate?.tab(self, willShowContextMenuAt: position, image: image, link: link, selectedText: selectedText)
     }
 
 }

--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -39,6 +39,7 @@ final class BrowserTabViewController: NSViewController {
     private var contextMenuExpected = false
     private var contextMenuLink: URL?
     private var contextMenuImage: URL?
+    private var contextMenuSelectedText: String?
 
     required init?(coder: NSCoder) {
         fatalError("BrowserTabViewController: Bad initializer")
@@ -314,10 +315,15 @@ extension BrowserTabViewController: TabDelegate {
         tabCollectionViewModel.remove(at: index)
     }
 
-    func tab(_ tab: Tab, willShowContextMenuAt position: NSPoint, image: URL?, link: URL?) {
+    func tab(_ tab: Tab,
+             willShowContextMenuAt position: NSPoint,
+             image: URL?,
+             link: URL?,
+             selectedText: String?) {
         contextMenuImage = image
         contextMenuLink = link
         contextMenuExpected = true
+        contextMenuSelectedText = selectedText
     }
 
     func tab(_ tab: Tab, detectedLogin host: String) {
@@ -452,6 +458,16 @@ extension BrowserTabViewController: ImageMenuItemSelectors {
         guard let url = contextMenuImage else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(url.absoluteString, forType: .URL)
+    }
+
+}
+
+extension BrowserTabViewController: MenuItemSelectors {
+
+    func search(_ sender: NSMenuItem) {
+        let selectedText = contextMenuSelectedText ?? ""
+        let url = URL.makeSearchUrl(from: selectedText)
+        openNewTab(with: url, parentTab: tabViewModel?.tab, selected: true)
     }
 
 }

--- a/DuckDuckGo/BrowserTab/View/MenuItemSelectors.swift
+++ b/DuckDuckGo/BrowserTab/View/MenuItemSelectors.swift
@@ -36,6 +36,12 @@ import Cocoa
 
 }
 
+@objc protocol MenuItemSelectors {
+
+    func search(_ sender: NSMenuItem)
+
+}
+
 @objc protocol FolderMenuItemSelectors {
 
     func newFolder(_ sender: NSMenuItem)

--- a/DuckDuckGo/BrowserTab/View/WebView.swift
+++ b/DuckDuckGo/BrowserTab/View/WebView.swift
@@ -31,13 +31,16 @@ final class WebView: WKWebView {
 
         // Images
         "WKMenuItemIdentifierOpenImageInNewWindow": #selector(ImageMenuItemSelectors.openImageInNewWindow(_:)),
-        "WKMenuItemIdentifierDownloadImage": #selector(ImageMenuItemSelectors.saveImageAs(_:))
+        "WKMenuItemIdentifierDownloadImage": #selector(ImageMenuItemSelectors.saveImageAs(_:)),
+
+        "WKMenuItemIdentifierSearchWeb": #selector(MenuItemSelectors.search(_:))
     ]
 
     static let itemTitles: [String: String] = [
         "WKMenuItemIdentifierOpenLink": UserText.openLinkInNewTab,
         "WKMenuItemIdentifierDownloadImage": UserText.saveImageAs,
-        "WKMenuItemIdentifierDownloadLinkedFile": UserText.downloadLinkedFileAs
+        "WKMenuItemIdentifierDownloadLinkedFile": UserText.downloadLinkedFileAs,
+        "WKMenuItemIdentifierSearchWeb": UserText.searchWithDuckDuckGo
     ]
 
     static private let maxMagnification: CGFloat = 3.0

--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -67,6 +67,7 @@ struct UserText {
     static let copyImageAddress = NSLocalizedString("copy.image.address", value: "Copy Image Address", comment: "Context menu item")
     static let saveImageAs = NSLocalizedString("save.image.as", value: "Save Image As...", comment: "Context menu item")
     static let downloadLinkedFileAs = NSLocalizedString("save.image.as", value: "Download Linked File As...", comment: "Context menu item")
+    static let searchWithDuckDuckGo = NSLocalizedString("search.with.DuckDuckGo", value: "Search with DuckDuckGo", comment: "Context menu item")
 
     static let findInPage = NSLocalizedString("find.in.page", value: "%1$d of %2$d", comment: "Find in page status (e.g. 1 of 99)")
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200566625151700/f

**Description**:
If user has Google as a default search engine in Safari, our context menu contained “Search with Google” when text was selected. It always opened a Safari window and triggered search
The PR fixes the context menu item and triggers DuckDuckGo search on our new tab.

**Steps to test this PR**:
1. Select text on a website
2. Right click
3. Select 'Search with DuckDuckGo' and make sure a new search tab is open with your selected text.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**