### PR TITLE
Fix new tab page fire glitch

### DIFF
--- a/DuckDuckGo/Home Page/Model/HomePageRecentlyVisitedModel.swift
+++ b/DuckDuckGo/Home Page/Model/HomePageRecentlyVisitedModel.swift
@@ -152,6 +152,10 @@ final class RecentlyVisitedSiteModel: ObservableObject {
     @Published var numberOfTrackersBlocked = 0
     @Published var trackersFound = false
 
+    // These are used by the burning animation
+    @Published var isBurning = false
+    @Published var isHidden = false
+
     init(domain: String, bookmarkManager: BookmarkManager = LocalBookmarkManager.shared) {
         self.domain = domain
         if let url = domain.url {

--- a/DuckDuckGo/Home Page/View/RecentlyVisitedView.swift
+++ b/DuckDuckGo/Home Page/View/RecentlyVisitedView.swift
@@ -104,8 +104,6 @@ struct RecentlyVisitedSite: View {
     @ObservedObject var site: HomePage.Models.RecentlyVisitedSiteModel
 
     @State var isHovering = false
-    @State var isBurning = false
-    @State var isHidden = false
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -141,7 +139,7 @@ struct RecentlyVisitedSite: View {
 
             }
             .padding([.leading, .trailing, .top], 12)
-            .visibility(isHidden ? .invisible : .visible)
+            .visibility(site.isHidden ? .invisible : .visible)
 
             HStack(spacing: 2) {
 
@@ -155,9 +153,9 @@ struct RecentlyVisitedSite: View {
 
                 HoverButton(size: 24, imageName: "Burn", imageSize: 16, cornerRadius: 4) {
                     isHovering = false
-                    isBurning = true
+                    site.isBurning = true
                     withAnimation(.default.delay(0.4)) {
-                        isHidden = true
+                        site.isHidden = true
                     }
                 }
                 .foregroundColor(Color("HomeFeedItemButtonTintColor"))
@@ -166,15 +164,15 @@ struct RecentlyVisitedSite: View {
             }
             .padding(.trailing, 12)
             .padding(.top, 13)
-            .visibility(isHidden ? .invisible : .visible)
+            .visibility(site.isHidden ? .invisible : .visible)
 
             FireAnimation()
                 .cornerRadius(8)
-                .visibility(isBurning ? .visible : .gone)
+                .visibility(site.isBurning ? .visible : .gone)
                 .zIndex(100)
                 .onAppear {
                     withAnimation(.default.delay(1.0)) {
-                        isBurning = false
+                        site.isBurning = false
                     }
                 }
                 .onDisappear {


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202082895427645/f
Tech Design URL: 
CC:

**Description**:

Move some state into the model so that SwiftUI doesn't remember it if that object comes back.

**Steps to test this PR**:
1. Open a couple of web pages
1. Open a new tab
3. Burn the first site in the list
5. Immediately visit that site again
7. Open a new tab
9. Site should be visible again

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
