### PR TITLE
Fix UI glitches in popovers on Catalina

### DIFF
--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -71,7 +71,8 @@ final class BookmarkListViewController: NSViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        view.subscribeForAppApperanceUpdates()?.store(in: &cancellables)
         preferredContentSize = CGSize(width: 420, height: 500)
         
         outlineView.register(BookmarkOutlineViewCell.nib, forIdentifier: BookmarkOutlineViewCell.identifier)

--- a/DuckDuckGo/Bookmarks/View/BookmarkPopoverViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkPopoverViewController.swift
@@ -17,6 +17,7 @@
 //
 
 import Cocoa
+import Combine
 
 protocol BookmarkPopoverViewControllerDelegate: AnyObject {
 
@@ -43,9 +44,12 @@ final class BookmarkPopoverViewController: NSViewController {
         }
     }
 
+    private var appearanceCancellable: AnyCancellable?
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        appearanceCancellable = view.subscribeForAppApperanceUpdates()
         textField.delegate = self
     }
 

--- a/DuckDuckGo/Common/Extensions/NSViewExtension.swift
+++ b/DuckDuckGo/Common/Extensions/NSViewExtension.swift
@@ -17,6 +17,7 @@
 //
 
 import Cocoa
+import Combine
 import os.log
 
 extension NSView {
@@ -133,6 +134,32 @@ extension NSView {
     func applyFaviconStyle() {
         wantsLayer = true
         layer?.cornerRadius = 3.0
+    }
+
+    // MARK: - Appearance updates
+
+    /**
+     * Sets current app appearance to the view and subscribes for subsequent updates.
+     *
+     * This is needed on Catalina for views displayed in popovers that have custom, opaque backgrounds.
+     * Presentation in popover overrides view appearance to `.vibrantLight` or `.vibrantDark`, which
+     * makes subviews such as `NSTextField` and `NSButton` draw their backgrounds with vibrancy effect,
+     * which in turn removes opaque background locally. Calling this method on the top-level view seems
+     * to be solving the issue.
+     *
+     * See [](https://app.asana.com/0/1177771139624306/1202121324275642/f) for an example screenshot.
+     */
+    func subscribeForAppApperanceUpdates() -> AnyCancellable? {
+        if #available(macOS 11.0, *) {
+            return nil
+        }
+
+        appearance = NSApp.effectiveAppearance
+
+        return NSApp
+            .publisher(for: \.effectiveAppearance)
+            .map { $0 as NSAppearance? }
+            .assign(to: \.appearance, onWeaklyHeld: self)
     }
 
 }

--- a/DuckDuckGo/Secure Vault/View/PasswordManagementViewController.swift
+++ b/DuckDuckGo/Secure Vault/View/PasswordManagementViewController.swift
@@ -101,6 +101,7 @@ final class PasswordManagementViewController: NSViewController {
 
     var emptyStateCancellable: AnyCancellable?
     var editingCancellable: AnyCancellable?
+    var appearanceCancellable: AnyCancellable?
 
     var domain: String?
     var isEditing = false
@@ -148,6 +149,8 @@ final class PasswordManagementViewController: NSViewController {
         super.viewDidLoad()
         createListView()
         createLoginItemView()
+
+        appearanceCancellable = view.subscribeForAppApperanceUpdates()
 
         emptyStateTitle.attributedStringValue = NSAttributedString.make(emptyStateTitle.stringValue, lineHeight: 1.14, kern: -0.23)
         emptyStateMessage.attributedStringValue = NSAttributedString.make(emptyStateMessage.stringValue, lineHeight: 1.05, kern: -0.08)

--- a/DuckDuckGo/Secure Vault/View/SaveCredentialsViewController.swift
+++ b/DuckDuckGo/Secure Vault/View/SaveCredentialsViewController.swift
@@ -57,6 +57,8 @@ final class SaveCredentialsViewController: NSViewController {
 
     private var saveButtonAction: (() -> Void)?
 
+    private var appearanceCancellable: AnyCancellable?
+
     var passwordData: Data {
         let string = hiddenPasswordField.isHidden ? visiblePasswordField.stringValue : hiddenPasswordField.stringValue
         return string.data(using: .utf8)!
@@ -136,6 +138,8 @@ final class SaveCredentialsViewController: NSViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        appearanceCancellable = view.subscribeForAppApperanceUpdates()
         visiblePasswordField.isHidden = true
         saveButton.becomeFirstResponder()
     }

--- a/DuckDuckGo/Secure Vault/View/SaveIdentityViewController.swift
+++ b/DuckDuckGo/Secure Vault/View/SaveIdentityViewController.swift
@@ -18,6 +18,7 @@
 
 import AppKit
 import BrowserServicesKit
+import Combine
 import os.log
 
 protocol SaveIdentityDelegate: AnyObject {
@@ -46,7 +47,8 @@ final class SaveIdentityViewController: NSViewController {
     weak var delegate: SaveIdentityDelegate?
     
     private var identity: SecureVaultModels.Identity?
-    
+    private var appearanceCancellable: AnyCancellable?
+
     // MARK: - Actions
     
     @IBAction func onNotNowClicked(sender: NSButton) {
@@ -83,6 +85,14 @@ final class SaveIdentityViewController: NSViewController {
         self.identity = identity
         
         buildStackView(from: identity)
+    }
+
+    // MARK: -
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        appearanceCancellable = view.subscribeForAppApperanceUpdates()
     }
     
     // MARK: - Private

--- a/DuckDuckGo/Secure Vault/View/SavePaymentMethodViewController.swift
+++ b/DuckDuckGo/Secure Vault/View/SavePaymentMethodViewController.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import BrowserServicesKit
+import Combine
 import os.log
 
 protocol SavePaymentMethodDelegate: AnyObject {
@@ -47,7 +48,8 @@ final class SavePaymentMethodViewController: NSViewController {
     weak var delegate: SavePaymentMethodDelegate?
     
     private var paymentMethod: SecureVaultModels.CreditCard?
-    
+    private var appearanceCancellable: AnyCancellable?
+
     // MARK: - Public
     
     func savePaymentMethod(_ paymentMethod: SecureVaultModels.CreditCard) {
@@ -92,5 +94,13 @@ final class SavePaymentMethodViewController: NSViewController {
         WindowControllersManager.shared.showPreferencesTab()
         self.delegate?.shouldCloseSavePaymentMethodViewController(self)
     }
-    
+
+    // MARK: -
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        appearanceCancellable = view.subscribeForAppApperanceUpdates()
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202121324275642/f

**Description**:
On Catalina, override popovers' top-level views appearance so that the vibrancy effect is removed,
and then subscribe to app appearance updates to keep them in sync with the rest of the app.

**Steps to test this PR**:
1. Run the app on Catalina. You can use the review build attached to Asana task.
1. If you're still with me, trigger the following popovers and verify that they don't contain transparent areas around labels and buttons:
    1. Autofill
    1. Save Identity/Credentials/Payment Method
    1. Bookmarks
    1. Add bookmark (from address bar)
1. If you like, you can also do this:
    1. SSH to Catalina
    1. While keeping the popover open, trigger the following command to switch between dark and light mode, and verify that the popover UI is correctly updated to the new appearance:
```
$ osascript -e 'tell app "System Events" to tell appearance preferences to set dark mode to not dark mode'
```
(you can't do it from the UI on Catalina machine because popover would disappear when losing focus).

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
