### PR TITLE
Fix test and animation on Tab removal

### DIFF
--- a/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
+++ b/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
@@ -148,14 +148,16 @@ internal class MouseOverButton: NSButton {
         }
 
         NSAppearance.withAppAppearance {
-            if isMouseDown {
-                NSAnimationContext.current.duration = 0.0
-                backgroundLayer.backgroundColor = mouseDownColor?.cgColor ?? NSColor.clear.cgColor
-            } else if isMouseOver {
-                NSAnimationContext.current.duration = 0.0
-                backgroundLayer.backgroundColor = mouseOverColor?.cgColor ?? NSColor.clear.cgColor
-            } else {
-                backgroundLayer.backgroundColor = NSColor.clear.cgColor
+            NSAnimationContext.runAnimationGroup { context in
+                if isMouseDown {
+                    context.duration = 0.0
+                    backgroundLayer.backgroundColor = mouseDownColor?.cgColor ?? NSColor.clear.cgColor
+                } else if isMouseOver {
+                    context.duration = 0.0
+                    backgroundLayer.backgroundColor = mouseOverColor?.cgColor ?? NSColor.clear.cgColor
+                } else {
+                    backgroundLayer.backgroundColor = NSColor.clear.cgColor
+                }
             }
         }
     }

--- a/Unit Tests/FileDownload/DownloadListCoordinatorTests.swift
+++ b/Unit Tests/FileDownload/DownloadListCoordinatorTests.swift
@@ -426,7 +426,7 @@ final class DownloadListCoordinatorTests: XCTestCase {
             e.fulfill()
         }
         coordinator.cancel(downloadWithIdentifier: id)
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 1)
     }
 
     func testSync() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199237043630360/1200115006833274
Tech Design URL:
CC: @tomasstrba 

**Description**:
fixes minor issues after Downloads UI merge

**Steps to test this PR**:
1. Open several tabs, select the rightmost, close unselected tab to the left: validate there's Tab Removal animation and other Tabs animations
2. Validate buttons are transitioning their state TO mouseOver and mouseDown Without animation, and FROM mouseOver - with animation
3. Validate testWhenDownloadCancelledThenTaskIsCancelled test not failing


**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
