### PR TITLE
Color of the hover label fixed

### DIFF
--- a/DuckDuckGo/Browser Tab/View/Base.lproj/BrowserTab.storyboard
+++ b/DuckDuckGo/Browser Tab/View/Base.lproj/BrowserTab.storyboard
@@ -73,7 +73,7 @@
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                        <color key="value" name="TooltipBackgroundColor"/>
+                                        <color key="value" name="BrowserTabBackgroundColor"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                         <real key="value" value="4"/>
@@ -126,9 +126,6 @@
     <resources>
         <namedColor name="BrowserTabBackgroundColor">
             <color red="0.98039215686274506" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="TooltipBackgroundColor">
-            <color red="0.97254901960784312" green="0.97254901960784312" blue="0.97254901960784312" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1202055431868952/f
Tech Design URL:
CC: @jaceklyp 

**Description**:
Fix of the hover label font color in dark mode. (Hover label is the label in the bottom left corner shown when cursor is over the link)

**Steps to test this PR**:
1. Switch to dark mode in system. 
1. Verify the hover label font color is correct (link is readable)
1. Switch to light mode in system
1. Verify the hover label font color is correct (link is readable)
1. Switch to dark mode in the app Preferences
1. Verify the hover label font color is correct (link is readable)2. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
