### PR TITLE
Fix storyboard color usage

### DIFF
--- a/DuckDuckGo/Home Page/View/HomePage.storyboard
+++ b/DuckDuckGo/Home Page/View/HomePage.storyboard
@@ -16,7 +16,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                <color key="value" name="HomepageBackgroundColor"/>
+                                <color key="value" name="HomePageBackgroundColor"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </view>
@@ -171,8 +171,8 @@ Gw
         </scene>
     </scenes>
     <resources>
-        <namedColor name="HomepageBackgroundColor">
-            <color red="0.97647058823529409" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="HomePageBackgroundColor">
+            <color red="0.97600001096725464" green="0.98000001907348633" blue="0.98000001907348633" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/DuckDuckGo/Preferences/View/Preferences.storyboard
+++ b/DuckDuckGo/Preferences/View/Preferences.storyboard
@@ -170,7 +170,7 @@
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                        <color key="value" name="HomepageBackgroundColor"/>
+                                        <color key="value" name="HomePageBackgroundColor"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </customView>
@@ -591,13 +591,10 @@ DQ
             <color red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="HomePageBackgroundColor">
-            <color red="0.97647058823529409" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="HomepageBackgroundColor">
-            <color red="0.97647058823529409" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.97600001096725464" green="0.98000001907348633" blue="0.98000001907348633" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="LinkBlueColor">
-            <color red="0.22400000691413879" green="0.41200000047683716" blue="0.93699997663497925" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.22352941176470589" green="0.41176470588235292" blue="0.93333333333333335" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201956542814249/f
Tech Design URL:
CC:

**Description**:

This PR fixes a misnamed color in storyboards. Offending values were found with `rg "HomepageBackgroundColor -C 10"`, if you want to verify that no other uses of this exist.

**Steps to test this PR**:
1. Run the app in light and dark modes, check colors on the home page to make sure everything looks fine
1. Check that the main preferences screen looks fine in light and dark mode 
1. Check that the preferences About page looks fine in light and dark mode
**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
