### PR TITLE
Update the new tab page background color when the theme changes

### DIFF
--- a/DuckDuckGo/Homepage/View/HomepageBackgroundView.swift
+++ b/DuckDuckGo/Homepage/View/HomepageBackgroundView.swift
@@ -43,4 +43,9 @@ final class HomepageBackgroundView: NSView {
         collectionView.enclosingScrollView?.frame = frame
     }
 
+    override func updateLayer() {
+        super.updateLayer()
+        layer?.backgroundColor = backgroundColor?.cgColor
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200738670933202/f
Tech Design URL:
CC:

**Description**:

This PR updates the home page to refresh its background color when the theme changes.

I've used the [approach recommended by Apple](https://developer.apple.com/documentation/uikit/appearance_customization/supporting_dark_mode_in_your_interface), which is to use `updateLayer` to set the layer's background color.

**Steps to test this PR**:
1. Launch the browser and open a new tab
1. Change the system theme via System Preferences
1. Check that the background color has changed

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
