### PR TITLE
Default to Chrome or Safari when importing Logins and Bookmarks

### DIFF
--- a/DuckDuckGo/Data Import/DataImport.swift
+++ b/DuckDuckGo/Data Import/DataImport.swift
@@ -30,6 +30,8 @@ enum DataImport {
         case lastPass
         case csv
 
+        static let preferredSources: [Self] = [.chrome, .safari]
+
         var importSourceName: String {
             switch self {
             case .brave:

--- a/DuckDuckGo/Data Import/View/DataImportViewController.swift
+++ b/DuckDuckGo/Data Import/View/DataImportViewController.swift
@@ -534,6 +534,10 @@ extension NSPopUpButton {
             addItem(withTitle: source.importSourceName)
             lastItem?.image = source.importSourceImage?.resized(to: NSSize(width: 16, height: 16))
         }
+
+        if let preferredSource = DataImport.Source.preferredSources.first(where: { validSources.contains($0) }) {
+            selectItem(withTitle: preferredSource.importSourceName)
+        }
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1201621708108816/1202077207271006/1202080358238152/f
Tech Design URL:
CC: @samsymons 

**Description**:
If Chrome or Safari (in this order) are valid import sources, make one of them preselected in the import dialog.

**Steps to test this PR**:
1. Have logins/bookmarks in Chrome and Safari
1. Go to Preferences -> Autofill
1. Click "Import Bookmarks and Preferences..."
1. Observe that Chrome is preselected
1. Uninstall Chrome 🎉
1. Reenter Import Dialog
1. Observe that Safari is preselected

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
