### PR TITLE
Update BSK to fix percent encoding query parameters

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -5581,7 +5581,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 11.2.2;
+				minimumVersion = 11.2.3;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/duckduckgo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "db82d8ee678cfef274366e838fd5473008e25b63",
-          "version": "11.2.2"
+          "revision": "7d2c892e0dfdbd458cd8288ec54c72c0fc167889",
+          "version": "11.2.3"
         }
       },
       {

--- a/Unit Tests/Common/Extensions/URLExtensionTests.swift
+++ b/Unit Tests/Common/Extensions/URLExtensionTests.swift
@@ -52,7 +52,7 @@ final class URLExtensionTests: XCTestCase {
             ("local ", "https://duckduckgo.com/?q=local"),
             ("test string with spaces", "https://duckduckgo.com/?q=test%20string%20with%20spaces"),
             ("http://💩.la:8080 ", "http://xn--ls8h.la:8080"),
-            ("http:// 💩.la:8080 ", "https://duckduckgo.com/?q=http://%20%F0%9F%92%A9.la:8080"),
+            ("http:// 💩.la:8080 ", "https://duckduckgo.com/?q=http%3A%2F%2F%20%F0%9F%92%A9.la%3A8080"),
             ("https://xn--ls8h.la/path/to/resource", "https://xn--ls8h.la/path/to/resource")
         ]
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201985700849146/f
Tech Design URL:
CC: @tomasstrba 

**Description**:
When adding a new query parameter to an existing URL, manually percent encode the name and value and add them to percentEncodedQueryItems. When percent-encoding the parameter, use a modified allowed characters set that does not include "URI query reserved characters" as they need to be percent encoded (when part of the parameter name or value).

**Steps to test this PR**:
1. Search for star;trek (using search bar)
1. Verify that the search is performed for `star;trek` and not for `star`.
1. Submit feedback containing a semicolon in the notes. 
1. Verify on the macOS feedback board that the feedback notes are not truncated at the semicolon.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
