### PR TITLE
Fix reloading data in BookmarkListViewController

### DIFF
--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -100,7 +100,7 @@ final class BookmarkListViewController: NSViewController {
     private func reloadData() {
         let selectedNodes = self.selectedNodes
         
-        treeController.rebuild()
+        dataSource.reloadData()
         outlineView.reloadData()
         
         expandAndRestore(selectedNodes: selectedNodes)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201475153527864/f
CC: @samsymons 

**Description**:
Reload `BookmarkOutlineViewDataSource` (that rebuilds bookmarks tree internally) 
when reloading `BookmarkListViewController` contents. The same approach is taken
in `BookmarkManagementSidebarViewController` where this bug is not observed.

**Steps to test this PR**:
1. Visit a website
1. Add a bookmark but edit its name before confirming
1. Go to three-dots menu -> Bookmarks
1. Verify that the new bookmark appears under a custom name

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
