### PR TITLE
Remove mouse event listeners on browser close

### DIFF
--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -27,7 +27,9 @@ protocol ChildAutofillUserScriptDelegate: AnyObject {
     func browserTabViewController(_ browserTabViewController: BrowserTabViewController, didClickAtPoint: CGPoint)
 }
 
+// swiftlint:disable type_body_length
 // swiftlint:disable file_length
+
 final class BrowserTabViewController: NSViewController {
 
     @IBOutlet weak var errorView: NSView!
@@ -1015,4 +1017,5 @@ extension BrowserTabViewController {
 
 }
 
+// swiftlint:enable type_body_length
 // swiftlint:enable file_length


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201889534538164/f
Tech Design URL:
CC:

**Description**:

Fixes browser restart click handler issue.

**Steps to test this PR**:
Please describe the issue in as much detail as possible.:
1. Open the browser.
2. Close the browser window.
3. Open a new window.
4. Try to click on the menu button or fire button.
5. Navigate to a website.
6. Try to click on something in the web content.

At steps 4 and 6, clicking doesn't should now work.


**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
