### PR TITLE
Fix synchronous data removal from PixelDataStore cache

### DIFF
--- a/DuckDuckGo/Statistics/PixelDataStore.swift
+++ b/DuckDuckGo/Statistics/PixelDataStore.swift
@@ -164,6 +164,7 @@ final class LocalPixelDataStore<T: NSManagedObject>: PixelDataStore {
     }
 
     func removeValue(forKey key: String, completionHandler: ((Error?) -> Void)?) {
+        self.cache.removeValue(forKey: key)
         let predicate = self.predicate(forKey: key)
 
         func mainQueueCompletion(_ error: Error?) {
@@ -184,8 +185,6 @@ final class LocalPixelDataStore<T: NSManagedObject>: PixelDataStore {
                 let deletedObjects = result?.result as? [NSManagedObjectID] ?? []
                 let changes: [AnyHashable: Any] = [NSDeletedObjectsKey: deletedObjects]
                 NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [context])
-                
-                self.cache.removeValue(forKey: key)
                 
                 mainQueueCompletion(nil)
             } catch {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:
Fixes Pixel Data Store Cached value available after removing a value from PixelDataStore (and later data race when removing the value from background thread)

**Steps to test this PR**:
1. Validate PixelDataStore.remove(valueForKey: ..) removes the value from cache synchronously

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
