### PR TITLE
Rename weakAssign to assign(to:onWeaklyHeld:)

### DIFF
--- a/DuckDuckGo/BrowserTab/Model/UserContentController.swift
+++ b/DuckDuckGo/BrowserTab/Model/UserContentController.swift
@@ -53,7 +53,7 @@ final class UserContentController: WKUserContentController {
         self.privacyConfigurationManager = privacyConfigurationManager
         super.init()
 
-        cancellable = assetsPublisher.receive(on: DispatchQueue.main).map { $0 }.weakAssign(to: \.contentBlockingAssets, on: self)
+        cancellable = assetsPublisher.receive(on: DispatchQueue.main).map { $0 }.assign(to: \.contentBlockingAssets, onWeaklyHeld: self)
 
 #if DEBUG
         // make sure delegate for UserScripts is set shortly after init

--- a/DuckDuckGo/BrowserTab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/BrowserTab/ViewModel/TabViewModel.swift
@@ -114,9 +114,9 @@ final class TabViewModel {
     }
 
     private func subscribeToPermissions() {
-        tab.permissions.$permissions.weakAssign(to: \.usedPermissions, on: self)
+        tab.permissions.$permissions.assign(to: \.usedPermissions, onWeaklyHeld: self)
             .store(in: &cancellables)
-        tab.permissions.$authorizationQuery.weakAssign(to: \.permissionAuthorizationQuery, on: self)
+        tab.permissions.$authorizationQuery.assign(to: \.permissionAuthorizationQuery, onWeaklyHeld: self)
             .store(in: &cancellables)
     }
 

--- a/DuckDuckGo/Common/Extensions/PublisherExtension.swift
+++ b/DuckDuckGo/Common/Extensions/PublisherExtension.swift
@@ -21,7 +21,7 @@ import Combine
 
 extension Publisher where Failure == Never {
 
-    func weakAssign<T: AnyObject>(to keyPath: ReferenceWritableKeyPath<T, Output>, on object: T) -> AnyCancellable {
+    func assign<T: AnyObject>(to keyPath: ReferenceWritableKeyPath<T, Output>, onWeaklyHeld object: T) -> AnyCancellable {
         sink { [weak object] value in
             object?[keyPath: keyPath] = value
         }

--- a/DuckDuckGo/ContentBlocker/ContentBlocking.swift
+++ b/DuckDuckGo/ContentBlocker/ContentBlocking.swift
@@ -176,7 +176,7 @@ final class ContentBlockingUpdating {
             .map { $0.0 } // drop gpcEnabled value: $0.1
             // DefaultScriptSourceProvider instance should be created once per rules/config change and fed into UserScripts initialization
             .map(makeValue)
-            .weakAssign(to: \.bufferedValue, on: self) // buffer latest update value
+            .assign(to: \.bufferedValue, onWeaklyHeld: self) // buffer latest update value
 
         // 2. Publish ContentBlockingAssets(Rules+Scripts) for WKUserContentController per subscription
         self.userContentBlockingAssets = $bufferedValue

--- a/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
+++ b/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
@@ -115,10 +115,10 @@ final class WebKitDownloadTask: NSObject, ProgressReporting {
         self.progress.fileDownloadingSourceURL = download.originalRequest?.url
         if let progress = (self.download as? ProgressReporting)?.progress {
             progress.publisher(for: \.totalUnitCount)
-                .weakAssign(to: \.totalUnitCount, on: self.progress)
+                .assign(to: \.totalUnitCount, onWeaklyHeld: self.progress)
                 .store(in: &self.cancellables)
             progress.publisher(for: \.completedUnitCount)
-                .weakAssign(to: \.completedUnitCount, on: self.progress)
+                .assign(to: \.completedUnitCount, onWeaklyHeld: self.progress)
                 .store(in: &self.cancellables)
         }
     }

--- a/DuckDuckGo/Geolocation/GeolocationProvider.swift
+++ b/DuckDuckGo/Geolocation/GeolocationProvider.swift
@@ -110,7 +110,7 @@ final class GeolocationProvider: NSObject, GeolocationProviderProtocol {
         super.init()
 
         geolocationProviderCallbacks = geolocationManager.setProvider(self)
-        appIsActiveCancellable = appIsActivePublisher.weakAssign(to: \.isAppActive, on: self)
+        appIsActiveCancellable = appIsActivePublisher.assign(to: \.isAppActive, onWeaklyHeld: self)
     }
 
     convenience init?(processPool: WKProcessPool,

--- a/DuckDuckGo/Main/View/MainWindowController.swift
+++ b/DuckDuckGo/Main/View/MainWindowController.swift
@@ -92,7 +92,7 @@ final class MainWindowController: NSWindowController {
         trafficLightsAlphaCancellable = window?.standardWindowButton(.closeButton)?
             .publisher(for: \.alphaValue)
             .map { alphaValue in TabBarViewController.HorizontalSpace.leadingStackViewPadding.rawValue * alphaValue }
-            .weakAssign(to: \.constant, on: tabBarViewController.leadingStackViewLeadingConstraint)
+            .assign(to: \.constant, onWeaklyHeld: tabBarViewController.leadingStackViewLeadingConstraint)
     }
 
     private var shouldPreventUserInteractionCancellable: AnyCancellable?

--- a/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -183,7 +183,7 @@ final class AddressBarViewController: NSViewController {
         }
         passiveAddressBarStringCancellable = selectedTabViewModel.$passiveAddressBarString
             .receive(on: DispatchQueue.main)
-            .weakAssign(to: \.stringValue, on: passiveTextField)
+            .assign(to: \.stringValue, onWeaklyHeld: passiveTextField)
     }
 
     private func subscribeToProgressEvents() {
@@ -226,7 +226,7 @@ final class AddressBarViewController: NSViewController {
     }
 
     func subscribeToButtonsWidth() {
-        addressBarButtonsViewController!.$buttonsWidth.weakAssign(to: \.constant, on: passiveTextFieldMinXConstraint)
+        addressBarButtonsViewController!.$buttonsWidth.assign(to: \.constant, onWeaklyHeld: passiveTextFieldMinXConstraint)
             .store(in: &cancellables)
     }
 

--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -380,7 +380,7 @@ final class NavigationBarViewController: NSViewController {
                 let progress = DownloadListCoordinator.shared.progress
                 return progress.fractionCompleted == 1.0 || progress.totalUnitCount == 0 ? nil : progress.fractionCompleted
             }
-            .weakAssign(to: \.progress, on: downloadsProgressView)
+            .assign(to: \.progress, onWeaklyHeld: downloadsProgressView)
             .store(in: &downloadsCancellables)
     }
 

--- a/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -215,7 +215,7 @@ final class TabBarViewItem: NSCollectionViewItem {
             self?.currentURL = content.url
         }.store(in: &cancellables)
 
-        tabViewModel.$usedPermissions.weakAssign(to: \.usedPermissions, on: self).store(in: &cancellables)
+        tabViewModel.$usedPermissions.assign(to: \.usedPermissions, onWeaklyHeld: self).store(in: &cancellables)
     }
 
     func clear() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
Tech Design URL:
CC:

**Description**:
Follow-up after discussion https://github.com/more-duckduckgo-org/macos-browser/pull/402 with @bwaresiak:
Rename Publisher.weakAssign to Publisher.assign(to:onWealyHeld) improving code readability, as "weakAssign" may cause confusion that it's assigning weak value instead of assigning on a weakly held object

**Steps to test this PR**:
1.
1.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
