### PR TITLE
Fix URL Preview showing empty box

### DIFF
--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -88,6 +88,7 @@ final class BrowserTabViewController: NSViewController {
     /// 3. A URL is provided after already adding the webview, so the webview should be reloaded.
     private func updateInterface() {
         changeWebView()
+        scheduleHoverLabelUpdatesForUrl(nil)
         show(tabContent: tabCollectionViewModel.selectedTabViewModel?.tab.content)
     }
 
@@ -386,6 +387,10 @@ extension BrowserTabViewController: TabDelegate {
         scheduleHoverLabelUpdatesForUrl(url)
     }
 
+    func windowDidResignKey() {
+        scheduleHoverLabelUpdatesForUrl(nil)
+    }
+
     private func scheduleHoverLabelUpdatesForUrl(_ url: URL?) {
         // cancel previous animation, if any
         hoverLabelWorkItem?.cancel()
@@ -399,7 +404,7 @@ extension BrowserTabViewController: TabDelegate {
             animationItem = DispatchWorkItem { [weak self] in
                 self?.hoverLabelContainer.animator().alphaValue = 0
             }
-        } else if hoverLabelContainer.alphaValue < 1 {
+        } else if url != nil && hoverLabelContainer.alphaValue < 1 {
             // schedule a fade in
             delay = 0.5
             animationItem = DispatchWorkItem { [weak self] in

--- a/DuckDuckGo/Main/MainViewController.swift
+++ b/DuckDuckGo/Main/MainViewController.swift
@@ -73,6 +73,10 @@ final class MainViewController: NSViewController {
         updateStopMenuItem()
     }
 
+    func windowDidResignKey() {
+        browserTabViewController.windowDidResignKey()
+    }
+
     override func encodeRestorableState(with coder: NSCoder) {
         fatalError("Default AppKit State Restoration should not be used")
     }

--- a/DuckDuckGo/Main/View/MainWindowController.swift
+++ b/DuckDuckGo/Main/View/MainWindowController.swift
@@ -160,6 +160,10 @@ extension MainWindowController: NSWindowDelegate {
         WindowControllersManager.shared.lastKeyMainWindowController = self
     }
 
+    func windowDidResignKey(_ notification: Notification) {
+        mainViewController.windowDidResignKey()
+    }
+
     func windowWillEnterFullScreen(_ notification: Notification) {
         mainViewController.tabBarViewController.draggingSpace.isHidden = true
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199237043630360/1201273566475681
Tech Design URL:
CC: @tomasstrba @samsymons 

**Description**:
Fixes issue of empty URL preview tooltip

**Steps to test this PR**:
1. Point cursor to a GitHub link: file name or commit message, don't wait for ToolTip to appear - instantly point to the empty place right after the link - Empty toolTip should not appear
2. Point cursor to a link, wait until tooltip appears, click the link - tooltip should disappear
3. Point cursor to a link opening new tab, wait until tooltip appears, click the link - tooltip should disappear
4. Point cursor to a link, wait until tooltip appears, switch to another App/Window using Cmd/Ctrl + Tab

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
