### PR TITLE
Hotfix: suggestion selection crash

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -500,7 +500,7 @@ final class AddressBarTextField: NSTextField {
 
         func toAttributedString(size: CGFloat) -> NSAttributedString {
             let attrs = [NSAttributedString.Key.font: NSFont.systemFont(ofSize: size, weight: .light),
-                            .foregroundColor: NSColor.addressBarSuffixColor]
+                         .foregroundColor: NSColor.addressBarSuffixColor]
             return NSAttributedString(string: string, attributes: attrs)
         }
 
@@ -518,9 +518,9 @@ final class AddressBarTextField: NSTextField {
                     return Self.searchSuffix
                 } else {
                     return " – " + url.toString(decodePunycode: false,
-                                                  dropScheme: true,
-                                                  needsWWW: false,
-                                                  dropTrailingSlash: false)
+                                                dropScheme: true,
+                                                needsWWW: false,
+                                                dropTrailingSlash: false)
                 }
             case .title(let title):
                 return " – " + title
@@ -798,7 +798,7 @@ extension AddressBarTextField: SuggestionViewControllerDelegate {
 extension AddressBarTextField: NSTextViewDelegate {
 
     func textView(_ textView: NSTextView, willChangeSelectionFromCharacterRange _: NSRange, toCharacterRange range: NSRange) -> NSRange {
-        defer {
+        DispatchQueue.main.async {
             // artifacts can appear when the selection changes, especially if the size of the field has changed, this clears them
             textView.needsDisplay = true
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1199237043628108/1201958708460468/1201958708499920
Tech Design URL:
CC:

**Description**:
Fixes crash when selecting shorter suggestion:

Seems that touchbar doesn't get the updated string value before "willChangeSelection" is called and using an old string range value

in the reproduction steps below it got {0, 27} range whereas the real range is {0, 23}

So the async call is not for the threads issue but to get the touchbar updated before we call redraw


**Steps to test this PR**:
0. Activate Xcode->Window->Touch Bar->Show Touch Bar
1. Enter "a" text into search field
2. Select down till a long item switching to a short one (aerlingus.com/... -> aib, see screenshot; Erase and re-enter "a" until the needed result appears)
3. Validate there's no crash

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
