### PR TITLE
Missing tab separator issue

### DIFF
--- a/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
+++ b/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
@@ -80,12 +80,13 @@ final class TabBarCollectionView: NSCollectionView {
         collectionViewLayout?.invalidateLayout()
     }
 
-    private func updateItemsLeftToSelectedItems(_ selectionIndexPaths: Set<IndexPath>) {
+    func updateItemsLeftToSelectedItems(_ selectionIndexPaths: Set<IndexPath>? = nil) {
+        let indexPaths = selectionIndexPaths ?? self.selectionIndexPaths
         visibleItems().forEach {
             ($0 as? TabBarViewItem)?.isLeftToSelected = false
         }
 
-        for indexPath in selectionIndexPaths where indexPath.item > 0 {
+        for indexPath in indexPaths where indexPath.item > 0 {
             let leftToSelectionIndexPath = IndexPath(item: indexPath.item - 1)
             (item(at: leftToSelectionIndexPath) as? TabBarViewItem)?.isLeftToSelected = true
         }

--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -107,6 +107,7 @@ final class TabBarViewController: NSViewController {
 
     private func reloadSelection() {
         guard collectionView.selectionIndexPaths.first?.item != tabCollectionViewModel.selectionIndex else {
+            collectionView.updateItemsLeftToSelectedItems()
             return
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201481592770624/f
Tech Design URL:
CC:

**Description**:


**Steps to test this PR**:
I was usually able to reproduce missing tab separator with these three actions happening quickly:
1. Selected the last tab, 
2. Trigger loading of a website
3. Immediately select the first tab

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
