### PR TITLE
Tab closing animation

### DIFF
--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -398,30 +398,34 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
         let shouldScroll = collectionView.isAtEndScrollPosition
             && (!self.view.isMouseLocationInsideBounds() || removedIndex == self.collectionView.numberOfItems(inSection: 0) - 1)
         let visiRect = collectionView.enclosingScrollView!.contentView.documentVisibleRect
-        collectionView.animator().performBatchUpdates {
-            let tabWidth = currentTabWidth(removedIndex: removedIndex)
-            if shouldScroll {
-                collectionView.animator().scroll(CGPoint(x: scrollView.contentView.bounds.origin.x - tabWidth, y: 0))
-            }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.15
 
-            if collectionView.selectionIndexPaths != selectionIndexPathSet {
-                collectionView.clearSelection()
-                collectionView.animator().selectItems(at: selectionIndexPathSet, scrollPosition: .centeredHorizontally)
-            }
-            collectionView.animator().deleteItems(at: removedIndexPathSet)
-        } completionHandler: { [weak self] _ in
-            guard let self = self else { return }
+            collectionView.animator().performBatchUpdates {
+                let tabWidth = currentTabWidth(removedIndex: removedIndex)
+                if shouldScroll {
+                    collectionView.animator().scroll(CGPoint(x: scrollView.contentView.bounds.origin.x - tabWidth, y: 0))
+                }
 
-            self.frozenLayout = self.view.isMouseLocationInsideBounds()
-            if !self.frozenLayout {
-                self.updateLayout()
-            }
-            self.updateEmptyTabArea()
-            self.enableScrollButtons()
-            self.hideTooltip()
+                if collectionView.selectionIndexPaths != selectionIndexPathSet {
+                    collectionView.clearSelection()
+                    collectionView.animator().selectItems(at: selectionIndexPathSet, scrollPosition: .centeredHorizontally)
+                }
+                collectionView.animator().deleteItems(at: removedIndexPathSet)
+            } completionHandler: { [weak self] _ in
+                guard let self = self else { return }
 
-            if !shouldScroll {
-                self.collectionView.enclosingScrollView!.contentView.scroll(to: visiRect.origin)
+                self.frozenLayout = self.view.isMouseLocationInsideBounds()
+                if !self.frozenLayout {
+                    self.updateLayout()
+                }
+                self.updateEmptyTabArea()
+                self.enableScrollButtons()
+                self.hideTooltip()
+
+                if !shouldScroll {
+                    self.collectionView.enclosingScrollView!.contentView.scroll(to: visiRect.origin)
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200085849431499/f

**Description**:
Setting lower duration of the tab closing animation to make the browser feel faster. The main point is to avoid long fade out.


**Steps to test this PR**:
1. Compare the closing animation with your currently installed released version. It should feel faster.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
