### PR TITLE
Removing unnecessary menu items from the address bar field context menu

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -791,7 +791,7 @@ extension AddressBarTextField: NSTextViewDelegate {
         return removingAttributeChangingMenuItems(from: menu)
     }
 
-    private static var selectorsToRemove = [
+    private static var selectorsToRemove: Set<Selector> = Set([
         Selector(("_makeLinkFromMenu:")),
         Selector(("_searchWithGoogleFromMenu:")),
         #selector(NSFontManager.orderFrontFontPanel(_:)),
@@ -800,21 +800,22 @@ extension AddressBarTextField: NSTextViewDelegate {
         #selector(NSStandardKeyBindingResponding.uppercaseWord(_:)),
         #selector(NSTextView.startSpeaking(_:)),
         #selector(NSTextView.changeLayoutOrientation(_:))
-    ]
+    ])
 
     private func removingAttributeChangingMenuItems(from menu: NSMenu) -> NSMenu {
         menu.items.reversed().forEach { menuItem in
-            if let action = menuItem.action {
-                if Self.selectorsToRemove.contains(action) { menu.removeItem(menuItem) }
-            }
-            if let submenu = menuItem.submenu, submenu.items.first(where: { submenuItem in
-                if let submenuAction = submenuItem.action, Self.selectorsToRemove.contains(submenuAction) {
-                    return true
-                } else {
-                    return false
-                }
-            }) != nil {
+            if let action = menuItem.action, Self.selectorsToRemove.contains(action) {
                 menu.removeItem(menuItem)
+            } else {
+                if let submenu = menuItem.submenu, submenu.items.first(where: { submenuItem in
+                    if let submenuAction = submenuItem.action, Self.selectorsToRemove.contains(submenuAction) {
+                        return true
+                    } else {
+                        return false
+                    }
+                }) != nil {
+                    menu.removeItem(menuItem)
+                }
             }
         }
         return menu


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1148564399326804/1201546959960286

**Description**:
There was unnecessary "Make Link", "Search with Google" and "Fonts" menu items in the context menu of the address bar text field.

**Steps to test this PR**:
1. Load a website, 
2. Unfocus the address bar
1. Right click the address bar


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
