### PR TITLE
Fix Catalina onboarding lock up

### DIFF
--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -261,7 +261,9 @@ final class BrowserTabViewController: NSViewController {
 
         case .onboarding:
             removeAllTabContent()
-            requestDisableUI()
+            if !OnboardingViewModel().onboardingFinished {
+                requestDisableUI()
+            }
             showTransientTabContentController(OnboardingViewController.create(withDelegate: self))
 
         case .url:


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1201737990269948
Tech Design URL:
CC: @bstandaert-ddg 

**Description**:

Don't disable the UI unless onboarding has been marked as finished

**Steps to test this PR**:
1. Clean install of the browser.
1. Start the browser and click through all the onboarding steps until you get to the last page ("you're all set!")
2. Open a new tab
3. Switch back to the onboarding tab - browser controls should not be disabled
4. Restart the browser, the onboarding page reopens and browser controls should not be disabled

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
