### PR TITLE
Reset tracker info on page change

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/Tab.swift
+++ b/DuckDuckGo/BrowserTab/Model/Tab.swift
@@ -127,8 +127,6 @@ final class Tab: NSObject {
            let host = content.url?.host {
             faviconService.cacheIfNeeded(favicon: favicon, for: host, isFromUserScript: false)
         }
-
-        updateDashboardInfo(url: content.url)
     }
 
     deinit {
@@ -151,7 +149,6 @@ final class Tab: NSObject {
         didSet {
             handleFavicon(oldContent: oldValue)
             invalidateSessionStateData()
-            updateDashboardInfo(oldUrl: oldValue.url, url: content.url)
             reloadIfNeeded()
 
             if let title = content.title {
@@ -294,7 +291,6 @@ final class Tab: NSObject {
             webView.load(url)
         } else {
             webView.reload()
-            updateDashboardInfo(url: content.url)
         }
     }
 
@@ -501,15 +497,9 @@ final class Tab: NSObject {
     @Published var serverTrust: ServerTrust?
     @Published var connectionUpgradedTo: URL?
 
-    private func updateDashboardInfo(oldUrl: URL? = nil, url: URL?) {
-        guard let url = url, let host = url.host else {
-            trackerInfo = nil
-            serverTrust = nil
-            return
-        }
-
-        if oldUrl?.host != host || oldUrl?.scheme != url.scheme {
-            trackerInfo = TrackerInfo()
+    public func resetDashboardInfo(_ url: URL?) {
+        trackerInfo = TrackerInfo()
+        if self.serverTrust?.host != url?.host {
             serverTrust = nil
         }
     }

--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -329,6 +329,7 @@ extension BrowserTabViewController: TabDelegate {
         guard let tabViewModel = tabViewModel else { return }
 
         tabViewModel.closeFindInPage()
+        tabViewModel.tab.resetDashboardInfo(tabViewModel.tab.webView.url)
         tab.permissions.tabDidStartNavigation()
         if !tabViewModel.isLoading,
            tabViewModel.tab.webView.isLoading {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201233794429580/f
Tech Design URL:
CC:

**Description**:
Reset tracker information on URL path change

Before | After
--- | ---
![before-tracker-data-reset](https://user-images.githubusercontent.com/635903/142204280-fed3875c-8478-4647-8678-ac27dc47d220.gif) | ![after-tracker-data-reset](https://user-images.githubusercontent.com/635903/142204309-a6046122-7962-4750-9830-db29d2b9f4eb.gif)

**Steps to test this PR**:
1. Go to http://privacy-test-pages.glitch.me/index.html
2. Open Privacy Dashboard popover — it should say "0 Trackers Found"
3. Click on the link "Image loaded via document fragment" 
4. Open Privacy Dashboard popover — it should say "1 Tracker Found"
5. Click on the link "[Home]"
6. Open Privacy Dashboard popover — it should say "0 Trackers Found"

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
