### PR TITLE
Hide the password when showing the Save Credentials prompt

### DIFF
--- a/DuckDuckGo/SecureVault/View/PasswordManager.storyboard
+++ b/DuckDuckGo/SecureVault/View/PasswordManager.storyboard
@@ -193,7 +193,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EIo-j5-p5Y">
-                                <rect key="frame" x="20" y="101" width="304" height="22"/>
+                                <rect key="frame" x="20" y="101" width="282" height="22"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" bezelStyle="round" id="dDD-I5-wve">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -201,7 +201,7 @@
                                 </textFieldCell>
                             </textField>
                             <secureTextField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vTO-BL-OkT">
-                                <rect key="frame" x="20" y="101" width="304" height="22"/>
+                                <rect key="frame" x="20" y="101" width="282" height="22"/>
                                 <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="kgY-kh-qxi">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -212,9 +212,9 @@
                                 </secureTextFieldCell>
                             </secureTextField>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Z5y-mU-9wm">
-                                <rect key="frame" x="288" y="102" width="32" height="20"/>
+                                <rect key="frame" x="302" y="102" width="30" height="20"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="32" id="HAU-Wt-gas"/>
+                                    <constraint firstAttribute="width" constant="30" id="HAU-Wt-gas"/>
                                     <constraint firstAttribute="height" constant="20" id="h6a-D2-FGc"/>
                                 </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="SecureEyeToggle" imagePosition="only" alignment="center" inset="2" id="rKf-uz-UmT">
@@ -327,11 +327,11 @@ DQ
                             <constraint firstItem="wxi-3R-xRg" firstAttribute="leading" secondItem="B3X-Kr-GS1" secondAttribute="leading" constant="22" id="Sxs-eK-KMc"/>
                             <constraint firstItem="vTO-BL-OkT" firstAttribute="leading" secondItem="B3X-Kr-GS1" secondAttribute="leading" constant="20" symbolic="YES" id="T2j-Mw-9TT"/>
                             <constraint firstItem="Yxz-ka-dem" firstAttribute="width" secondItem="B3X-Kr-GS1" secondAttribute="width" id="UXJ-KW-z5A"/>
+                            <constraint firstItem="EIo-j5-p5Y" firstAttribute="width" secondItem="vTO-BL-OkT" secondAttribute="width" id="UlF-V8-ypv"/>
                             <constraint firstItem="vTO-BL-OkT" firstAttribute="top" secondItem="Q6k-W1-mHc" secondAttribute="bottom" constant="8" symbolic="YES" id="WAg-6r-6ii"/>
                             <constraint firstItem="PJE-OH-k14" firstAttribute="top" secondItem="Yxz-ka-dem" secondAttribute="bottom" constant="8" symbolic="YES" id="XJ1-bT-HUt"/>
                             <constraint firstItem="yiH-18-x9b" firstAttribute="width" secondItem="B3X-Kr-GS1" secondAttribute="width" id="XSm-5b-ImD"/>
                             <constraint firstItem="yiH-18-x9b" firstAttribute="centerX" secondItem="B3X-Kr-GS1" secondAttribute="centerX" id="Xqc-bb-esg"/>
-                            <constraint firstAttribute="trailing" secondItem="EIo-j5-p5Y" secondAttribute="trailing" constant="20" symbolic="YES" id="ZBz-m0-RbU"/>
                             <constraint firstItem="Yxz-ka-dem" firstAttribute="centerX" secondItem="B3X-Kr-GS1" secondAttribute="centerX" id="c7D-U7-jPn"/>
                             <constraint firstItem="wIW-tZ-7h0" firstAttribute="centerY" secondItem="DIw-JQ-5Ie" secondAttribute="centerY" id="ekJ-xj-NCF"/>
                             <constraint firstItem="eiY-Kq-70Z" firstAttribute="top" secondItem="yiH-18-x9b" secondAttribute="bottom" constant="20" symbolic="YES" id="f5K-fC-B2H"/>
@@ -340,12 +340,12 @@ DQ
                             <constraint firstItem="ibe-8n-iFx" firstAttribute="leading" secondItem="B3X-Kr-GS1" secondAttribute="leading" constant="20" symbolic="YES" id="h6U-i3-Zbn"/>
                             <constraint firstItem="EIo-j5-p5Y" firstAttribute="leading" secondItem="B3X-Kr-GS1" secondAttribute="leading" constant="20" symbolic="YES" id="iKT-Mj-flT"/>
                             <constraint firstItem="rkK-Ob-3VB" firstAttribute="top" secondItem="yiH-18-x9b" secondAttribute="bottom" constant="20" symbolic="YES" id="jle-HD-EWW"/>
