### PR TITLE
Forward delete collision with suffix resolved

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -658,28 +658,38 @@ extension AddressBarTextField: NSTextFieldDelegate {
             return false
         }
 
-        guard suggestionWindowController?.window?.isVisible == true else {
-            return false
+        // Collision of suffix and forward deleting
+        if [#selector(NSResponder.deleteForward(_:)), #selector(NSResponder.deleteWordForward(_:))].contains(commandSelector) {
+            if let currentEditor = currentEditor(),
+               currentEditor.selectedRange.location == value.string.utf16.count,
+               currentEditor.selectedRange.length == 0 {
+                // Don't do delete when cursor is in the end
+                return true
+            }
         }
 
-        switch commandSelector {
-        case #selector(NSResponder.moveDown(_:)):
-            suggestionContainerViewModel.selectNextIfPossible(); return true
-        case #selector(NSResponder.moveUp(_:)):
-            suggestionContainerViewModel.selectPreviousIfPossible(); return true
-        case #selector(NSResponder.deleteBackward(_:)),
-             #selector(NSResponder.deleteForward(_:)),
-             #selector(NSResponder.deleteToMark(_:)),
-             #selector(NSResponder.deleteWordForward(_:)),
-             #selector(NSResponder.deleteWordBackward(_:)),
-             #selector(NSResponder.deleteToEndOfLine(_:)),
-             #selector(NSResponder.deleteToEndOfParagraph(_:)),
-             #selector(NSResponder.deleteToBeginningOfLine(_:)),
-             #selector(NSResponder.deleteBackwardByDecomposingPreviousCharacter(_:)):
-            suggestionContainerViewModel.clearSelection(); return false
-        default:
-            return false
+        if suggestionWindowController?.window?.isVisible ?? false {
+            switch commandSelector {
+            case #selector(NSResponder.moveDown(_:)):
+                suggestionContainerViewModel.selectNextIfPossible(); return true
+            case #selector(NSResponder.moveUp(_:)):
+                suggestionContainerViewModel.selectPreviousIfPossible(); return true
+            case #selector(NSResponder.deleteBackward(_:)),
+                #selector(NSResponder.deleteForward(_:)),
+                #selector(NSResponder.deleteToMark(_:)),
+                #selector(NSResponder.deleteWordForward(_:)),
+                #selector(NSResponder.deleteWordBackward(_:)),
+                #selector(NSResponder.deleteToEndOfLine(_:)),
+                #selector(NSResponder.deleteToEndOfParagraph(_:)),
+                #selector(NSResponder.deleteToBeginningOfLine(_:)),
+                #selector(NSResponder.deleteBackwardByDecomposingPreviousCharacter(_:)):
+                suggestionContainerViewModel.clearSelection(); return false
+            default:
+                return false
+            }
         }
+
+        return false
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1200785043101085/f

**Description**:
PR resolves issue of the address bar adding '- Search DuckDuckGo' into the query when user does forward delete

**Steps to test this PR**:
1. Type search query
2. Place cursor to the end
3. Do forward delete
4. Make sure nothing chances

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
