### PR TITLE
Remove find in page performance pixel support

### DIFF
--- a/DuckDuckGo/FindInPage/FindInPageUserScript.swift
+++ b/DuckDuckGo/FindInPage/FindInPageUserScript.swift
@@ -32,11 +32,6 @@ final class FindInPageUserScript: NSObject, StaticUserScript {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard let dict = message.body as? [String: Any] else { return }
 
-        if let performancePixel = dict["performancePixel"] as? String {
-            Pixel.shared?.fire(pixelNamed: performancePixel)
-            return
-        }
-
         let currentResult = dict["currentResult"] as? Int
         let totalResults = dict["totalResults"] as? Int
         model?.update(currentSelection: currentResult, matchesFound: totalResults)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1200467065115223/1200825763313285/f
Tech Design URL:
CC:

**Description**:
Now that we're no longer sending performance data from find-in-page (https://github.com/more-duckduckgo-org/duckduckgo-find-in-page/pull/5), we can revert support for it (https://github.com/more-duckduckgo-org/macos-browser/pull/204)

**Steps to test this PR**:
This is unused code, so should have no impact on the browser.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
