### PR TITLE
Advance content-scope-scripts forward

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -5547,7 +5547,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 11.2.1;
+				minimumVersion = 11.2.2;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/duckduckgo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "256c06ff40188d965916a21d70c07defde6b6065",
-          "version": "11.2.1"
+          "revision": "db82d8ee678cfef274366e838fd5473008e25b63",
+          "version": "11.2.2"
         }
       },
       {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/569473074191537/1201894298881763/f
Tech Design URL:
CC:

**Description**:

Draft commit to test: https://app.asana.com/0/569473074191537/1201894298881763/f and https://github.com/duckduckgo/BrowserServicesKit/pull/73

**Steps to test this PR**:

1. Open https://good.third-party.site/security/js-leaks.html
2. Click Safari
3. Click check

Check for globals that look defined by us (the test gets outdated per Safari release: but previously we had 'init' and 'contentScopeFeatures' leaked)

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
