### PR TITLE
Stop privacy icon animation when navigating

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/Tab.swift
+++ b/DuckDuckGo/BrowserTab/Model/Tab.swift
@@ -123,8 +123,13 @@ final class Tab: NSObject {
         userScripts?.remove(from: webView.configuration.userContentController)
     }
 
-    let webView: WebView
+    // MARK: - Event Publishers
+
     let webViewDidFinishNavigationPublisher = PassthroughSubject<Void, Never>()
+
+    // MARK: - Properties
+
+    let webView: WebView
 
     var userEnteredUrl = true
 

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -400,6 +400,7 @@ final class AddressBarButtonsViewController: NSViewController {
         }
 
         urlCancellable = selectedTabViewModel.tab.$content.receive(on: DispatchQueue.main).sink { [weak self] _ in
+            self?.stopAnimations()
             self?.updateBookmarkButtonImage()
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201107727284733/f

**Description**:
Stopping privacy icon animation when user navigates to different URL

**Steps to test this PR**:
1. Visit a website with trackers and wait for the animation
1. When animation is in progress perform a navigation (back, forward, website link, ...)
2. Make sure the animation stops

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
