### PR TITLE
Remove the automatic unlock logic

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -91,8 +91,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         guard !Self.isRunningTests else { return }
 
-        // IMPORTANT: This call needs to run before ATB is initialized, as it is used to determine whether this is an existing install being migrated.
+#if DEBUG || REVIEW
         Waitlist.unlockExistingInstallIfNecessary()
+#endif
 
         PrivacyFeatures.httpsUpgrade.loadDataAsync()
         LocalBookmarkManager.shared.loadBookmarks()

--- a/DuckDuckGo/Statistics/ATB/LocalStatisticsStore.swift
+++ b/DuckDuckGo/Statistics/ATB/LocalStatisticsStore.swift
@@ -62,7 +62,6 @@ final class LocalStatisticsStore: StatisticsStore {
         static let appRetentionAtb = "stats.appretentionatb.key"
         static let variant = "stats.variant.key"
         static let lastAppRetentionRequestDate = "stats.appretentionatb.last.request.key"
-        static let waitlistUpgradeCheckComplete = "waitlist.upgradecomplete"
         static let waitlistUnlocked = "waitlist.unlocked"
         static let autoLockEnabled = "auto-lock.enabled"
         static let autoLockThreshold = "auto-lock.threshold"
@@ -186,17 +185,6 @@ final class LocalStatisticsStore: StatisticsStore {
             } else {
                 pixelDataStore.removeValue(forKey: Keys.lastAppRetentionRequestDate)
             }
-        }
-    }
-    
-    var waitlistUpgradeCheckComplete: Bool {
-        get {
-            guard let booleanStringValue: String = pixelDataStore.value(forKey: Keys.waitlistUpgradeCheckComplete) else { return false }
-            return Bool(booleanStringValue) ?? false
-        }
-        set {
-            let booleanAsString = String(newValue)
-            pixelDataStore.set(booleanAsString, forKey: Keys.waitlistUpgradeCheckComplete)
         }
     }
     

