### PR TITLE
Fix of the homepage textfield glitch

### DIFF
--- a/DuckDuckGo/Homepage/View/HomepageHeaderView.swift
+++ b/DuckDuckGo/Homepage/View/HomepageHeaderView.swift
@@ -168,7 +168,11 @@ final class HomepageHeaderView: NSView {
     }
 
     private func updateSearchView() {
-        if window?.firstResponder != field.currentEditor() {
+        guard let firstResponder = window?.firstResponder else {
+            return
+        }
+
+        if firstResponder != field.currentEditor() {
            showSearchInactive()
         } else if field.isSuggestionWindowVisible {
             showSearchHasResults()

--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -131,6 +131,11 @@ final class AddressBarTextField: NSTextField {
     }
 
     private func updateValue() {
+        guard !isHomepageAddressBar else {
+            value = .text("")
+            return
+        }
+
         guard let selectedTabViewModel = tabCollectionViewModel.selectedTabViewModel else {
             return
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201675704545679/f
Tech Design URL:
CC:

**Description**:
PR fixes visual glitch of the homepage textfield. It appears right after switching to the homepage. The textfield contained URL address and was also focused (stronger shadow) for a short period of time. Now it is just empty and unfocused right after switching

**Steps to test this PR**:
1. Please follow testing steps of #340
2. Make sure homepage textfield is empty and unfocused right after switching to the homepage

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
