### PR TITLE
Check for an existing lock screen before showing a new one

### DIFF
--- a/DuckDuckGo/Waitlist/Waitlist.swift
+++ b/DuckDuckGo/Waitlist/Waitlist.swift
@@ -44,9 +44,15 @@ struct Waitlist {
         let lockScreenViewController = MacWaitlistLockScreenViewController.instantiate()
         let lockScreenWindow = lockScreenViewController.wrappedInWindowController()
         
-        viewController.beginSheet(lockScreenWindow)
+        let currentSheets = viewController.view.window?.sheets ?? []
+        let alreadyHasLockScreen = currentSheets.contains(where: { window in
+            return window.contentViewController is MacWaitlistLockScreenViewController
+        })
         
-        Pixel.fire(.waitlistPresentedLockScreen)
+        if !alreadyHasLockScreen {
+            viewController.beginSheet(lockScreenWindow)
+            Pixel.fire(.waitlistPresentedLockScreen)
+        }
         
         return true
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1201856209410871/f
Tech Design URL:
CC: @brindy 

**Description**:

This PR updates the Lock Screen logic to check whether one is already visible before displaying a new one. This issue couldn't lock users out of the app, but it looked weird.

**Steps to test this PR**:
1. Comment out the `#if DEBUG` checks that automatically unlock debug builds of the app (specifically, `unlockExistingInstallIfNecessary` inside `Waitlist.swift`)
1. Launch the app, and select "Reset Mac Waitlist Lock Screen" if one hasn't appeared
1. Close the current window, open a new one, the lock screen should appear
1. Minimize the window and maximize it repeatedly
1. After doing this a few times, enter `DAX` as the code and proceed through the waitlist flow
1. Check that the lock screen is dismissed and no more lock screens appear

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
