### PR TITLE
Ensure the default browser prompt gets dismissed after setting the default

### DIFF
--- a/DuckDuckGo/Homepage/View/HomepageViewController.swift
+++ b/DuckDuckGo/Homepage/View/HomepageViewController.swift
@@ -84,7 +84,7 @@ final class HomepageViewController: NSViewController {
         collectionView.register(nib, forItemWithIdentifier: HomepageCollectionViewItem.identifier)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(displayDefaultBrowserPromptIfNeeded),
+                                               selector: #selector(displayDefaultBrowserPromptAfterDelayIfNeeded),
                                                name: NSApplication.didBecomeActiveNotification,
                                                object: nil)
 
@@ -114,9 +114,17 @@ final class HomepageViewController: NSViewController {
         self.view.addSubview(defaultBrowserPromptView)
     }
 
-    @objc
     private func displayDefaultBrowserPromptIfNeeded() {
         defaultBrowserPromptView.isHidden = DefaultBrowserPreferences.isDefault || defaultBrowserPromptDismissed
+    }
+
+    @objc
+    private func displayDefaultBrowserPromptAfterDelayIfNeeded() {
+        // The app checks whether it is the default after becoming active, in order to detect changes from the default browser prompt. However, if it
+        // checks for this immediately after returning from the prompt then the default browser has not yet changed, so a small delay has been added.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.displayDefaultBrowserPromptIfNeeded()
+        }
     }
 
     private func subscribeToBookmarkList() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1200837105140789/f
Tech Design URL:
CC:

**Description**:

This PR adds a short delay when checking whether the browser is the default. This is because the Default Browser prompt has not yet had time to finish setting the default browser before our browser is made active, and the banner was not dismissed.

NOTE: There is logic to make the debug browser appear like the production one as far as being the default is concerned, so if you test this you will need to account for that.

**Steps to test this PR**:
1. Launch the browser, and make sure something else is the default (like Safari)
1. Trigger the default browser prompt
1. Verify that the banner is dismissed after making it the default

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
