### PR TITLE
Use pageZoom instead of magnification when adjusting web view zoom level

### DIFF
--- a/DuckDuckGo/BrowserTab/View/WebView.swift
+++ b/DuckDuckGo/BrowserTab/View/WebView.swift
@@ -43,30 +43,46 @@ final class WebView: WKWebView {
         "WKMenuItemIdentifierSearchWeb": UserText.searchWithDuckDuckGo
     ]
 
-    static private let maxMagnification: CGFloat = 3.0
-    static private let minMagnification: CGFloat = 0.5
-    static private let magnificationStep: CGFloat = 0.1
+    static private let maxZoomLevel: CGFloat = 3.0
+    static private let minZoomLevel: CGFloat = 0.5
+    static private let zoomLevelStep: CGFloat = 0.1
+    
+    var zoomLevel: CGFloat {
+        get {
+            if #available(macOS 11.0, *) {
+                return pageZoom
+            }
+            return magnification
+        }
+        set {
+            if #available(macOS 11.0, *) {
+                pageZoom = newValue
+            } else {
+                magnification = newValue
+            }
+        }
+    }
 
     var canZoomToActualSize: Bool {
-        self.window != nil && self.magnification != 1.0
+        self.window != nil && self.zoomLevel != 1.0
     }
 
     var canZoomIn: Bool {
-        self.window != nil && self.magnification < Self.maxMagnification
+        self.window != nil && self.zoomLevel < Self.maxZoomLevel
     }
 
     var canZoomOut: Bool {
-        self.window != nil && self.magnification > Self.minMagnification
+        self.window != nil && self.zoomLevel > Self.minZoomLevel
     }
 
     func zoomIn() {
         guard canZoomIn else { return }
-        self.magnification = min(self.magnification + Self.magnificationStep, Self.maxMagnification)
+        self.zoomLevel = min(self.zoomLevel + Self.zoomLevelStep, Self.maxZoomLevel)
     }
 
     func zoomOut() {
         guard canZoomOut else { return }
-        self.magnification = max(self.magnification - Self.magnificationStep, Self.minMagnification)
+        self.zoomLevel = max(self.zoomLevel - Self.zoomLevelStep, Self.minZoomLevel)
     }
 
     deinit {

--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -232,7 +232,7 @@ extension MainViewController {
             return
         }
 
-        selectedTabViewModel.tab.webView.magnification = 1.0
+        selectedTabViewModel.tab.webView.zoomLevel = 1.0
     }
 
     @IBAction func toggleDownloads(_ sender: Any) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1200398379892840/f
Tech Design URL:
CC:

**Description**:
I updated zoom level manipulation methods to operate on `WKWebView.pageZoom` instead of `WKWebView.magnification` where possible (i.e. >=macOS 11). According to the docs, `pageZoom` adjusts CSS zoom attribute which is what we want here, while `magnification` applies a scale transform to the canvas (which is appropriate e.g. for pinch zooming). This change gives us the behavior similar to Safari.

**Steps to test this PR**:
1. Open any webpage (I was testing with GitHub)
1. Zoom out using ⌘- and notice that the canvas size stays the same while the webpage components become smaller
1. Zoom in using ⌘+ and notice that the canvas size stays the same while the webpage components become larger

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