--- a/DuckDuckGo/Statistics/ATB/StatisticsStore.swift
+++ b/DuckDuckGo/Statistics/ATB/StatisticsStore.swift
@@ -22,7 +22,6 @@ import Foundation
 protocol StatisticsStore: AnyObject {
 
     var hasInstallStatistics: Bool { get }
-    var hasCurrentOrDeprecatedInstallStatistics: Bool { get }
     var installDate: Date? { get set }
     var atb: String? { get set }
     var searchRetentionAtb: String? { get set }
@@ -32,7 +31,6 @@ protocol StatisticsStore: AnyObject {
     var lastAppRetentionRequestDate: Date? { get set }
     var isAppRetentionFiredToday: Bool { get }
     
-    var waitlistUpgradeCheckComplete: Bool { get set }
     var waitlistUnlocked: Bool { get set }
 
     var autoLockEnabled: Bool { get set }

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -140,7 +140,6 @@ extension Pixel {
         case autofillItemSaved(kind: FormAutofillKind)
         
         case waitlistFirstLaunch
-        case waitlistMigratedExistingInstall
         case waitlistPresentedLockScreen
         case waitlistDismissedLockScreen
 
@@ -306,9 +305,6 @@ extension Pixel.Event {
             
         case .waitlistFirstLaunch:
             return "m_mac_waitlist_first_launch_while_locked"
-            
-        case .waitlistMigratedExistingInstall:
-            return "m_mac_waitlist_migrated_existing_install"
             
         case .waitlistPresentedLockScreen:
             return "m_mac_waitlist_lock_screen_presented"

--- a/DuckDuckGo/Statistics/PixelParameters.swift
+++ b/DuckDuckGo/Statistics/PixelParameters.swift
@@ -107,7 +107,6 @@ extension Pixel.Event {
              .onboardingSetDefaultSkipped,
              .onboardingTypingSkipped,
              .waitlistFirstLaunch,
-             .waitlistMigratedExistingInstall,
              .waitlistPresentedLockScreen,
              .waitlistDismissedLockScreen,
              .autoconsentOptOutFailed,

--- a/DuckDuckGo/Waitlist/Model/MacWaitlistStore.swift
+++ b/DuckDuckGo/Waitlist/Model/MacWaitlistStore.swift
@@ -20,7 +20,6 @@ import Foundation
 
 protocol MacWaitlistStore {
     
-    func isExistingInstall() -> Bool
     func isUnlocked() -> Bool
     func unlock()
     
@@ -40,49 +39,15 @@ final class MacWaitlistEncryptedFileStorage: MacWaitlistStore {
         self.statisticsStore = statisticsStore
     }
     
-    func isExistingInstall() -> Bool {
-        return statisticsStore.hasCurrentOrDeprecatedInstallStatistics
-    }
-    
     func isUnlocked() -> Bool {
         return statisticsStore.waitlistUnlocked
     }
     
-    /// Marks an existing installation of the browser as unlocked, if it has been detected to have been previously installed.
-    /// This check is done by inspecting the install date value of the ATB database, leading to two cases:
-    ///
-    /// 1. **The install date is present**: In this case, the browser will be unlocked
-    /// 2. **The install date is not present**: In this case, the browser saves metadata indicating that this check has been already performed, thus future checks
-    ///   of the ATB value will be ignored even if it is present.
-    func unlockExistingInstallIfNecessary() {
-        // If the user has previously ran the upgrade check, then we can't check that they're an existing install. At
-        // that point they may have ATB data and masquerade as an existing user, so the browser needs to remember that
-        // they've tried to upgrade and failed, and now only an invite code can unlock them.
-        guard !statisticsStore.waitlistUpgradeCheckComplete else {
-            return
-        }
-        
-        // No waitlist check has been performed, meaning that this is the first time that the browser has been run with
-        // the lock screen feature included. Check for ATB and unlock the browser if it's present.
-        if isExistingInstall() {
-            unlock()
-            Pixel.fire(.waitlistMigratedExistingInstall)
-        } else {
-            saveFailedUnlockAttempt()
-        }
-    }
-    
     func unlock() {
-        statisticsStore.waitlistUpgradeCheckComplete = true
         statisticsStore.waitlistUnlocked = true
     }
     
-    func saveFailedUnlockAttempt() {
-        statisticsStore.waitlistUpgradeCheckComplete = true
-    }
-    
     func deleteExistingMetadata() {
-        statisticsStore.waitlistUpgradeCheckComplete = false
         statisticsStore.waitlistUnlocked = false
     }
     

--- a/DuckDuckGo/Waitlist/Waitlist.swift
+++ b/DuckDuckGo/Waitlist/Waitlist.swift
@@ -23,18 +23,12 @@ struct Waitlist {
     static var isUnlocked: Bool {
         return MacWaitlistEncryptedFileStorage().isUnlocked()
     }
-
-    static var isExistingInstall: Bool {
-        return MacWaitlistEncryptedFileStorage().isExistingInstall()
-    }
     
-    static func unlockExistingInstallIfNecessary() {
 #if DEBUG || REVIEW
+    static func unlockExistingInstallIfNecessary() {
         MacWaitlistEncryptedFileStorage().unlock()
-#else
-        MacWaitlistEncryptedFileStorage().unlockExistingInstallIfNecessary()
-#endif
     }
+#endif
     
     static func displayLockScreenIfNecessary(in viewController: NSViewController) -> Bool {
         guard !isUnlocked else {

--- a/Unit Tests/Statistics/ATB/Mock/MockStatisticsStore.swift
+++ b/Unit Tests/Statistics/ATB/Mock/MockStatisticsStore.swift
@@ -32,7 +32,6 @@ final class MockStatisticsStore: StatisticsStore {
     var lastAppRetentionRequestDate: Date?
     
     var waitlistUnlocked: Bool = false
-    var waitlistUpgradeCheckComplete: Bool = false
     
     var autoLockEnabled: Bool = true
     var autoLockThreshold: String? = LoginsPreferences.AutoLockThreshold.fifteenMinutes.rawValue

--- a/Unit Tests/Statistics/LocalStatisticsStoreTests.swift
+++ b/Unit Tests/Statistics/LocalStatisticsStoreTests.swift
@@ -63,15 +63,6 @@ class LocalStatisticsStoreTests: XCTestCase {
         XCTAssertEqual(pixelStore.data.count, 0)
     }
     
-    func testWaitlistUpgradeCheckComplete() {
-        let pixelStore = PixelStoreMock()
-        let store = LocalStatisticsStore(pixelDataStore: pixelStore)
-        
-        XCTAssertFalse(store.waitlistUpgradeCheckComplete)
-        store.waitlistUpgradeCheckComplete = true
-        XCTAssertTrue(store.waitlistUpgradeCheckComplete)
-    }
-    
     // Legacy Statistics:
 
     func testWhenInitializingTheLocalStatisticsStore_ThenLegacyStatisticsAreCleared() {

--- a/Unit Tests/Waitlist/MacWaitlistStoreTests.swift
+++ b/Unit Tests/Waitlist/MacWaitlistStoreTests.swift
@@ -30,22 +30,6 @@ class MacWaitlistStoreTests: XCTestCase {
         super.tearDown()
         UserDefaultsWrapper<Any>.clearAll()
     }
-
-    func testWhenNoInstallStatisticsAreFound_ThenTheAppIsNotAnExistingInstall() {
-        let mockStatisticsStore = mockStatisticsStore()
-        let store = MacWaitlistEncryptedFileStorage(statisticsStore: mockStatisticsStore)
-        
-        XCTAssertFalse(store.isExistingInstall())
-    }
-    
-    func testWhenInstallStatisticsAreFound_ThenTheAppIsAnExistingInstall() {
-        let mockStatisticsStore = mockStatisticsStore()
-        mockStatisticsStore.atb = "atb"
-
-        let store = MacWaitlistEncryptedFileStorage(statisticsStore: mockStatisticsStore)
-        
-        XCTAssertTrue(store.isExistingInstall())
-    }
     
     func testWhenStoreDoesNotHaveInstallMetadata_ThenIsUnlockedReturnsFalse() {
         let mockStatisticsStore = mockStatisticsStore()
@@ -67,10 +51,8 @@ class MacWaitlistStoreTests: XCTestCase {
         let mockStatisticsStore = mockStatisticsStore()
         let store = MacWaitlistEncryptedFileStorage(statisticsStore: mockStatisticsStore)
         
-        XCTAssertFalse(mockStatisticsStore.waitlistUpgradeCheckComplete)
         XCTAssertFalse(mockStatisticsStore.waitlistUnlocked)
         store.unlock()
-        XCTAssertTrue(mockStatisticsStore.waitlistUpgradeCheckComplete)
         XCTAssertTrue(mockStatisticsStore.waitlistUnlocked)
     }
     
@@ -79,62 +61,10 @@ class MacWaitlistStoreTests: XCTestCase {
         let store = MacWaitlistEncryptedFileStorage(statisticsStore: mockStatisticsStore)
         
         store.unlock()
-        XCTAssertTrue(mockStatisticsStore.waitlistUpgradeCheckComplete)
         XCTAssertTrue(mockStatisticsStore.waitlistUnlocked)
         
         store.deleteExistingMetadata()
-        XCTAssertFalse(mockStatisticsStore.waitlistUpgradeCheckComplete)
         XCTAssertFalse(mockStatisticsStore.waitlistUnlocked)
-    }
-    
-    func testWhenUnlockingExistingInstall_And_ATBIsSet_ThenInstallIsUnlocked() {
-        let mockStatisticsStore = mockStatisticsStore()
-        mockStatisticsStore.atb = "atb"
-
-        let store = MacWaitlistEncryptedFileStorage(statisticsStore: mockStatisticsStore)
-        
-        store.unlockExistingInstallIfNecessary()
-        
-        XCTAssertTrue(store.isUnlocked())
-    }
-    
-    func testWhenUnlockingExistingInstall_And_LegacyATBIsSet_ThenInstallIsUnlocked() {
-        var legacyStore = LocalStatisticsStore.LegacyStatisticsStore()
-        legacyStore.atb = "atb"
-
-        let mockStatisticsStore = mockStatisticsStore()
-        let store = MacWaitlistEncryptedFileStorage(statisticsStore: mockStatisticsStore)
-        
-        store.unlockExistingInstallIfNecessary()
-        
-        XCTAssertTrue(store.isUnlocked())
-    }
-    
-    func testWhenUnlockingExistingInstall_And_ATBIsNotSet_ThenInstallRemainsLocked() {
-        let mockStatisticsStore = mockStatisticsStore()
-        let store = MacWaitlistEncryptedFileStorage(statisticsStore: mockStatisticsStore)
-        
-        store.unlockExistingInstallIfNecessary()
-        
-        XCTAssertFalse(store.isUnlocked())
-    }
-    
-    func testWhenUnlockingExistingInstall_AndATBIsNotSet_AndATBIsLaterSet_ThenInstallRemainsLocked() {
-        let mockStatisticsStore = mockStatisticsStore()
-
-        let store = MacWaitlistEncryptedFileStorage(statisticsStore: mockStatisticsStore)
-        store.unlockExistingInstallIfNecessary()
-        XCTAssertFalse(store.isUnlocked())
-        
-        // Verify that the store remembers that ATB was not initially set and can't be tricked into unlocking by setting
-        // it and trying again.
-        mockStatisticsStore.atb = "atb"
-        store.unlockExistingInstallIfNecessary()
-        XCTAssertFalse(store.isUnlocked())
-        
-        // When receiving a legitimate unlock attempt at this point, it should unlock.
-        store.unlock()
-        XCTAssertTrue(store.isUnlocked())
     }
     
     private func mockStatisticsStore() -> StatisticsStore {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1201945424795364/f
Tech Design URL:
CC:

**Description**:

This PR removes the automatic Lock Screen unlock logic. This logic was used to make sure internal users of the browser didn't all need to get an invite code just to keep using the browser.

Now everyone internally has unlocked, we can remove the logic, in case users find a way to exploit it.

**Steps to test this PR**:
1. Run a clean build of the browser in debug mode and ensure it **does** unlock automatically, we want to make sure that debug and review build users still bypass the lock screen 
1. Run a clean build of the browser in release mode and ensure it does not unlock automatically. Ideally, install an old version of the browser and run it, then install an archived version of this branch over top and check that it's locked.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
