### PR TITLE
Fix Downloads Popover appearing in multiple windows; Fix crash

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -242,7 +242,9 @@ final class NavigationBarViewController: NSViewController {
             downloadsPopover.close()
             return
         }
-        guard closeTransientPopovers() else { return }
+        guard closeTransientPopovers(),
+              downloadsButton.window != nil
+        else { return }
 
         downloadsButton.isHidden = false
         setDownloadButtonHidingTimer()
@@ -302,11 +304,17 @@ final class NavigationBarViewController: NSViewController {
         DownloadListCoordinator.shared.updates
             .throttle(for: 1.0, scheduler: DispatchQueue.main, latest: true)
             .sink { [weak self] update in
-                let shouldShowPopover = update.kind == .updated && update.item.destinationURL != nil && update.item.tempURL == nil
+                guard let self = self else { return }
+
+                let shouldShowPopover = update.kind == .updated
+                    && update.item.destinationURL != nil
+                    && update.item.tempURL == nil
+                    && WindowControllersManager.shared.lastKeyMainWindowController?.window === self.downloadsButton.window
+
                 if shouldShowPopover {
-                    self?.showDownloadsPopoverAndAutoHide()
+                    self.showDownloadsPopoverAndAutoHide()
                 }
-                self?.updateDownloadsButton()
+                self.updateDownloadsButton()
             }
             .store(in: &downloadsCancellables)
         DownloadListCoordinator.shared.progress


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1200541656900018/1201219744323668
Tech Design URL:
CC:

**Description**:
- Validate window is still open when displaying Popover
- Only show Download Popover in a topmost window

**Steps to test this PR**:
The crash reproduced adding the following code to viewDidLoad:
`downloadsButton.publisher(for: \.window).sink { if $0 == nil { self.toggleDownloadsPopover(shouldFirePixel: false) }}.store(in: &downloadsCancellables)`
1. Validate there's no crash when trying to show the Popover when window == nil
2. Validate when multiple windows open and download completes, the Popover is shown in topmost window only

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
