### PR TITLE
Remove extra space on popup windows

### DIFF
--- a/DuckDuckGo/Main/View/Main.storyboard
+++ b/DuckDuckGo/Main/View/Main.storyboard
@@ -35,7 +35,7 @@
                                 </connections>
                             </containerView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="af1-Eb-VaG" userLabel="Separator" customClass="ColorView" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="702" width="1024" height="1"/>
+                                <rect key="frame" x="0.0" y="708" width="1024" height="1"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="hrt-pu-NuL"/>
                                 </constraints>
@@ -46,16 +46,16 @@
                                 </userDefinedRuntimeAttributes>
                             </customView>
                             <containerView translatesAutoresizingMaskIntoConstraints="NO" id="wFH-xq-50o">
-                                <rect key="frame" x="0.0" y="703" width="1024" height="48"/>
+                                <rect key="frame" x="0.0" y="709" width="1024" height="42"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="48" id="vZS-tl-wOP"/>
+                                    <constraint firstAttribute="height" constant="42" id="vZS-tl-wOP"/>
                                 </constraints>
                                 <connections>
                                     <segue destination="R9l-dg-lKa" kind="embed" destinationCreationSelector="createNavigationBarViewControllerWithCoder:sender:segueIdentifier:" id="Br9-o3-sQ8"/>
                                 </connections>
                             </containerView>
                             <containerView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbn-9T-FNt" userLabel="Find in Page Container View">
-                                <rect key="frame" x="312" y="667" width="400" height="40"/>
+                                <rect key="frame" x="312" y="673" width="400" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="Hzq-Qn-wpU"/>
                                     <constraint firstAttribute="width" constant="400" id="Ndt-bt-exS"/>
@@ -101,6 +101,7 @@
                         <outlet property="navigationBarTopConstraint" destination="TRm-AX-VcL" id="cCS-Fd-hJd"/>
                         <outlet property="tabBarContainerView" destination="lYg-bX-QrJ" id="nor-E0-cFP"/>
                         <outlet property="webContainerView" destination="SYo-8W-jl3" id="DoZ-Ih-dHA"/>
+                        <outlet property="webViewTopConstraint" destination="js0-Db-kRi" id="puD-Cr-Val"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/DuckDuckGo/Main/View/MainViewController.swift
+++ b/DuckDuckGo/Main/View/MainViewController.swift
@@ -29,6 +29,7 @@ final class MainViewController: NSViewController {
     @IBOutlet weak var findInPageContainerView: NSView!
     @IBOutlet var navigationBarTopConstraint: NSLayoutConstraint!
     @IBOutlet var addressBarHeightConstraint: NSLayoutConstraint!
+    @IBOutlet var webViewTopConstraint: NSLayoutConstraint!
 
     @IBOutlet var divider: NSView!
 
@@ -72,6 +73,7 @@ final class MainViewController: NSViewController {
             tabBarViewController.view.isHidden = true
             tabBarContainerView.isHidden = true
             navigationBarTopConstraint.constant = 0.0
+            webViewTopConstraint.constant = navigationBarViewController.view.frame.height
             addressBarHeightConstraint.constant = tabBarContainerView.frame.height
         } else {
             navigationBarContainerView.wantsLayer = true


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1202106510507140
Tech Design URL:
CC:

**Description**:

Set the default height of the navigation bar so that it can be used when configuring a popup window

**Steps to test this PR**:
1. Open a few tabs, check that the address bar and web view look to be positioned correctly.
1. Visit https://jsfiddle.net/pb7Lqsky/ and open the popup window.  Check that there is no extra space above the webview.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
