### PR TITLE
Fix recent download not appearing in Downloads Popover

### DIFF
--- a/DuckDuckGo/FileDownload/View/DownloadsViewController.swift
+++ b/DuckDuckGo/FileDownload/View/DownloadsViewController.swift
@@ -51,11 +51,12 @@ final class DownloadsViewController: NSViewController {
 
         downloadsCancellable = viewModel.$items
             .throttle(for: 0.1, scheduler: DispatchQueue.main, latest: true)
-            .scan((old: [DownloadViewModel](), new: [DownloadViewModel]()), { ($0.new, $1) })
-            .dropFirst()
+            .scan((old: [DownloadViewModel](), new: viewModel.items), { ($0.new, $1) })
             .sink { [weak self] value in
                 guard let self = self else { return }
                 let diff = value.new.difference(from: value.old) { $0.id == $1.id }
+                guard !diff.isEmpty else { return }
+                
                 self.tableView.beginUpdates()
                 for change in diff {
                     switch change {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1199237043628108/1201205306678401/1201214603436718
Tech Design URL:
CC: @tomasstrba 

**Description**:
Fixes fast downloaded item not appearing in Downloads Popover

**Steps to test this PR**:
1. Launch Browser
2. Download an image via Save Image As->Save
3. Validate downloaded image is shown in opened Popover

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
