### PR TITLE
Fix issue where tabs were not being deallocated on window close

### DIFF
--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -89,6 +89,7 @@ final class TabBarViewController: NSViewController {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        tabCollectionViewModel.removeAllTabs()
     }
 
     @IBAction func addButtonAction(_ sender: NSButton) {


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

**Description**:
If the user clicks on the window close button the tabs are not deallocated from memory

**Steps to test this PR**:
1. Open one or more tabs with audio playing on them(YouTube works)
2. Click on the top left close button on the window
3. Notice that the audio keeps playing even after the window is closed

Alternative test method:
1. Add a breakpoint on the `deinit` method inside `Tab.swift`
2. Open one or more tabs 
3. Click on the top left close button on the window
4. Notice that the `deinit` method was not called


**Testing checklist**:

* [x] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
