### PR TITLE
Navigation bar improvement: CMD + back or CMD + forward opens a new tab

### DIFF
--- a/DuckDuckGo/Navigation Bar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/Navigation Bar/View/NavigationBarViewController.swift
@@ -168,7 +168,12 @@ final class NavigationBarViewController: NSViewController {
             return
         }
 
-        selectedTabViewModel.tab.goBack()
+        if NSApp.isCommandPressed,
+           let backItem = selectedTabViewModel.tab.webView.backForwardList.backItem {
+            openNewChildTab(with: backItem.url)
+        } else {
+            selectedTabViewModel.tab.goBack()
+        }
     }
 
     @IBAction func goForwardAction(_ sender: NSButton) {
@@ -177,7 +182,17 @@ final class NavigationBarViewController: NSViewController {
             return
         }
 
-        selectedTabViewModel.tab.goForward()
+        if NSApp.isCommandPressed,
+           let forwardItem = selectedTabViewModel.tab.webView.backForwardList.forwardItem {
+            openNewChildTab(with: forwardItem.url)
+        } else {
+            selectedTabViewModel.tab.goForward()
+        }
+    }
+
+    private func openNewChildTab(with url: URL) {
+        let tab = Tab(content: .url(url), parentTab: tabCollectionViewModel.selectedTabViewModel?.tab, shouldLoadInBackground: true)
+        tabCollectionViewModel.insertChild(tab: tab, selected: false)
     }
 
     @IBAction func refreshAction(_ sender: NSButton) {

--- a/DuckDuckGo/Tab Bar/ViewModel/TabCollectionViewModel.swift
+++ b/DuckDuckGo/Tab Bar/ViewModel/TabCollectionViewModel.swift
@@ -194,7 +194,7 @@ final class TabCollectionViewModel: NSObject {
         guard changesEnabled else { return }
         guard let parentTab = tab.parentTab,
               let parentTabIndex = tabCollection.tabs.firstIndex(where: { $0 === parentTab }) else {
-            os_log("TabCollection: No tab selected", type: .error)
+            os_log("TabCollection: No parent tab", type: .error)
             return
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201674380651572/f

**Description**:
This PR adds a new functionality based on feedback by users. CMD + clicking back or CMD + clicking forward in the navigation bar opens a new tab instead of triggering the direct navigation

**Steps to test this PR**:
1. Open a new tab and visit few sites to create a tab history
1. Hit CMD and click back in the navigation bar
2. Make sure your currently selected tab didn't change and the first URL in the back tab history list was open in a new tab
3. Test the same with the forward button

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
