### PR TITLE
Attempt to cap the home page search bar from having an infinite width

### DIFF
--- a/DuckDuckGo/Homepage/View/HomepageHeader.xib
+++ b/DuckDuckGo/Homepage/View/HomepageHeader.xib
@@ -128,7 +128,7 @@
                         <constraint firstItem="ziH-o6-MGN" firstAttribute="leading" secondItem="r0u-XH-URQ" secondAttribute="leading" constant="1" id="Cju-tR-Jyc"/>
                         <constraint firstItem="GuE-Dc-cYk" firstAttribute="centerY" secondItem="3Vr-DR-fdD" secondAttribute="centerY" id="DT6-ch-P8V"/>
                         <constraint firstAttribute="trailing" secondItem="GuE-Dc-cYk" secondAttribute="trailing" constant="10" id="F4a-Dx-qlR"/>
-                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="475" id="H18-6d-SBy"/>
+                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="550" id="H18-6d-SBy"/>
                         <constraint firstItem="ziH-o6-MGN" firstAttribute="top" secondItem="r0u-XH-URQ" secondAttribute="top" constant="1" id="JkK-Rg-T5V"/>
                         <constraint firstAttribute="trailing" secondItem="3Vr-DR-fdD" secondAttribute="trailing" constant="42" id="LaC-0U-E3Y"/>
                         <constraint firstItem="bS2-51-Skh" firstAttribute="centerY" secondItem="3Vr-DR-fdD" secondAttribute="centerY" id="T9L-OV-h4X"/>
@@ -140,21 +140,21 @@
             </subviews>
             <constraints>
                 <constraint firstItem="9BZ-pG-ZEW" firstAttribute="leading" secondItem="r0u-XH-URQ" secondAttribute="leading" id="0m2-R0-ReL"/>
-                <constraint firstItem="9BZ-pG-ZEW" firstAttribute="width" secondItem="r0u-XH-URQ" secondAttribute="width" id="ACR-tz-1H1"/>
-                <constraint firstAttribute="trailing" secondItem="r0u-XH-URQ" secondAttribute="trailing" priority="750" constant="8" id="BWd-az-JDX"/>
+                <constraint firstItem="r0u-XH-URQ" firstAttribute="leading" secondItem="sgY-8u-Li4" secondAttribute="leading" priority="250" constant="8" id="3oN-VA-Z76"/>
                 <constraint firstItem="ziH-o6-MGN" firstAttribute="height" secondItem="xd9-q4-UZz" secondAttribute="height" multiplier="0.95" id="IN2-ex-oHb"/>
                 <constraint firstItem="ZFe-Yi-fiG" firstAttribute="centerX" secondItem="sgY-8u-Li4" secondAttribute="centerX" id="LlC-ek-imj"/>
+                <constraint firstItem="9BZ-pG-ZEW" firstAttribute="width" secondItem="r0u-XH-URQ" secondAttribute="width" id="Mlq-mM-tQc"/>
                 <constraint firstItem="9BZ-pG-ZEW" firstAttribute="trailing" secondItem="r0u-XH-URQ" secondAttribute="trailing" id="Pah-rG-GHv"/>
                 <constraint firstItem="xd9-q4-UZz" firstAttribute="width" secondItem="r0u-XH-URQ" secondAttribute="width" id="R9K-l8-jgZ"/>
                 <constraint firstItem="xd9-q4-UZz" firstAttribute="top" secondItem="r0u-XH-URQ" secondAttribute="top" id="TJL-lA-Vgo"/>
                 <constraint firstItem="xd9-q4-UZz" firstAttribute="trailing" secondItem="r0u-XH-URQ" secondAttribute="trailing" id="ZNd-Ag-IcI"/>
+                <constraint firstAttribute="trailing" secondItem="r0u-XH-URQ" secondAttribute="trailing" priority="250" constant="8" id="a9k-gf-kRZ"/>
                 <constraint firstItem="9BZ-pG-ZEW" firstAttribute="height" secondItem="r0u-XH-URQ" secondAttribute="height" id="aSe-Gs-Rn9"/>
                 <constraint firstItem="ZFe-Yi-fiG" firstAttribute="top" secondItem="sgY-8u-Li4" secondAttribute="top" constant="20" symbolic="YES" id="bog-VG-Nqd"/>
                 <constraint firstItem="9BZ-pG-ZEW" firstAttribute="top" secondItem="r0u-XH-URQ" secondAttribute="top" id="dZi-BX-Vau"/>
-                <constraint firstItem="xd9-q4-UZz" firstAttribute="centerX" secondItem="r0u-XH-URQ" secondAttribute="centerX" id="e47-39-zCa"/>
                 <constraint firstItem="r0u-XH-URQ" firstAttribute="top" secondItem="ZFe-Yi-fiG" secondAttribute="bottom" constant="40" id="jhX-jF-olu"/>
                 <constraint firstItem="xd9-q4-UZz" firstAttribute="leading" secondItem="r0u-XH-URQ" secondAttribute="leading" id="l1R-XK-zo9"/>
-                <constraint firstItem="r0u-XH-URQ" firstAttribute="leading" secondItem="sgY-8u-Li4" secondAttribute="leading" priority="750" constant="8" id="zS0-UO-C49"/>
+                <constraint firstItem="r0u-XH-URQ" firstAttribute="centerX" secondItem="sgY-8u-Li4" secondAttribute="centerX" id="q7C-bg-fOd"/>
             </constraints>
             <connections>
                 <outlet property="backgroundHeight" destination="HKL-uV-eF3" id="Qaf-DX-a9f"/>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201266110806348/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue that a few people have had lately where the home page search bar can expand to the full width of the tab. The previous implementation of this search bar was set to have leading and trailing equal to the width of the homepage header, and somehow it seems like that header's width can break and go to the full width of the tab, taking the search bar with it.

I can't reproduce the issue, so I've tried to take the safest and easiest approach to save time before F&F:

1. Set a maximum width of 550 on the search bar, which is roughly what it was being sized to before
2. Update it to have weak leading and trailing constraints with its superview, but have a 1000 priority center X constraint in case something goes wrong with the superview width - that way, if the layout gets weird, the search bar will remain centered and at a reasonable width
3. I changed the Shadow and Background Views to have equal leading and trailing to the search bar's container, now they will always remain in sync with whatever layout the container view has

Not super satisfied with the solution since the "correct" thing to do would be to keep this view as it is and figure out what's going wrong with the collection view layout to cause this, but we don't have a lot of time before F&F and I have other priorities 😭 

**Steps to test this PR**:
1. Open a new tab and resize the window a bunch, check that the search bar remains at a fixed width

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
