### PR TITLE
Fix BrowserTabViewController leakage

### DIFF
--- a/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/BrowserTab/View/BrowserTabViewController.swift
@@ -359,8 +359,8 @@ final class BrowserTabViewController: NSViewController {
         guard let overlay = _contentOverlayPopover else {
             let overlayPopover = ContentOverlayPopover(currentTabView: view)
             WindowControllersManager.shared.stateChanged
-                .sink { _ in
-                    self._contentOverlayPopover?.websiteAutofillUserScriptCloseOverlay(nil)
+                .sink { [weak self] _ in
+                    self?._contentOverlayPopover?.websiteAutofillUserScriptCloseOverlay(nil)
                 }.store(in: &cancellables)
             _contentOverlayPopover = overlayPopover
             return overlayPopover


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1199237043628108/1201937895290423/1201946177136629
CC:

**Description**:
Fixes BrowserTabViewController leakage

**Steps to test this PR**:
1. Open a new window
2. Navigate to a website (e.g. youtube and start video)
3. Close Tab 
4. Validate the Tab and BrowserTabViewController is deallocated (and video is stopped)


**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
