### PR TITLE
Don't cancel request for background tabs

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -877,7 +877,7 @@ extension Tab: WKNavigationDelegate {
 
                 return .cancel
 
-            } else if navigationAction.navigationType != .backForward,
+            } else if navigationAction.navigationType != .backForward, !isRequestingNewTab,
                       let request = GPCRequestFactory.shared.requestForGPC(basedOn: navigationAction.request) {
                 self.invalidateBackItemIfNeeded(for: navigationAction)
                 defer {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1201433189309418/f
Tech Design URL:
CC: @GuiltyDolphin 

**Description**:
This PR fixes an issue where trying to open a tab in the background for sites on the GPC header sites opens in the current tab instead.

**Steps to test this PR**:
1. Ensure you are loading the local config only
2. Visit nytimes.com
3. Command+click any link that stays on nytimes.com. Page should open in the background
4. Visit globalprivacycontrol.org
5. Command+click "[Test against the reference server.](https://global-privacy-control.glitch.me/)" Page should open in the background and GPC signal detected. 

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs
* [x] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
