### PR TITLE
Update tracker information on refresh to support toggling protection

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/Tab.swift
+++ b/DuckDuckGo/BrowserTab/Model/Tab.swift
@@ -280,6 +280,7 @@ final class Tab: NSObject {
             webView.load(url)
         } else {
             webView.reload()
+            updateDashboardInfo(url: content.url)
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1201282392835599/f
Tech Design URL:
CC: @tomasstrba 

**Description**:
Update the tracker info held about the tab on refresh. This prevents the protection animation from showing when protections are toggled off (and the page refreshes).

**Steps to test this PR**:
1. Go to https://cheese.com/ 
    - Protections should be enabled
    - The shield icon should animate to show trackers are blocked
1. Open Privacy Dashboard and turn protections **off**
     - The protections should be disabled and the page should refresh
     - After refresh, the shield icon should **not** animate to show trackers are not being blocked
1. Open Privacy Dashboard and turn protections **on**
     - The protections should be enabled and the page should refresh
     - After refresh, the shield icon should once again animate to show trackers are blocked

![privacy-dashboard-icon-animation2](https://user-images.githubusercontent.com/635903/139286747-0484bbce-bbd8-41da-a1a3-a19b69ac7418.gif)

**Testing checklist**:
* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
