### PR TITLE
Check for click handler on printing user script

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/PrintingUserScript.swift
+++ b/DuckDuckGo/BrowserTab/Model/PrintingUserScript.swift
@@ -33,11 +33,10 @@ public class PrintingUserScript: NSObject, UserScript {
     public var source: String = """
 (function() {
     document.addEventListener("click", function(event) {
-        event = event || window.event;
 
         let onClickAttribute = event.target.getAttribute('onclick');
 
-        if (onClickAttribute.includes('window.print()')) {
+        if (onClickAttribute && onClickAttribute.includes('window.print()')) {
             webkit.messageHandlers.printHandler.postMessage({});
         }
     });


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201167517963996/f
Tech Design URL:
CC:

**Description**:
Fixes error in printing user script

**Steps to test this PR**:
1. Go to an amazon order summary and open the web developer console
1. Click the "Order Placed" text
2. `TypeError: null is not an object (evaluating 'onClickAttribute.includes')` should not show
2. Click the "Print this page for your records" link
2. The print dialog should open

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