+                            <constraint firstItem="Z5y-mU-9wm" firstAttribute="leading" secondItem="vTO-BL-OkT" secondAttribute="trailing" id="jzp-Gj-hJU"/>
                             <constraint firstItem="NmT-4X-rSL" firstAttribute="leading" secondItem="B3X-Kr-GS1" secondAttribute="leading" constant="20" symbolic="YES" id="lgc-sf-4Uu"/>
                             <constraint firstItem="eiY-Kq-70Z" firstAttribute="leading" secondItem="coN-gA-zuO" secondAttribute="trailing" constant="12" symbolic="YES" id="nE7-ms-SdC"/>
                             <constraint firstItem="DIw-JQ-5Ie" firstAttribute="leading" secondItem="wIW-tZ-7h0" secondAttribute="trailing" constant="12" symbolic="YES" id="ncj-2P-sO9"/>
-                            <constraint firstAttribute="trailing" secondItem="Z5y-mU-9wm" secondAttribute="trailing" constant="24" id="pHK-yd-7q6"/>
+                            <constraint firstAttribute="trailing" secondItem="Z5y-mU-9wm" secondAttribute="trailing" constant="12" id="pHK-yd-7q6"/>
                             <constraint firstAttribute="trailing" secondItem="ibe-8n-iFx" secondAttribute="trailing" constant="20" symbolic="YES" id="sdA-AX-bLA"/>
-                            <constraint firstAttribute="trailing" secondItem="vTO-BL-OkT" secondAttribute="trailing" constant="20" symbolic="YES" id="tx7-iW-KZH"/>
                             <constraint firstItem="JGJ-to-6ws" firstAttribute="leading" secondItem="B3X-Kr-GS1" secondAttribute="leading" constant="20" symbolic="YES" id="wYF-xk-Gbe"/>
                             <constraint firstItem="Yxz-ka-dem" firstAttribute="top" secondItem="JGJ-to-6ws" secondAttribute="bottom" constant="14" id="wpN-WW-YYD"/>
                             <constraint firstAttribute="trailing" secondItem="HEP-bz-HhW" secondAttribute="trailing" constant="16" id="xbR-Rg-Pye"/>
@@ -372,7 +372,7 @@ DQ
         </scene>
     </scenes>
     <resources>
-        <image name="Add" width="14" height="14"/>
+        <image name="Add" width="16" height="16"/>
         <image name="DuckDuckGo-Symbol" width="32" height="32"/>
         <image name="SecureEyeToggle" width="13" height="13"/>
         <namedColor name="ButtonColor">
@@ -385,7 +385,7 @@ DQ
             <color red="0.0" green="0.0" blue="0.0" alpha="0.10000000149011612" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="PopoverBackgroundColor">
-            <color red="0.94899999999999995" green="0.94099999999999995" blue="0.94099999999999995" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94900000095367432" green="0.94099998474121094" blue="0.94099998474121094" alpha="0.89999997615814209" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
+++ b/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
@@ -137,17 +137,7 @@ final class SaveCredentialsViewController: NSViewController {
     }
 
     @IBAction func onTogglePasswordVisibility(sender: Any?) {
-
-        if hiddenPasswordField.isHidden {
-            hiddenPasswordField.stringValue = visiblePasswordField.stringValue
-            hiddenPasswordField.isHidden = false
-            visiblePasswordField.isHidden = true
-        } else {
-            visiblePasswordField.stringValue = hiddenPasswordField.stringValue
-            visiblePasswordField.isHidden = false
-            hiddenPasswordField.isHidden = true
-        }
-
+        updatePasswordFieldVisibility(visible: !hiddenPasswordField.isHidden)
     }
 
     override func viewDidLoad() {
@@ -156,9 +146,26 @@ final class SaveCredentialsViewController: NSViewController {
         saveButton.becomeFirstResponder()
     }
 
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        updatePasswordFieldVisibility(visible: false)
+    }
+
     func loadFaviconForDomain(_ domain: String) {
         faviconImage.image = LocalFaviconService.shared.getCachedFavicon(for: domain, mustBeFromUserScript: false)
             ?? NSImage(named: NSImage.Name("Web"))
+    }
+
+    private func updatePasswordFieldVisibility(visible: Bool) {
+        if visible {
+            visiblePasswordField.stringValue = hiddenPasswordField.stringValue
+            visiblePasswordField.isHidden = false
+            hiddenPasswordField.isHidden = true
+        } else {
+            hiddenPasswordField.stringValue = visiblePasswordField.stringValue
+            hiddenPasswordField.isHidden = false
+            visiblePasswordField.isHidden = true
+        }
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200733409875784/f
Tech Design URL:
CC:

**Description**:

This PR changes the Save Credentials view controller so that every time it is displayed, the password is hidden. This VC persists through the lifetime of the window, and so it was remembering the hidden state incorrectly.

I've also tweaked the UI to prevent the Show Password indicator from overlapping, am awaiting feedback from Stephen to confirm that is an acceptable change.

**Steps to test this PR**:
1. Go through the Save Password flow, and show the password before you dismiss the popover
1. Go through the Save Password flow on another website, and check that the password is hidden when it opens

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**