### PR TITLE
add alternate menu item for paste and match with style

### DIFF
--- a/DuckDuckGo/Menus/MainMenu.storyboard
+++ b/DuckDuckGo/Menus/MainMenu.storyboard
@@ -196,6 +196,11 @@ CA
                                                 <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Paste and Match Style" alternate="YES" keyEquivalent="V" id="aSK-Ud-Crj">
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="79p-cJ-JKN"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Delete" id="pa3-QI-u2k">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1201908561430620
Tech Design URL:
CC:

**Description**:

Add alternate menu shortcut for paste and match with style

**Steps to test this PR**:
1. Open https://twitter.com/duckduckgo and copy the page 
1. Open https://www.richtexteditor.com/demos/
1. Cmd-V into the text area and you see a bunch of rich text pasted
1. Delete the contents of the text area (or refresh the page)
1. Check that cmd-shift-v and option-shift-cmd-v to paste both paste plain text


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
