### PR TITLE
Remove debug menu item in release builds

### DIFF
--- a/DuckDuckGo/Menus/MainMenu.swift
+++ b/DuckDuckGo/Menus/MainMenu.swift
@@ -51,7 +51,15 @@ final class MainMenu: NSMenu {
     @IBOutlet weak var favoritesMenuItem: NSMenuItem?
     @IBOutlet weak var favoriteThisPageMenuItem: NSMenuItem?
 
-    @IBOutlet weak var debugMenuItem: NSMenuItem?
+    @IBOutlet weak var debugMenuItem: NSMenuItem? {
+        didSet {
+#if !DEBUG
+            if let item = debugMenuItem {
+                removeItem(item)
+            }
+#endif
+        }
+    }
 
     @IBOutlet weak var helpMenuItem: NSMenuItem?
     @IBOutlet weak var helpSeparatorMenuItem: NSMenuItem?
@@ -101,14 +109,6 @@ final class MainMenu: NSMenu {
 
         helpMenuItemSubmenu.removeItem(helpSeparatorMenuItem)
         helpMenuItemSubmenu.removeItem(sendFeedbackMenuItem)
-
-#endif
-
-#if !DEBUG
-
-        if let item = debugMenuItem {
-            removeItem(item)
-        }
 
 #endif
 


### PR DESCRIPTION
This outlet was nil at the time of the `setup` function call, so it has been updated to check whether it should be removed right after it gets set.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201281767696937/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue where the Debug menu item wasn't being removed in release builds. I noticed that this IBOutlet was nil at the time of `setup` being called, so I've moved this check to the `didSet` block so that it's caught immediately after the outlet is populated.

I worry that this will also affect the `FEEDBACK` check too. I haven't touched it yet due to lack of time and because we don't plan to disable that yet to my knowledge.

**Steps to test this PR**:
1. Run the app in debug mode, check that the menu item is present
1. Flip the check from `#if !DEBUG` to `#if DEBUG`, and run the app again, checking that the menu item is gone

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
