### PR TITLE
Missing credentials API fix

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -207,6 +207,8 @@
 		4BE0DF06267819A1006337B7 /* NSStoryboardExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE0DF0426781961006337B7 /* NSStoryboardExtension.swift */; };
 		4BF4951826C08395000547B8 /* ThirdPartyBrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF4951726C08395000547B8 /* ThirdPartyBrowserTests.swift */; };
 		7B4CE8E726F02135009134B1 /* TabBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4CE8E626F02134009134B1 /* TabBarTests.swift */; };
+		7B860DE227274A8C006D8957 /* NavigatorCredentialsUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B860DE127274A8B006D8957 /* NavigatorCredentialsUserScript.swift */; };
+		7B860DE427274E54006D8957 /* navigatorCredentials.js in Resources */ = {isa = PBXBuildFile; fileRef = 7B860DE327274E54006D8957 /* navigatorCredentials.js */; };
 		7BA4727D26F01BC400EAA165 /* CoreDataTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9292C42667104B00AD2C21 /* CoreDataTestUtilities.swift */; };
 		8511E18425F82B34002F516B /* 01_Fire_really_small.json in Resources */ = {isa = PBXBuildFile; fileRef = 8511E18325F82B34002F516B /* 01_Fire_really_small.json */; };
 		853014D625E671A000FB8205 /* PageObserverUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853014D525E671A000FB8205 /* PageObserverUserScript.swift */; };
@@ -792,6 +794,8 @@
 		7B4CE8DA26F02108009134B1 /* UI Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UI Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B4CE8DE26F02108009134B1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7B4CE8E626F02134009134B1 /* TabBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarTests.swift; sourceTree = "<group>"; };
+		7B860DE127274A8B006D8957 /* NavigatorCredentialsUserScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigatorCredentialsUserScript.swift; sourceTree = "<group>"; };
+		7B860DE327274E54006D8957 /* navigatorCredentials.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = navigatorCredentials.js; sourceTree = "<group>"; };
 		8511E18325F82B34002F516B /* 01_Fire_really_small.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 01_Fire_really_small.json; sourceTree = "<group>"; };
 		853014D525E671A000FB8205 /* PageObserverUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageObserverUserScript.swift; sourceTree = "<group>"; };
 		85308E24267FC9F2001ABD76 /* NSAlertExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAlertExtension.swift; sourceTree = "<group>"; };
@@ -2384,6 +2388,8 @@
 			children = (
 				856CADEF271710F400E79BB0 /* HoverUserScript.swift */,
 				4B2E7D6226FF9D6500D2DB17 /* PrintingUserScript.swift */,
+				7B860DE327274E54006D8957 /* navigatorCredentials.js */,
+				7B860DE127274A8B006D8957 /* NavigatorCredentialsUserScript.swift */,
 				85D438B5256E7C9E00F3BAF8 /* ContextMenuUserScript.swift */,
 				4BB88B4425B7B55C006F6B06 /* DebugUserScript.swift */,
 				85E11C2E25E7DC7E00974CAF /* ExternalURLHandler.swift */,
@@ -3320,6 +3326,7 @@
 				4B6160D825B150E4007DE5B2 /* trackerData.json in Resources */,
 				AA80EC67256C4691007083E7 /* BrowserTab.storyboard in Resources */,
 				4B0511C1262CAA5A00F6079C /* PrivacySecurityPreferencesTableCellView.xib in Resources */,
+				7B860DE427274E54006D8957 /* navigatorCredentials.js in Resources */,
 				AA28C11F271AFD3600F33FF1 /* dark-trackers.json in Resources */,
 				4B0511D0262CAA5A00F6079C /* AppearancePreferencesTableCellView.xib in Resources */,
 				4B6160F725B157BB007DE5B2 /* contentblocker.js in Resources */,
@@ -3516,6 +3523,7 @@
 				B6A9E499261474120067D1B9 /* TimedPixel.swift in Sources */,
 				B6C0B23626E732000031CB7F /* DownloadListItem.swift in Sources */,
 				856C98A6256EB59600A22F1F /* MenuItemSelectors.swift in Sources */,
+				7B860DE227274A8C006D8957 /* NavigatorCredentialsUserScript.swift in Sources */,
 				B6B1E87E26D5DA0E0062C350 /* DownloadsPopover.swift in Sources */,
 				4B9292A026670D2A00AD2C21 /* SpacerNode.swift in Sources */,
 				B6E61EE8263ACE16004E11AB /* UTType.swift in Sources */,

--- a/DuckDuckGo/BrowserTab/Model/NavigatorCredentialsUserScript.swift
+++ b/DuckDuckGo/BrowserTab/Model/NavigatorCredentialsUserScript.swift
@@ -1,0 +1,37 @@
+//
+//  NavigatorCredentialsUserScript.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import WebKit
+
+public final class NavigatorCredentialsUserScript: NSObject, UserScript {
+    public let messageNames: [String] = []
+
+    init(scriptSource: ScriptSourceProviding = DefaultScriptSourceProvider.shared) {
+        source = scriptSource.navigatorCredentialsSource
+    }
+
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    }
+
+    public let source: String
+
+    public let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
+    public let forMainFrameOnly: Bool = false
+
+}

