### PR TITLE
fix trackers on DuckDuckGo in new tab page

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -705,7 +705,7 @@ extension Tab: ContentBlockerRulesUserScriptDelegate {
 
     func contentBlockerRulesUserScript(_ script: ContentBlockerRulesUserScript, detectedTracker tracker: DetectedTracker) {
         trackerInfo?.add(detectedTracker: tracker)
-        guard let url = webView.url else { return }
+        guard let url = URL(string: tracker.pageUrl) else { return }
         historyCoordinating.addDetectedTracker(tracker, onURL: url)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1202082893007257
Tech Design URL:
CC:

**Description**:

Use the page url in the tracker object rather than the current web view url

**Steps to test this PR**:
1. Use the fire button then start browsing the web.  Ensure trackers appear for pages.
1. Perform searches from DuckDuckGo.com and use the back button while on heavy tracker pages (e.g. cnn.com ), ensure DuckDuckGo does not show trackers

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
