### PR TITLE
Add tds etag to breakage reports

### DIFF
--- a/DuckDuckGo/Feedback and Breakage/View/FeedbackViewController.swift
+++ b/DuckDuckGo/Feedback and Breakage/View/FeedbackViewController.swift
@@ -274,7 +274,7 @@ final class FeedbackViewController: NSViewController {
                                                   siteUrlString: urlTextField.stringValue,
                                                   osVersion: "\(ProcessInfo.processInfo.operatingSystemVersion)",
                                                   upgradedHttps: currentTab?.connectionUpgradedTo != nil,
-                                                  tdsETag: DefaultConfigurationStorage.shared.loadEtag(for: .trackerRadar),
+                                                  tdsETag: ContentBlocking.shared.contentBlockingManager.currentRules.first?.etag,
                                                   blockedTrackerDomains: blockedTrackerDomains,
                                                   installedSurrogates: installedSurrogates)
             websiteBreakageSender.sendWebsiteBreakage(websiteBreakage)

--- a/DuckDuckGo/Privacy Dashboard/Model/PrivacyDashboardUserScript.swift
+++ b/DuckDuckGo/Privacy Dashboard/Model/PrivacyDashboardUserScript.swift
@@ -88,7 +88,7 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
             return
         }
 
-        let etag = DefaultConfigurationStorage.shared.loadEtag(for: .trackerRadar)?
+        let etag = ContentBlocking.shared.contentBlockingManager.currentRules.first?.etag
                     .trimmingCharacters(in: CharacterSet(charactersIn: "\"")) ?? ""
         Pixel.shared?.fire(pixelNamed: pixel,
                            withAdditionalParameters: [


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1201722757273633/f
Tech Design URL:
CC:

**Description**:
This PR adds the tds etag to the breakage report pixel

**Steps to test this PR**:
1. Send breakage report using dashboard
1. Ask breakage team to verify etag is attached

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