--- a/DuckDuckGo/BrowserTab/Model/UserScripts.swift
+++ b/DuckDuckGo/BrowserTab/Model/UserScripts.swift
@@ -30,6 +30,7 @@ final class UserScripts {
     let autofillScript = AutofillUserScript()
     let printingUserScript = PrintingUserScript()
     let hoverUserScript = HoverUserScript()
+    let navigatorCredentialsUserScript = NavigatorCredentialsUserScript()
     let debugScript = DebugUserScript()
     let gpcScript = GPCUserScript()
 
@@ -53,6 +54,7 @@ final class UserScripts {
         self.printingUserScript,
         self.hoverUserScript,
         self.gpcScript,
+        self.navigatorCredentialsUserScript,
         self.autofillScript
     ]
 

--- a/DuckDuckGo/BrowserTab/Model/navigatorCredentials.js
+++ b/DuckDuckGo/BrowserTab/Model/navigatorCredentials.js
@@ -1,0 +1,51 @@
+(function () {
+    function getTopLevelURL () {
+        try {
+            // FROM: https://stackoverflow.com/a/7739035/73479
+            // FIX: Better capturing of top level URL so that trackers in embedded documents are not considered first party
+            return new URL(window.location !== window.parent.location ? document.referrer : document.location.href)
+        } catch (error) {
+            return new URL(location.href)
+        }
+    }
+
+    const topLevelUrl = getTopLevelURL()
+    let unprotectedDomain = false
+    const domainParts = topLevelUrl && topLevelUrl.host ? topLevelUrl.host.split('.') : []
+    // walk up the domain to see if it's unprotected
+    while (domainParts.length > 1 && !unprotectedDomain) {
+        const partialDomain = domainParts.join('.')
+        unprotectedDomain = `
+        CREDENTIALS_EXCEPTIONS
+        `.split('\n').filter(domain => domain.trim() === partialDomain).length > 0
+        domainParts.shift()
+    }
+
+    if (!unprotectedDomain && topLevelUrl.host != null) {
+        unprotectedDomain = `
+          USER_UNPROTECTED_DOMAINS
+          `.split('\n').filter(domain => domain.trim() === topLevelUrl.host).length > 0
+    }
+
+    if (!unprotectedDomain) {
+        init();
+    }
+    function init() {
+        const script = document.createElement('script')
+        script.textContent = `(() => {
+            const value = {
+                get() {
+                    return Promise.reject()
+                }
+            }
+            Object.defineProperty(Navigator.prototype, 'credentials', {
+                value,
+                configurable: true,
+                enumerable: true
+            })
+        })()`
+        const el = document.head || document.documentElement
+        el.appendChild(script)
+        script.remove()
+    }
+})()

--- a/DuckDuckGo/ContentBlocker/PrivacyConfiguration.swift
+++ b/DuckDuckGo/ContentBlocker/PrivacyConfiguration.swift
@@ -29,6 +29,7 @@ public struct PrivacyConfiguration: Decodable {
     public enum SupportedFeatures: String {
         case contentBlocking
         case gpc
+        case navigatorCredentials
     }
     
     public init(features: [String: PrivacyFeature], unprotectedTemporary: [ExceptionEntry]) {

--- a/DuckDuckGo/ContentBlocker/macos-config.json
+++ b/DuckDuckGo/ContentBlocker/macos-config.json
@@ -5,6 +5,10 @@
             "state": "enabled",
             "exceptions": []
         },
+        "navigatorCredentials": {
+            "state": "enabled",
+            "exceptions": []
+        },
         "contentBlocking": {
             "state": "enabled",
             "exceptions": [

--- a/Unit Tests/UserScripts/UserScriptsManagerTests.swift
+++ b/Unit Tests/UserScripts/UserScriptsManagerTests.swift
@@ -36,6 +36,7 @@ final class UserScriptsManagerTests: XCTestCase {
         var contentBlockerRulesSource: String { fatalError() }
         var contentBlockerSource: String { fatalError() }
         var gpcSource: String { fatalError() }
+        var navigatorCredentialsSource: String { fatalError() }
     }
 
     func testWhenUserScriptsManagerInitializedUserScriptsAreLoadedAndStored() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201249917946402/f
Tech Design URL:
CC:

**Description**:

On imgur.com they're expecting the credential API to be present, probably based on UA string.

This is pending agreement on the config key and a PR to that repo but other than there is no blocker to merging.

There's more copy and paste here for the config checking, we could make part of this PR a separate file that we read in an external file, something like:
```
        return CredentialsUserScript.loadJS("credentials", from: .main, withReplacements: [
             "import * from 'utils';": CredentialsUserScript.loadJS("utils"),
             "USER_UNPROTECTED_DOMAINS": "",
             "CREDENTIALS_EXCEPTIONS": (unprotectedDomains + contentBlockingExceptions).joined(separator: "\n")
        ])
```

**Steps to test this PR**:
1. load imgur.com

Expected
Site to have content

Actual
Site is blank

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
