### PR TITLE
Hide Privacy Dashboard button on unknown protocols

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -480,14 +480,15 @@ final class AddressBarButtonsViewController: NSViewController {
             return
         }
 
-        let isURLNil = selectedTabViewModel.tab.content.url == nil
+        let urlScheme = selectedTabViewModel.tab.content.url?.scheme
+        let isHypertextUrl = urlScheme == "http" || urlScheme == "https"
         let isDuckDuckGoUrl = selectedTabViewModel.tab.content.url?.isDuckDuckGoSearch ?? false
 
         // Privacy entry point button
         privacyEntryPointButton.isHidden = isSearchingMode ||
             isTextFieldEditorFirstResponder ||
             isDuckDuckGoUrl ||
-            isURLNil ||
+            !isHypertextUrl ||
             selectedTabViewModel.errorViewState.isVisible
         imageButtonWrapper.isHidden = !privacyEntryPointButton.isHidden || trackerAnimationView.isAnimationPlaying
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1200835453786799/1201217438689724/f
Tech Design URL: n/a
CC: @tomasstrba @mallexxx @samsymons @jonathanKingston 

**Description**:
Only show Privacy Dashboard button for URLs using `http://` or `https://` -- this replaces the existing `nil` URL check

**Steps to test this PR**:

Data URL
1. Go to `data:,Hello%2C%20World%21`
1. Privacy Dashboard button should not show

HTTP URL
1. Go to `https://cheese.com/`
1. Privacy Dashboard button should show

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
