### PR TITLE
Fill Add Bookmark modal view with current tab website

### DIFF
--- a/DuckDuckGo/Bookmarks/View/AddBookmarkModalViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/AddBookmarkModalViewController.swift
@@ -27,6 +27,19 @@ protocol AddBookmarkModalViewControllerDelegate: AnyObject {
 
 final class AddBookmarkModalViewController: NSViewController {
 
+    struct WebsiteInfo {
+        let url: URL
+        let title: String?
+
+        init?(_ tab: Tab) {
+            guard case let .url(url) = tab.content else {
+                return nil
+            }
+            self.url = url
+            self.title = tab.title
+        }
+    }
+
     enum Constants {
         static let storyboardName = "Bookmarks"
         static let identifier = "AddBookmarkModalViewController"
@@ -35,6 +48,14 @@ final class AddBookmarkModalViewController: NSViewController {
     static func create() -> AddBookmarkModalViewController {
         let storyboard = NSStoryboard(name: Constants.storyboardName, bundle: nil)
         return storyboard.instantiateController(identifier: Constants.identifier)
+    }
+
+    var currentTabWebsite: WebsiteInfo? {
+        didSet {
+            if isViewLoaded {
+                updateWithCurrentTabWebsite()
+            }
+        }
     }
 
     @IBOutlet var titleTextField: NSTextField!
@@ -54,7 +75,7 @@ final class AddBookmarkModalViewController: NSViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        updateAddButton()
+        updateWithCurrentTabWebsite()
     }
 
     override func viewWillAppear() {
@@ -77,6 +98,14 @@ final class AddBookmarkModalViewController: NSViewController {
 
     private func updateAddButton() {
         addButton.isEnabled = hasValidInput
+    }
+
+    private func updateWithCurrentTabWebsite() {
+        if let website = currentTabWebsite, !LocalBookmarkManager.shared.isUrlBookmarked(url: website.url) {
+            titleTextField.stringValue = website.title ?? ""
+            urlTextField.stringValue = website.url.absoluteString
+        }
+        updateAddButton()
     }
 
 }

--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -38,6 +38,7 @@ final class BookmarkListViewController: NSViewController {
     }
 
     weak var delegate: BookmarkListViewControllerDelegate?
+    var currentTabWebsite: AddBookmarkModalViewController.WebsiteInfo?
 
     @IBOutlet var outlineView: NSOutlineView!
     @IBOutlet var contextMenu: NSMenu!
@@ -108,6 +109,7 @@ final class BookmarkListViewController: NSViewController {
     
     @IBAction func newBookmarkButtonClicked(_ sender: AnyObject) {
         let newBookmarkViewController = AddBookmarkModalViewController.create()
+        newBookmarkViewController.currentTabWebsite = currentTabWebsite
         newBookmarkViewController.delegate = self
         presentAsModalWindow(newBookmarkViewController)
     }
@@ -360,9 +362,9 @@ final class BookmarkListPopover: NSPopover {
         fatalError("BookmarkListPopover: Bad initializer")
     }
 
-    // swiftlint:disable force_cast
+    // swiftlint:disable:next force_cast
     var viewController: BookmarkListViewController { contentViewController as! BookmarkListViewController }
-    // swiftlint:enable force_cast
+
     private func setupContentController() {
         let controller = BookmarkListViewController.create()
         controller.delegate = self

--- a/DuckDuckGo/Navigation Bar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/Navigation Bar/View/NavigationBarViewController.swift
@@ -329,6 +329,9 @@ final class NavigationBarViewController: NSViewController {
     func showBookmarkListPopover() {
         guard closeTransientPopovers() else { return }
         bookmarkListButton.isHidden = false
+        if let tab = tabCollectionViewModel.selectedTabViewModel?.tab {
+            bookmarkListPopover.viewController.currentTabWebsite = .init(tab)
+        }
         bookmarkListPopover.show(relativeTo: bookmarkListButton.bounds.insetFromLineOfDeath(), of: bookmarkListButton, preferredEdge: .maxY)
         Pixel.fire(.bookmarksList(source: .button))
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201739440246345/f

**Description**:
If a current tab website is not bookmarked, the add bookmark dialog
is pre-populated with title and URL of the website.

**Steps to test this PR**:
1. Open a website that is not bookmarked
1. Select three dots menu -> Bookmarks
1. Click add bookmark button in the top-right corner of the popover
1. Verify that input fields are populated with the website title and URL
1. Open a website that is already bookmarked
1. Go to add bookmark modal view and verify that input fields are empty
1. Verify that input fields are empty also if the current tab is homepage, preferences or bookmarks.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
