### PR TITLE
Restrict popover height to fit within screen below browser

### DIFF
--- a/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
@@ -200,8 +200,21 @@ extension PrivacyDashboardViewController: PrivacyDashboardUserScriptDelegate {
         tabViewModel?.tab.permissions.set(permission, muted: paused)
     }
 
-    func userScript(_ userScript: PrivacyDashboardUserScript, setHeight height: Int) {
-        self.preferredContentSize = CGSize(width: self.view.frame.width, height: CGFloat(height))
+    func userScript(_ userScript: PrivacyDashboardUserScript, setHeight newHeight: Int) {
+        let width = self.view.frame.width
+        let height = CGFloat(newHeight)
+
+        guard let windowFrame = tabViewModel?.tab.webView.window?.frame else {
+            self.preferredContentSize = CGSize(width: width, height: height)
+            return
+        }
+
+        // The position of bottom left corner of the browser window + the height of the browser window
+        // gives us the distance to the bottom of the screen. If we keep the height of the popover less
+        // than that, then it won't shift about relative to the triggering button.
+        let availableSpace = windowFrame.origin.y + windowFrame.size.height
+        let bufferHeight = 150.0
+        self.preferredContentSize = CGSize(width: width, height: min(height, availableSpace - bufferHeight))
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1201321795174306/f
Tech Design URL:
CC: @mallexxx 

**Description**:
Calculate the space from the top of the browser to the bottom of the screen -- if the popover height is less than this then it should never jump to the side of the trigger button.

**Steps to test this PR**:
1. Open https://edition.cnn.com/
1. Move the browser window down a third of your screen
2. Open the Privacy Dashboard and go to the tracker list
3. The popover should extend in height, but remain downwards under the shield button -- rather than extending to the screen height and moving to the right of the shield button

Before | After
--- | ---
<img width="2048" alt="Screenshot 2021-11-04 at 00 13 15" src="https://user-images.githubusercontent.com/635903/140236190-68e32478-8c66-46d3-84b6-0b595b7aa017.png"> | <img width="2046" alt="Screenshot 2021-11-04 at 00 12 41" src="https://user-images.githubusercontent.com/635903/140236202-539ad72c-d995-40a7-aa48-dad86570c99e.png">

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
