### PR TITLE
Show red shield when protections disabled or on tracker network

### DIFF
--- a/DuckDuckGo/ContentBlocker/TrackerRadarManager.swift
+++ b/DuckDuckGo/ContentBlocker/TrackerRadarManager.swift
@@ -124,6 +124,12 @@ final class TrackerRadarManager {
         return nil
     }
 
+    func isHostMajorTrackingNetwork(_ host: String) -> Bool {
+        let majorTrackerThresholdPrevalence = 7.0
+        let parentEntity = findEntity(forHost: host)
+        return (parentEntity?.prevalence ?? 0.0) >= majorTrackerThresholdPrevalence
+    }
+
     private func variations(of host: String) -> [String] {
         var parts = host.components(separatedBy: ".")
         var domains = [String]()

--- a/DuckDuckGo/Core/DomainsProtectionUserDefaultsStore.swift
+++ b/DuckDuckGo/Core/DomainsProtectionUserDefaultsStore.swift
@@ -43,6 +43,10 @@ public class DomainsProtectionUserDefaultsStore: DomainsProtectionStore {
         }
     }
 
+    public func isHostUnprotected(forDomain domain: String) -> Bool {
+        return unprotectedDomains.contains(domain)
+    }
+
     public func disableProtection(forDomain domain: String) {
         var domains = unprotectedDomains
         domains.insert(domain)

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -539,13 +539,9 @@ final class AddressBarButtonsViewController: NSViewController {
             guard let host = url.host else { break }
 
             let isNotSecure = url.scheme == "http"
-
-            let majorTrackerThresholdPrevalence = 7.0
-            let parentEntity = TrackerRadarManager.shared.findEntity(forHost: host)
-            let isMajorTrackingNetwork = (parentEntity?.prevalence ?? 0.0) >= majorTrackerThresholdPrevalence
-
+            let isMajorTrackingNetwork = TrackerRadarManager.shared.isHostMajorTrackingNetwork(host)
             let protectionStore = DomainsProtectionUserDefaultsStore()
-            let isUnprotected = protectionStore.unprotectedDomains.contains(host)
+            let isUnprotected = protectionStore.isHostUnprotected(forDomain: host)
 
             privacyEntryPointButton.image = isNotSecure || isMajorTrackingNetwork || isUnprotected ? Self.shieldDotImage : Self.shieldImage
         default:


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1201318495713876/f
Tech Design URL:
CC:

**Description**:
Show the red dot shield icon for tracker networks and domains with protection disabled

**Steps to test this PR**:
When protections are disabled
1. Go to https://cheese.com/
1. Open Privacy Dashboard and turn off protections
2. Shield should now have the red dot

<img width="681" alt="image" src="https://user-images.githubusercontent.com/635903/140157915-73d6c2c0-c78c-45c6-93f8-aeb0632285a8.png">

When on a tracker network
1. Go to https://google.com/
2. Shield should have the red dot

<img width="680" alt="image" src="https://user-images.githubusercontent.com/635903/140158505-78f2e221-7da2-4c51-bfb5-6ac0cb20fdef.png">

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
