### PR TITLE
Prevent the Privacy Dashboard from closing when updating protection status

### DIFF
--- a/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
@@ -25,7 +25,7 @@ final class PrivacyDashboardViewController: NSViewController {
     @IBOutlet var webView: WKWebView!
     private let privacyDashboardScript = PrivacyDashboardUserScript()
     private var cancellables = Set<AnyCancellable>()
-    private var pendingUpdates = Set<String>()
+    @Published var pendingUpdates = Set<String>()
 
     weak var tabViewModel: TabViewModel?
     var serverTrustViewModel: ServerTrustViewModel?
@@ -43,6 +43,10 @@ final class PrivacyDashboardViewController: NSViewController {
 
     override func viewWillDisappear() {
         cancellables.removeAll()
+    }
+
+    public func isPendingUpdates() -> Bool {
+        return !pendingUpdates.isEmpty
     }
 
     private func initWebView() {
@@ -153,6 +157,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardUserScriptDelegate {
             return
         }
 
+        let activeTab = self.tabViewModel?.tab
         let protectionStore = DomainsProtectionUserDefaultsStore()
         let operation = isProtected ? protectionStore.enableProtection : protectionStore.disableProtection
         operation(domain)
@@ -164,6 +169,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardUserScriptDelegate {
             DefaultScriptSourceProvider.shared.reload()
             self.pendingUpdates.remove(domain)
             self.sendPendingUpdates()
+            activeTab?.reload()
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1201277434384534/f
Tech Design URL:
CC: @mallexxx @tomasstrba @samsymons 

**Description**:
UX change to prevent Privacy Dashboard for closing when updating protection status

**Steps to test this PR**:
1. Go to https://randomuser.me/ (and remember the random user shown)
2. Open Privacy Dashboard and turn off protections
3. While protections are being turned off, you should not be able to close the Privacy Dashboard
   - Clicking the shield button in the URL bar does not close the popover
   - Clicking on the webpage, the URL bar, etc. does not close the popover
   - Opening a new tab will continue to show the previous tabs Privacy Dashboard state
4. When the update has completed, the page will refresh and the Privacy Dashboard will close
    - To confirm a refresh, check that random user shown has changed from the one shown in step 1

![lock-privacy-dashboard-updating3](https://user-images.githubusercontent.com/635903/139060480-744fe0d9-b6a5-4bbb-a858-2e1676edb2db.gif)

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
