### PR TITLE
Fix of crash reports 

### DIFF
--- a/DuckDuckGo/App Delegate/AppDelegate.swift
+++ b/DuckDuckGo/App Delegate/AppDelegate.swift
@@ -113,9 +113,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         appUsageActivityMonitor = AppUsageActivityMonitor(delegate: self)
 
-        #if OUT_OF_APPSTORE
         crashReporter.checkForNewReports()
-        #endif
+
         urlEventHandler.applicationDidFinishLaunching()
 
         UserDefaultsWrapper<Any>.clearRemovedKeys()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202117406427486/f

**Description**:
Crash reports aren't coming because of the old compilation flag that appeared after a wrong merge.

**Steps to test this PR**:
1. I recommend to enable Debug menu for a build in Release configuration and then crash the app using the Fatal error menu item.
2. Make sure the crash report was generated 
4. Run the app again and submit the crash report when you get the form 

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
