### PR TITLE
fix new tab page for catalina

### DIFF
--- a/DuckDuckGo/Home Page/View/DefaultBrowserPromptView.swift
+++ b/DuckDuckGo/Home Page/View/DefaultBrowserPromptView.swift
@@ -24,11 +24,6 @@ struct DefaultBrowserPrompt: View {
 
     var body: some View {
 
-        ZStack {
-
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color("HomeDefaultBrowserPromptBackgroundColor"))
-
             HStack {
                 Spacer()
 
@@ -51,11 +46,12 @@ struct DefaultBrowserPrompt: View {
                     self.model.close()
                 }.padding()
 
-            }
-
-        }
-        .visibility(model.shouldShow ? .visible : .gone)
-        .padding(.top, 24)
+            }.background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color("HomeDefaultBrowserPromptBackgroundColor"))
+            )
+            .visibility(model.shouldShow ? .visible : .gone)
+            .padding(.top, 24)
 
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202117932150708
Tech Design URL:
CC:

**Description**:

Don't use ZStack as it messes up the layout on Catalina

**Steps to test this PR**:
1. Check the new tab page works OK on each platform you're able to (install and browse, then open the new tab page)

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
