### PR TITLE
Fix crash when background tabs trigger cookie popup

### DIFF
--- a/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -135,13 +135,14 @@ final class AutoconsentUserScript: NSObject, UserScriptWithAutoconsent {
             return
         }
         let now = Date.init()
-        guard Self.promptLastShown == nil || now > Self.promptLastShown!.addingTimeInterval(30) else {
+        guard Self.promptLastShown == nil || now > Self.promptLastShown!.addingTimeInterval(30),
+              let window = self.webview!.window else {
             callback(false)
             return
         }
         Self.promptLastShown = now
         let alert = NSAlert.cookiePopup()
-        alert.beginSheetModal(for: self.webview!.window!, completionHandler: { response in
+        alert.beginSheetModal(for: window, completionHandler: { response in
             switch response {
             case .alertFirstButtonReturn:
                 // User wants to turn on the feature


### PR DESCRIPTION
The webview may not have a window when we run this code.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1163321984198618/1201869397036687/f
Tech Design URL:
CC:

**Description**:


**Steps to test this PR**:
1. Clear app settings
1. Load several tabs in the background (which should have cookie popups)
2. Switch to closed tabs
3. Browser shouldn't crash.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
