### PR TITLE
Allow single quote to be used with "find in page" query

### DIFF
--- a/DuckDuckGo/FindInPage/FindInPageUserScript.swift
+++ b/DuckDuckGo/FindInPage/FindInPageUserScript.swift
@@ -43,7 +43,7 @@ final class FindInPageUserScript: NSObject, StaticUserScript {
     }
 
     func find(text: String, inWebView webView: WKWebView) {
-        evaluate(js: "window.__firefox__.find('\(text)')", inWebView: webView)
+        evaluate(js: "window.__firefox__.find('\(text.replacingOccurrences(of: "'", with: "\\\'"))')", inWebView: webView)
     }
 
     func done(withWebView webView: WKWebView) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1200467065115223/1200598718017480/f
Tech Design URL:
CC:

**Description**:
Previously this was causing a JavaScript syntax error as the interpolated string containing a single quote was finishing the JavaScript string early. Escaping this single quote fixes the issue.

cc: @brindy @tomasstrba @mallexxx @samsymons 

**Steps to test this PR**:
1. Open webpage, e.g. https://en.wikipedia.org/wiki/Main_Page
2. Search for `today's featured`

**With this fix:** Match count shown and highlights rendered, no syntax error in developer console
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/635903/133467871-3051b888-4511-4654-a613-0bb6945b3ca4.png">

**Previously:** No match count shown and no highlights rendered, `SyntaxError: Unexpected identifier 's'. Expected ')' to end an argument list.` show in developer console
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/635903/133467562-4b1ae94e-569b-4889-990d-7037b3225e12.png">


**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
