### PR TITLE
Fix save multiple logins

### DIFF
--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -367,12 +367,7 @@ extension BrowserTabViewController: FileDownloadManagerDelegate {
     }
 
     func tab(_ tab: Tab, requestedSaveCredentials credentials: SecureVaultModels.WebsiteCredentials) {
-
-        guard !FireproofDomains.shared.isAllowed(fireproofDomain: credentials.account.domain),
-              PasswordManagerSettings().canPromptOnDomain(credentials.account.domain) else {
-            return
-        }
-
+        guard PasswordManagerSettings().canPromptOnDomain(credentials.account.domain) else { return }
         tabViewModel?.credentialsToSave = credentials
     }
 

--- a/DuckDuckGo/SecureVault/SaveCredentialsViewController.swift
+++ b/DuckDuckGo/SecureVault/SaveCredentialsViewController.swift
@@ -108,12 +108,14 @@ final class SaveCredentialsViewController: NSViewController {
     @IBAction func onNotNowClicked(sender: Any?) {
         delegate?.shouldCloseSaveCredentialsViewController(self)
 
-        let host = domainLabel.stringValue
-
-        guard let window = view.window, !FireproofDomains.shared.isAllowed(fireproofDomain: host) else {
+        guard let window = view.window else {
             os_log("%s: Window is nil", type: .error, className)
             return
         }
+
+        let host = domainLabel.stringValue
+        // Don't ask if already fireproofed.
+        guard !FireproofDomains.shared.isAllowed(fireproofDomain: host) else { return }
 
         let alert = NSAlert.fireproofAlert(with: host.dropWWW())
         alert.beginSheetModal(for: window) { response in


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1200586776306072
Tech Design URL:
CC:

**Description**:

Separate fireproof and do not prompt checking logic so that multiple credentials can be stored.

**Steps to test this PR**:
1. Visit a site where you have multiple logins
1. Login, should get prompted to save
1. Save credentials
1. Sign out
1. Login with different username (just changing password will only trigger an update), should get prompted to save 
1. Click “not now”, should be asked to Fireproof
1. Click Fireproof, should fireproof site
1. Sign out
1. Login other credentials again, should get prompted to save
1. Click not now again, should not be prompted to fireproof
1. Sign out
1. Login with other credentials again, click save
1. Sign out
1. Ensure both sets of credentials are available to autofill 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**