### PR TITLE
check for default browser during onboarding

### DIFF
--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -885,6 +885,11 @@ extension BrowserTabViewController: OnboardingDelegate {
     }
 
     func onboardingDidRequestSetDefault(completion: @escaping () -> Void) {
+        if DefaultBrowserPreferences.isDefault {
+            completion()
+            return
+        }
+
         DefaultBrowserPreferences.becomeDefault()
 
         var observer: Any?


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1201554073062083
Tech Design URL:
CC:

**Description**:

Ensure that user can progress if they hit set as default and browser is (somehow) already default

**Steps to test this PR**:
1. Comment out the following lines in `DefaultBrowserPreferences.swift`:

```
        #if DEBUG
        bundleID = bundleID.drop(suffix: ".debug")
        #endif
```

1. With a window open from the Debug menu reset the Mac Waitlist Lock Screen
2. Open a new window and go through the flow.  At "set default" click the set as default button and set the browser as default using the system popup
3. Finish the flow and repeat from step 1
4. The second time through clicking the set as default button should just progress to the next screen

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
