### PR TITLE
Stopping privacy icon animation after textfield is focused

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -244,6 +244,9 @@ final class AddressBarButtonsViewController: NSViewController {
     func updateButtons(mode: AddressBarViewController.Mode,
                        isTextFieldEditorFirstResponder: Bool,
                        textFieldValue: AddressBarTextField.Value) {
+        stopAnimationsAfterFocus(oldIsTextFieldEditorFirstResponder: self.isTextFieldEditorFirstResponder,
+                                 newIsTextFieldEditorFirstResponder: isTextFieldEditorFirstResponder)
+
         self.isTextFieldEditorFirstResponder = isTextFieldEditorFirstResponder
 
         guard let selectedTabViewModel = tabCollectionViewModel.selectedTabViewModel else {
@@ -556,6 +559,12 @@ final class AddressBarButtonsViewController: NSViewController {
         stopAnimation(trackerAnimationView)
         stopAnimation(shieldAnimationView)
         stopAnimation(shieldDotAnimationView)
+    }
+
+    private func stopAnimationsAfterFocus(oldIsTextFieldEditorFirstResponder: Bool, newIsTextFieldEditorFirstResponder: Bool) {
+        if !oldIsTextFieldEditorFirstResponder && newIsTextFieldEditorFirstResponder {
+            stopAnimations()
+        }
     }
 
     private func bookmarkForCurrentUrl(setFavorite: Bool, accessPoint: Pixel.Event.AccessPoint) -> Bookmark? {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201107727284733/f

**Description**:
Stopping privacy icon animation when it is in progress and user focus the address bar

**Steps to test this PR**:
1. Load a website, make sure address bar is not the first responder  and wait for privacy icon animation
1. Click on the address bar
2. Animation should stop and disappear

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
