### PR TITLE
Check certificate is for root webview page

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/Tab.swift
+++ b/DuckDuckGo/BrowserTab/Model/Tab.swift
@@ -629,7 +629,7 @@ extension Tab: WKNavigationDelegate {
         }
 
         completionHandler(.performDefaultHandling, nil)
-        if let host = webView.url?.host, let serverTrust = challenge.protectionSpace.serverTrust {
+        if let host = webView.url?.host, let serverTrust = challenge.protectionSpace.serverTrust, host == challenge.protectionSpace.host {
             self.serverTrust = ServerTrust(host: host, secTrust: serverTrust)
         }
     }


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1201264186926820/f
Tech Design URL:
CC:

**Description**:

Every authentication challenge request will call the webView function,
but may not correspond to the root webview page. Only store the server
trust data for the request which corresponds t the root page, to be
displayed in the Privacy Dashboard.

⚠️ Although this solves an issue with the wrong certificate being shown, I think there's still another issue where browser caching means there is no request, therefore no call to `webView` with the `challenge` data, and thus no certificate data shown in the Privacy Dashboard (it doesn't break, but degrades to showing nothing).

**Steps to test this PR**:
1. Build PR
1. Go to any HTTPS site, e.g. https://cheese.com
2. Confirm that the certificate data corresponds to the site under view

Before | After
--- | ---
Showing certificate for request made to Yahoo | Showing certificate for request made to Cheese.com
<img width="1023" alt="Screenshot 2021-10-25 at 19 06 59" src="https://user-images.githubusercontent.com/635903/138748121-9c145501-644c-463b-b047-b5669a1d4f94.png"> | <img width="1023" alt="Screenshot 2021-10-25 at 18 55 26" src="https://user-images.githubusercontent.com/635903/138748134-57168a76-3db2-44cd-aef9-e552bac5c27c.png">

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
