### PR TITLE
Add missing next and previous find-in-page button handlers

### DIFF
--- a/DuckDuckGo/FindInPage/FindInPageViewController.swift
+++ b/DuckDuckGo/FindInPage/FindInPageViewController.swift
@@ -51,6 +51,14 @@ final class FindInPageViewController: NSViewController {
         updateFieldStates()
     }
 
+    @IBAction func findInPageNext(_ sender: Any?) {
+        delegate?.findInPageNext(self)
+    }
+
+    @IBAction func findInPagePrevious(_ sender: Any?) {
+        delegate?.findInPagePrevious(self)
+    }
+
     @IBAction func findInPageDone(_ sender: Any?) {
         delegate?.findInPageDone(self)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC: @brindy 

**Description**:
Previous and next buttons for find-in-page aren't working after https://github.com/more-duckduckgo-org/macos-browser/pull/331 -- adding in the handlers referenced in the storyboard

Before | After
--- | ---
![find-in-page-buttons-before](https://user-images.githubusercontent.com/635903/143461092-85e3ee93-c4f8-4881-b0ee-80056bb73140.gif) | ![find-in-page-buttons-after](https://user-images.githubusercontent.com/635903/143461085-5a7e9c0d-2683-40fc-88d6-03d5710e12ed.gif)

**Steps to test this PR**:
There's three ways to trigger next/previous for find-in-page -- confirm they all work as expected:

Enter / Shift+Enter
1. Go to https://cheese.com/ and search for "cheese"
2. With the find-in-page input focused...
     - Press the Enter key to move to the next match
     - press the Shift+Enter keys to move to the previous match

Next / Previous buttons
1. Go to https://cheese.com/ and search for "cheese"
2. Using the buttons to the right of the find-in-page input...
     - Click the down chevron to move to the next match
     - Click the up chevron to move to the previous match

Cmd+G / Shift+Cmd+G keyboard shortcupts
1. Go to https://cheese.com/ and search for "cheese"
2. With the find-in-page input blurred...
     - Press the Cmd+G keys to move to the next match
     - press the Shift+Cmd+G keys to move to the previous match

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
