### PR TITLE
Avoid an assertion failure when importing browser data

### DIFF
--- a/DuckDuckGo/Data Import/DataImport.swift
+++ b/DuckDuckGo/Data Import/DataImport.swift
@@ -65,14 +65,14 @@ enum DataImport {
     }
 
     struct BrowserProfileList {
-        let browser: ThirdPartyBrowser.BrowserType
+        let browser: ThirdPartyBrowser
         let profiles: [BrowserProfile]
 
         var validImportableProfiles: [BrowserProfile] {
             return profiles.filter(\.hasLoginData)
         }
 
-        init(browser: ThirdPartyBrowser.BrowserType, profileURLs: [URL]) {
+        init(browser: ThirdPartyBrowser, profileURLs: [URL]) {
             self.browser = browser
 
             switch browser {

--- a/DuckDuckGo/Data Import/ThirdPartyBrowser.swift
+++ b/DuckDuckGo/Data Import/ThirdPartyBrowser.swift
@@ -28,37 +28,27 @@ private struct BundleIdentifiers {
     }
 }
 
-struct ThirdPartyBrowser {
+enum ThirdPartyBrowser: CaseIterable {
 
-    static var brave: ThirdPartyBrowser { ThirdPartyBrowser(type: .brave) }
-    static var chrome: ThirdPartyBrowser { ThirdPartyBrowser(type: .chrome) }
-    static var edge: ThirdPartyBrowser { ThirdPartyBrowser(type: .edge) }
-    static var firefox: ThirdPartyBrowser { ThirdPartyBrowser(type: .firefox) }
-    static var safari: ThirdPartyBrowser { ThirdPartyBrowser(type: .safari) }
+    case brave
+    case chrome
+    case edge
+    case firefox
+    case safari
+    
+    static var installedBrowsers: [ThirdPartyBrowser] {
+        return allCases.filter(\.isInstalled)
+    }
 
     static func browser(for source: DataImport.Source) -> ThirdPartyBrowser? {
         switch source {
-        case .brave:
-            return Self.brave
-        case .chrome:
-            return Self.chrome
-        case .edge:
-            return Self.edge
-        case .firefox:
-            return Self.firefox
-        case .safari:
-            return Self.safari
-        case .csv:
-            return nil
+        case .brave: return .brave
+        case .chrome: return .chrome
+        case .edge: return .edge
+        case .firefox: return .firefox
+        case .safari: return .safari
+        case .csv: return nil
         }
-    }
-
-    enum BrowserType {
-        case brave
-        case chrome
-        case edge
-        case firefox
-        case safari
     }
 
     var isInstalled: Bool {
@@ -67,6 +57,16 @@ struct ThirdPartyBrowser {
 
     var isRunning: Bool {
         return !findRunningApplications().isEmpty
+    }
+    
+    var importSource: DataImport.Source {
+        switch self {
+        case .brave: return .brave
+        case .chrome: return .chrome
+        case .edge: return .edge
+        case .firefox: return .firefox
+        case .safari: return .safari
+        }
     }
 
     var applicationIcon: NSImage? {
@@ -85,14 +85,14 @@ struct ThirdPartyBrowser {
                                                                                       options: [.skipsHiddenFiles]).filter(\.hasDirectoryPath) else {
             // Safari is an exception, as it may need permissions granted before being able to read the contents of the profile path. To be safe,
             // return the profile anyway and check the file system permissions when preparing to import.
-            if type == .safari {
-                return DataImport.BrowserProfileList(browser: self.type, profileURLs: [profilePath])
+            if self == .safari {
+                return DataImport.BrowserProfileList(browser: self, profileURLs: [profilePath])
             } else {
                 return nil
             }
         }
 
-        return DataImport.BrowserProfileList(browser: self.type, profileURLs: potentialProfileURLs)
+        return DataImport.BrowserProfileList(browser: self, profileURLs: potentialProfileURLs)
     }
 
     // Returns the first available path to the application. This will test the production bundle ID, and any known pre-release versions, such as the
@@ -108,7 +108,7 @@ struct ThirdPartyBrowser {
     }
 
     private var bundleIdentifiers: BundleIdentifiers {
-        switch type {
+        switch self {
         case .brave: return BundleIdentifiers(productionBundleID: "com.brave.Browser", relatedBundleIDs: ["com.brave.Browser.nightly"])
         case .chrome: return BundleIdentifiers(productionBundleID: "com.google.Chrome", relatedBundleIDs: ["com.google.Chrome.canary"])
         case .edge: return BundleIdentifiers(productionBundleID: "com.microsoft.edgemac", relatedBundleIDs: [])
@@ -119,8 +119,6 @@ struct ThirdPartyBrowser {
         case .safari: return BundleIdentifiers(productionBundleID: "com.apple.safari", relatedBundleIDs: [])
         }
     }
-
-    private let type: BrowserType
 
     func forceTerminate() {
         let applications = findRunningApplications()
@@ -145,7 +143,7 @@ struct ThirdPartyBrowser {
     private func profilesDirectory() -> URL {
         let applicationSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
 
-        switch type {
+        switch self {
         case .brave: return applicationSupportURL.appendingPathComponent("BraveSoftware/Brave-Browser/")
         case .chrome: return applicationSupportURL.appendingPathComponent("Google/Chrome/")
         case .edge: return applicationSupportURL.appendingPathComponent("Microsoft Edge/")

--- a/DuckDuckGo/Data Import/View/DataImportViewController.swift
+++ b/DuckDuckGo/Data Import/View/DataImportViewController.swift
@@ -39,6 +39,14 @@ final class DataImportViewController: NSViewController {
     private struct ViewState {
         var selectedImportSource: DataImport.Source
         var interactionState: InteractionState
+        
+        static func defaultState() -> ViewState {
+            if let firstInstalledBrowser = ThirdPartyBrowser.installedBrowsers.first {
+                return ViewState(selectedImportSource: firstInstalledBrowser.importSource, interactionState: .ableToImport)
+            } else {
+                return ViewState(selectedImportSource: .csv, interactionState: .ableToImport)
+            }
+        }
     }
 
     static func create() -> DataImportViewController {
@@ -46,7 +54,7 @@ final class DataImportViewController: NSViewController {
         return storyboard.instantiateController(identifier: Constants.identifier)
     }
 
-    private var viewState: ViewState = ViewState(selectedImportSource: .brave, interactionState: .ableToImport) {
+    private var viewState: ViewState = .defaultState() {
         didSet {
             renderCurrentViewState()
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1201395805385122/f
Tech Design URL:
CC:

**Description**:

This PR cleans up a bit of `ThirdPartyBrowser`, turning it from a struct with a bunch of what were essentially cases in the form of `static let`s, into an enum.

This also replaces the default value of `.brave` when opening the import feature, and instead looks up the list of installed browsers and uses the first one.

**Steps to test this PR**:
1. Import from different browsers
1. Uninstall a browser that is installed and verify that everything is all good

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
