### PR TITLE
Allow Privacy Dashboard to set popover height

### DIFF
--- a/DuckDuckGo/Privacy Dashboard/Model/PrivacyDashboardUserScript.swift
+++ b/DuckDuckGo/Privacy Dashboard/Model/PrivacyDashboardUserScript.swift
@@ -25,6 +25,7 @@ protocol PrivacyDashboardUserScriptDelegate: AnyObject {
     func userScript(_ userScript: PrivacyDashboardUserScript, didChangeProtectionStateTo protectionState: Bool)
     func userScript(_ userScript: PrivacyDashboardUserScript, didSetPermission permission: PermissionType, to state: PermissionAuthorizationState)
     func userScript(_ userScript: PrivacyDashboardUserScript, setPermission permission: PermissionType, paused: Bool)
+    func userScript(_ userScript: PrivacyDashboardUserScript, setHeight height: Int)
 
 }
 
@@ -35,6 +36,7 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
         case privacyDashboardFirePixel
         case privacyDashboardSetPermission
         case privacyDashboardSetPermissionPaused
+        case privacyDashboardSetHeight
     }
 
     static var injectionTime: WKUserScriptInjectionTime { .atDocumentStart }
@@ -64,6 +66,9 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
 
         case .privacyDashboardSetPermissionPaused:
             handleSetPermissionPaused(message: message)
+
+        case .privacyDashboardSetHeight:
+            handleSetHeight(message: message)
         }
     }
 
@@ -107,6 +112,15 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
         }
 
         delegate?.userScript(self, setPermission: permission, paused: paused)
+    }
+
+    private func handleSetHeight(message: WKScriptMessage) {
+        guard let height = message.body as? Int else {
+            assertionFailure("privacyDashboardSetHeght: expected height Int")
+            return
+        }
+
+        delegate?.userScript(self, setHeight: height)
     }
 
     typealias AuthorizationState = [(permission: PermissionType, state: PermissionAuthorizationState)]

--- a/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboard.storyboard
+++ b/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,7 +11,7 @@
             <objects>
                 <viewController storyboardIdentifier="PrivacyDashboardViewController" id="bU7-R8-ocO" customClass="PrivacyDashboardViewController" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="tOy-S4-hL0">
-                        <rect key="frame" x="0.0" y="0.0" width="350" height="563"/>
+                        <rect key="frame" x="0.0" y="0.0" width="350" height="550"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </view>
                 </viewController>

--- a/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
@@ -136,6 +136,10 @@ extension PrivacyDashboardViewController: PrivacyDashboardUserScriptDelegate {
         tabViewModel?.tab.permissions.set(permission, muted: paused)
     }
 
+    func userScript(_ userScript: PrivacyDashboardUserScript, setHeight height: Int) {
+        self.preferredContentSize = CGSize(width: self.view.frame.width, height: CGFloat(height))
+    }
+
 }
 
 extension PrivacyDashboardViewController: WKNavigationDelegate {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1201088336842454/f
Tech Design URL:
CC: 

**Description**:
Allow privacy dashboard to set popover height by calling message handler (`window.webkit.messageHandlers.privacyDashboardSetHeight.postMessage(height)`)

**Steps to test this PR**:
1. To prove the communication, update `./Submodules/duckduckgo-privacy-dashboard/build/macos/public/js/popup.js` to call `privacyDashboardSetHeight` message handler, e.g.
      ```js
      let height = 450
      setInterval(() => {
        window.webkit.messageHandlers.privacyDashboardSetHeight.postMessage(height)
        height += 50
      }, 1000)
      ```
2. Build browser and open Privacy Dashboard -- using the example above, the popover should shrink and then grow by 50px every second

__Edit:__ Complementary Privacy Dashboard PR now up -- checkout this branch in `Submodules/duckduckgo-privacy-dashboard` to test this out
https://github.com/more-duckduckgo-org/duckduckgo-privacy-dashboard/pull/10

![privacy-dashboard-popover-height](https://user-images.githubusercontent.com/635903/137479164-7c0ed90d-f62b-4ed0-8337-6ca903bbf52f.gif)


**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
