### PR TITLE
Don't upgrade frames due to platform limitations

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/Tab.swift
+++ b/DuckDuckGo/BrowserTab/Model/Tab.swift
@@ -686,7 +686,7 @@ extension Tab: WKNavigationDelegate {
         }
 
         HTTPSUpgrade.shared.isUpgradeable(url: url) { [weak self] isUpgradable in
-            if isUpgradable, let upgradedUrl = url.toHttps() {
+            if isUpgradable && navigationAction.isTargetingMainFrame, let upgradedUrl = url.toHttps() {
                 self?.webView.load(upgradedUrl)
                 self?.setConnectionUpgradedTo(upgradedUrl, navigationAction: navigationAction)
                 decisionHandler(.cancel)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200118390627852/f
Tech Design URL:
CC:

**Description**:

Frames are currently exempted in the iOS code through the guard in [upgradeUrl](https://github.com/duckduckgo/iOS/blob/27cb3ce768b2a5f7861c8fddedb6db5589e78a1c/DuckDuckGo/TabViewController.swift#L1242) by the [call site](https://github.com/duckduckgo/iOS/blob/27cb3ce768b2a5f7861c8fddedb6db5589e78a1c/DuckDuckGo/TabViewController.swift#L1210) in the desktop browser we are not.

In https://app.asana.com/0/1199178362774117/1200118390627852/f we are seeing the upgraded frame URLs creating a top level navigation which will break certain sites.

**Steps to test this PR**:
1. Go to http://privacy-test-pages.glitch.me/privacy-protections/https-upgrades/
2. Click start test

The first tab should be a report of the upgraded URLs

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
