### PR TITLE
Fix Inspector Hiding crashing in DEBUG

### DIFF
--- a/DuckDuckGo/BrowserTab/View/WebView.swift
+++ b/DuckDuckGo/BrowserTab/View/WebView.swift
@@ -146,8 +146,7 @@ final class WebView: WKWebView {
     }
 
     var isInspectorShown: Bool {
-        guard let result = inspectorPerform("isVisible") else { return false }
-        return result.toOpaque() == UnsafeMutableRawPointer(bitPattern: 0x1)
+        return inspectorPerform("isVisible") != nil
     }
 
     @nonobjc func openDeveloperTools() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/more-duckduckgo-org/macos-browser/issues/390
Tech Design URL:
CC: @shakyShane 

**Description**:
Fixes crash in DEBUG when closing Web Inspector

**Steps to test this PR**:
1. Open Inspector when running build in DEBUG mode
2. Close inspector with Cmd+Opt+I shortcut - this should not crash


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
