### PR TITLE
Hotfix of the memory leak

### DIFF
--- a/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -52,7 +52,7 @@ final class AutoconsentUserScript: NSObject, UserScriptWithAutoconsent {
     let tabId: Int
     let config: PrivacyConfiguration
     var actionInProgress = false
-    var webview: WKWebView?
+    weak var webview: WKWebView?
     weak var delegate: AutoconsentUserScriptDelegate?
 
     init(scriptSource: ScriptSourceProviding, config: PrivacyConfiguration) {
@@ -65,7 +65,7 @@ final class AutoconsentUserScript: NSObject, UserScriptWithAutoconsent {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard let messageName = MessageName(rawValue: message.name) else { return }
         if message.webView != nil {
-            webview = message.webView!
+            webview = message.webView
         }
 
         switch messageName {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201887846026720/f

**Description**:
Fix of the reference cycle between a webview instance and its autoconsent user script.


**Steps to test this PR**:
**Test deallocation**
1. Run the app, open plenty of tabs. 
2. In Xcode, open Debug Memory Graph and make sure you see the number of webview instances.
3. Hit continue and close all tabs
4. Open Debug Memory Graph again and make sure webviews were deallocated

**Test autoconsent feature**
5. Make sure Autoconsent works as expected

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
