### PR TITLE
Clear Favicon cache when fire button is pressed

### DIFF
--- a/DuckDuckGo/BrowserTab/Services/FaviconService.swift
+++ b/DuckDuckGo/BrowserTab/Services/FaviconService.swift
@@ -26,6 +26,7 @@ protocol FaviconService {
     func fetchFavicon(_ faviconUrl: URL?, for host: String, isFromUserScript: Bool, completion: @escaping (NSImage?, Error?) -> Void)
     func getCachedFavicon(for host: String, mustBeFromUserScript: Bool) -> NSImage?
     func cacheIfNeeded(favicon: NSImage, for host: String, isFromUserScript: Bool)
+    func invalidateCache()
 
 }
 
@@ -134,7 +135,7 @@ final class LocalFaviconService: FaviconService {
         invalidateCache()
     }
     
-    private func invalidateCache() {
+    func invalidateCache() {
         cache = [String: CacheEntry]()
     }
 

--- a/Unit Tests/BrowserTab/Services/FaviconServiceMock.swift
+++ b/Unit Tests/BrowserTab/Services/FaviconServiceMock.swift
@@ -34,4 +34,7 @@ final class FaviconServiceMock: FaviconService {
     func cacheIfNeeded(favicon: NSImage, for host: String, isFromUserScript: Bool) {
     }
 
+    func invalidateCache() {
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1201299206237926/f
Tech Design URL:
CC:

**Description**:

Clears all the favicon cache when the user clicks on the fire button.

**Steps to test this PR**:

1. Visit mail.google.com
2. Press fire button
3. Visit google.com

Expected
G icon

Actual
Gmail icon


**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
