### PR TITLE
Fix crash when launched with url as argument

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -36,6 +36,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var stateRestorationManager: AppStateRestorationManager!
     private var grammarFeaturesManager = GrammarFeaturesManager()
 
+    private var urlsToOpen: [URL]?
+
+    private var didFinishLaunching = false
+
 #if OUT_OF_APPSTORE
 
 #if !BETA
@@ -105,6 +109,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         crashReporter.checkForNewReports()
 
 #endif
+
+        if let urlsToOpen = urlsToOpen {
+            for url in urlsToOpen {
+                Self.handleURL(url)
+            }
+        }
+
+        didFinishLaunching = true
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -129,11 +141,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func application(_ sender: NSApplication, openFiles files: [String]) {
-        for path in files {
-            guard FileManager.default.fileExists(atPath: path) else { continue }
-            let url = URL(fileURLWithPath: path)
-
-            Self.handleURL(url)
+        let urlsToOpen: [URL] = files.compactMap {
+            if let url = URL(string: $0),
+               ["http", "https"].contains(url.scheme) {
+                return url
+            } else if FileManager.default.fileExists(atPath: $0) {
+                let url = URL(fileURLWithPath: $0)
+                return url
+            }
+            return nil
+        }
+        if didFinishLaunching {
+            urlsToOpen.forEach(Self.handleURL)
+        } else {
+            self.urlsToOpen = urlsToOpen
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199237043630360/1200913726868394/f
Tech Design URL:
CC: @tomasstrba @samsymons @brindy 

**Description**:
Fixes crash/hang/no action when opening a file/URL from terminal

**Steps to test this PR**:
1. Launch app from Terminal with a url argument: `/Applications/DuckDuckgo.app/Contents/MacOS/DuckDuckGo https://duckduckgo.com` — should open the URL
2. Launch app from Terminal with a local file path argument: `/Applications/DuckDuckgo.app/Contents/MacOS/DuckDuckGo /path/to/local.html` — should open the file
3. Open a local file from Finder while _default_ browser is not running  — should open the file
4. Open a local file from Finder while _default_ browser is running  — should open the file
5. Open a link file from another app while _default_ browser is not running  — should open the link
6. Open a link file from another app while _default_ browser is running  — should open the link

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
