### PR TITLE
Hotfix: Rename ATB keys so that the app thinks it's a new install

### DIFF
--- a/DuckDuckGo/Statistics/ATB/LocalStatisticsStore.swift
+++ b/DuckDuckGo/Statistics/ATB/LocalStatisticsStore.swift
@@ -55,6 +55,8 @@ final class LocalStatisticsStore: StatisticsStore {
         static let lastAppRetentionRequestDate = "stats.appretentionatb.last.request.key"
     }
 
+    // These are the original ATB keys that have been replaced in order to resolve retention data issues.
+    // These keys should be removed from the database in the future.
     private struct DeprecatedKeys {
         static let installDate = "statistics.installdate.key"
         static let atb = "statistics.atb.key"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1201495686896081/f
Tech Design URL:
CC: @tomasstrba 

**Description**:

This PR renames the ATB keys to trick the browser into thinking that it's a new install, so that users on existing versions don't muddy our retention data.

**Important:** @tomasstrba I branched off of `main` for this with the intention of us putting out a release purely with this change, and nothing else on `develop`. 

**Steps to test this PR**:
1. Run a clean install of the debug version of the browser, and check that the ATB install statistic requests are made
1. Check this branch out and run it
1. Verify that the ATB requests are made again – subsequent calls should obviously not continue to call it

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
