### PR TITLE
Fix Logins Popover detaching and endless Alert loop when cancelling 

### DIFF
--- a/DuckDuckGo/SecureVault/Model/PasswordManagementItemListModel.swift
+++ b/DuckDuckGo/SecureVault/Model/PasswordManagementItemListModel.swift
@@ -228,16 +228,18 @@ final class PasswordManagementItemListModel: ObservableObject {
         self.items = items.sorted()
     }
 
-    func selected(item: SecureVaultItem?) {
+    func selected(item: SecureVaultItem?, notify: Bool = true) {
         let previous = selected
         selected = item
-        onItemSelected(previous, item)
+        if notify {
+            onItemSelected(previous, item)
+        }
     }
 
-    func select(item: SecureVaultItem) {
+    func select(item: SecureVaultItem, notify: Bool = true) {
         for section in displayedItems {
             if let first = section.items.first(where: { $0 == item }) {
-                selected(item: first)
+                selected(item: first, notify: notify)
             }
         }
     }

--- a/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -343,11 +343,8 @@ final class PasswordManagementViewController: NSViewController {
                 self.refetchWithText(self.searchField.stringValue)
                 self.postChange()
 
-            case .alertSecondButtonReturn:
-                break // cancel, do nothing
-
             default:
-                fatalError("Unknown response \(response)")
+                break // cancel, do nothing
             }
 
         }
@@ -367,11 +364,8 @@ final class PasswordManagementViewController: NSViewController {
                 self.refetchWithText(self.searchField.stringValue)
                 self.postChange()
 
-            case .alertSecondButtonReturn:
-                break // cancel, do nothing
-
             default:
-                fatalError("Unknown response \(response)")
+                break // cancel, do nothing
             }
 
         }
@@ -391,11 +385,8 @@ final class PasswordManagementViewController: NSViewController {
                 self.refetchWithText(self.searchField.stringValue)
                 self.postChange()
 
-            case .alertSecondButtonReturn:
-                break // cancel, do nothing
-
             default:
-                fatalError("Unknown response \(response)")
+                break // cancel, do nothing
             }
 
         }
@@ -415,11 +406,8 @@ final class PasswordManagementViewController: NSViewController {
                 self.refetchWithText(self.searchField.stringValue)
                 self.postChange()
 
-            case .alertSecondButtonReturn:
-                break // cancel, do nothing
-
             default:
-                fatalError("Unknown response \(response)")
+                break // cancel, do nothing
             }
 
         }
@@ -471,13 +459,10 @@ final class PasswordManagementViewController: NSViewController {
                         self?.itemModel?.cancel()
                         loadNewItemWithID()
 
-                    case .alertThirdButtonReturn: // Cancel
+                    default: // Cancel
                         if let previousValue = previousValue {
-                            self?.listModel?.select(item: previousValue)
+                            self?.listModel?.select(item: previousValue, notify: false)
                         }
-
-                    default:
-                        fatalError("Unknown response \(response)")
                     }
 
                 }
@@ -562,11 +547,8 @@ final class PasswordManagementViewController: NSViewController {
                     self.itemModel?.cancel()
                     createNew()
 
-                case .alertThirdButtonReturn: // Cancel
+                default: // Cancel
                     break // just do nothing
-
-                default:
-                    fatalError("Unknown response \(response)")
                 }
 
             }
@@ -599,11 +581,8 @@ final class PasswordManagementViewController: NSViewController {
                     self.itemModel?.cancel()
                     createNew()
 
-                case .alertThirdButtonReturn: // Cancel
+                default: // Cancel
                     break // just do nothing
-
-                default:
-                    fatalError("Unknown response \(response)")
                 }
 
             }
@@ -636,11 +615,8 @@ final class PasswordManagementViewController: NSViewController {
                     self.itemModel?.cancel()
                     createNew()
 
-                case .alertThirdButtonReturn: // Cancel
+                default: // Cancel
                     break // just do nothing
-
-                default:
-                    fatalError("Unknown response \(response)")
                 }
 
             }
@@ -673,11 +649,8 @@ final class PasswordManagementViewController: NSViewController {
                     self.itemModel?.cancel()
                     createNew()
 
-                case .alertThirdButtonReturn: // Cancel
+                default: // Cancel
                     break // just do nothing
-
-                default:
-                    fatalError("Unknown response \(response)")
                 }
 
             }
@@ -685,7 +658,7 @@ final class PasswordManagementViewController: NSViewController {
             createNew()
         }
     }
-    
+
 }
 
 extension PasswordManagementViewController: NSTextFieldDelegate {


### PR DESCRIPTION
…irty Editing mode

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1199237043628108/1201290101396705/1201345287513869
Tech Design URL:
CC: @tomasstrba @sammacbeth 

**Description**:
Fixes issue of Logins Popover detaching when an Alert is shown
Also fixes another issue of endless Alert loop when making a change, selecting another item and choosing Cancel in "Save changes?" dialog.

**Steps to test this PR**:
1. Validate the Logins Popover closes when clicking outside of it or deactivating the App or another Browser Window
2. Validate the Popover doesn't detach after an Alert is shown (e.g. Delete confirmation)
3. Validate the Popover closes when clicking outside of it when an Alert is shown
4. Validate the Popover stays in Dirty (editing) state when closing it

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
