### PR TITLE
support cmd-option-left/right for navigating tabs

### DIFF
--- a/DuckDuckGo/Menus/MainMenu.storyboard
+++ b/DuckDuckGo/Menus/MainMenu.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -534,6 +534,12 @@ GQ
                                                 <action selector="showPreviousTab:" target="Ady-hI-5gd" id="sdG-QM-RLb"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Show Previous Tab (Hidden)" hidden="YES" keyEquivalent="" allowsKeyEquivalentWhenHidden="YES" id="GuX-M1-3LQ">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="showPreviousTab:" target="Ady-hI-5gd" id="NKT-sZ-qox"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Show Next Tab" id="ell-8c-IYS">
                                             <string key="keyEquivalent" base64-UTF8="YES">
 CQ
@@ -547,6 +553,12 @@ CQ
                                             <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                             <connections>
                                                 <action selector="showNextTab:" target="Ady-hI-5gd" id="wOR-ar-KT6"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show Next Tab (Hidden)" hidden="YES" keyEquivalent="" allowsKeyEquivalentWhenHidden="YES" id="bCk-E5-pHd">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="showNextTab:" target="Ady-hI-5gd" id="DB1-dn-3YS"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Show First Tab (Hidden)" hidden="YES" keyEquivalent="1" allowsKeyEquivalentWhenHidden="YES" id="jjn-9W-TQZ">


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1201362956220539
Tech Design URL:
CC:

**Description**:

Chrome and Safari both support cmd-option-left/right for navigating tabs so helps keep muscle memory.

**Steps to test this PR**:
1. Launch a few tabs.  
2. Check cmd-option-right to move to next tab
3. Check cmd-option-left to move to previous tab
4. Moving beyond the end should move to tab at the other end
5. Ensure only one Show Previous/Next tab menu option under Window menu

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
