### PR TITLE
move the next/previous handlers to the main view controller

### DIFF
--- a/DuckDuckGo/FindInPage/FindInPageViewController.swift
+++ b/DuckDuckGo/FindInPage/FindInPageViewController.swift
@@ -51,14 +51,6 @@ final class FindInPageViewController: NSViewController {
         updateFieldStates()
     }
 
-    @IBAction func findInPageNext(_ sender: Any?) {
-        delegate?.findInPageNext(self)
-    }
-
-    @IBAction func findInPagePrevious(_ sender: Any?) {
-        delegate?.findInPagePrevious(self)
-    }
-
     @IBAction func findInPageDone(_ sender: Any?) {
         delegate?.findInPageDone(self)
     }
@@ -73,10 +65,10 @@ final class FindInPageViewController: NSViewController {
         modifiers.remove(.capsLock)
         switch modifiers {
         case .shift:
-            findInPagePrevious(self)
+            delegate?.findInPagePrevious(self)
             return true
         case []:
-            findInPageNext(self)
+            delegate?.findInPageNext(self)
             return true
         default:
             return false

--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -384,6 +384,14 @@ extension MainViewController {
         tabCollectionViewModel.selectedTabViewModel?.startFindInPage()
     }
 
+    @IBAction func findInPageNext(_ sender: Any?) {
+        self.tabCollectionViewModel.selectedTabViewModel?.findInPageNext()
+    }
+
+    @IBAction func findInPagePrevious(_ sender: Any?) {
+        self.tabCollectionViewModel.selectedTabViewModel?.findInPagePrevious()
+    }
+
     /// Declines handling findInPage action if there's no page loaded currently.
     override func responds(to aSelector: Selector!) -> Bool {
         if aSelector == #selector(findInPage(_:)) && tabCollectionViewModel.selectedTabViewModel?.tab.content.url == nil {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1200892114192842
Tech Design URL:
CC:

**Description**:

Allows next/previous to work if find controller does not have focus.

Note that the menu items will stay visible even when the find controller is closed, this is the same as Safari/Chrome.

**Steps to test this PR**:
1. Open a page with plenty of text and search for something with a few hits (e.g "and")
1. Use the next/previous short cuts and ensure the selected item moves
2. Check enter/shift-enter also works
2. Click out of the find window without closing it
3. Use the next/previous shortcuts and ensure the selected item moves
4.  Close the find window
5. Use the next/previous shortcuts - nothing should happen

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
