### PR TITLE
fix ContentBlockerRules compilation race condition

### DIFF
--- a/DuckDuckGo/ContentBlocker/ContentBlockerRulesManager.swift
+++ b/DuckDuckGo/ContentBlocker/ContentBlockerRulesManager.swift
@@ -44,12 +44,10 @@ final class ContentBlockerRulesManager {
         let protectionStore = DomainsProtectionUserDefaultsStore()
         let userDisabledProtection = protectionStore.unprotectedDomains
 
-        DispatchQueue.global(qos: .userInitiated).async {
-            self.compileRules(with: trackerData,
-                              withExceptions: Array(userDisabledProtection),
-                              andTemporaryUnprotectedDomains: unprotectedDomains,
-                              completion: completion)
-        }
+        self.compileRules(with: trackerData,
+                          withExceptions: Array(userDisabledProtection),
+                          andTemporaryUnprotectedDomains: unprotectedDomains,
+                          completion: completion)
     }
 
     private func loadUnprotectedDomains() -> [String] {


### PR DESCRIPTION
Async rule compilation at startup causes rules to not be applied to initial tab load.

Task with steps to test: https://app.asana.com/0/1163321984198618/1201190116754047

**Description**:
As per the task we have an issue on browser startup that contentblockerrules are not compiled and ready before the initial tab is loaded.  This means we don't block tracker immediately upon startup.  This removes the async rules compilation step that causes this issue.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
