### PR TITLE
Make website URLs clickable in Logins+

### DIFF
--- a/DuckDuckGo/SecureVault/Model/PasswordManagementLoginModel.swift
+++ b/DuckDuckGo/SecureVault/Model/PasswordManagementLoginModel.swift
@@ -161,6 +161,10 @@ final class PasswordManagementLoginModel: ObservableObject, PasswordManagementIt
         isEditing = true
     }
 
+    func openURL(_ url: URL) {
+        WindowControllersManager.shared.show(url: url, newTab: true)
+    }
+
     private func populateViewModelFromCredentials() {
         let titleString = credentials?.account.title ?? ""
         title =  titleString.isEmpty ? normalizedDomain(credentials?.account.domain ?? "") : titleString

--- a/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
@@ -274,10 +274,19 @@ private struct WebsiteView: View {
                 .padding(.bottom, interItemSpacing)
 
         } else {
-
-            Text(model.domain)
+            if let domainURL = model.domain.url {
+                Button {
+                    model.openURL(domainURL)
+                } label: {
+                    Text(model.domain)
+                        .foregroundColor(Color("LinkBlueColor"))
+                }
+                .buttonStyle(.plain)
                 .padding(.bottom, interItemSpacing)
-
+            } else {
+                Text(model.domain)
+                    .padding(.bottom, interItemSpacing)
+            }
         }
 
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201548487133814/f
Tech Design URL:
CC:

**Description**:
If `domain` can represent a valid URL, display it as a text button that opens a website in a new tab, otherwise fall back to a text label. Opening a website does not cause Logins+ popover to hide, which I think is a feature, as it still may be useful for the user.

**Steps to test this PR**:
1. Open Logins+ with at least 1 saved website password
1. Verify that "Website URL" is clickable and opens the website in a new tab
1. Add a new login item with an invalid URL.
1. Verify that "Website URL" is not clickable.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
