### PR TITLE
Revert the change to Arc4RandomUniformVariantRNG and silence SwiftLint warning

### DIFF
--- a/DuckDuckGo/Statistics/ATB/VariantManager.swift
+++ b/DuckDuckGo/Statistics/ATB/VariantManager.swift
@@ -134,7 +134,8 @@ final class Arc4RandomUniformVariantRNG: VariantRNG {
     init() { }
 
     func nextInt(upperBound: Int) -> Int {
-        return .random(in: 0..<upperBound)
+        // swiftlint:disable:next legacy_random
+        return Int(arc4random_uniform(UInt32(upperBound)))
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: N/A
Tech Design URL:
CC: @tomasstrba 

**Description**:
It turns out that `upperBound` parameter passed to the function in question is always (?) 0,
in which case it crashed with an invalid range (`0..<0`). This needs further investigation as we agreed.

**Steps to test this PR**:
1. Run `./clean-app.sh debug`
1. Run the app
1. Verify that it does not crash
1. Verify that SwiftLint does not produce a warning around the changed code.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
