### PR TITLE
Autofill scrolling fix

### DIFF
--- a/DuckDuckGo/Secure Vault/View/PasswordManagementItemList.swift
+++ b/DuckDuckGo/Secure Vault/View/PasswordManagementItemList.swift
@@ -33,15 +33,12 @@ struct PasswordManagementItemListView: View {
 
     private enum Constants {
         static let dividerFadeInDistance: CGFloat = 100
-        static let coordinateSpace = "frameLayer"
     }
  
     @EnvironmentObject var model: PasswordManagementItemListModel
     
-    @State private var opacity = CGFloat.zero
-
     var body: some View {
-
+        
         VStack(spacing: 0) {
             PasswordManagementItemListCategoryView()
                 .padding(.top, 15)
@@ -51,7 +48,6 @@ struct PasswordManagementItemListView: View {
                 .opacity(model.canChangeCategory ? 1.0 : 0.5)
             
             Divider()
-                .opacity(opacity)
             
             if #available(macOS 11.0, *) {
                 ScrollView {
@@ -65,31 +61,15 @@ struct PasswordManagementItemListView: View {
                                     }
                                 }
                             }
-                            .background(GeometryReader { proxy in
-                                Color.clear.preference(key: ScrollOffsetKey.self, value: -proxy.frame(in: .named(Constants.coordinateSpace)).minY)
-                            })
-                            .onPreferenceChange(ScrollOffsetKey.self) { offset in
-                                if offset <= 0 {
-                                    self.opacity = 0
-                                } else {
-                                    self.opacity = offset / Constants.dividerFadeInDistance
-                                }
-                            }
                     }
                 }
-                .coordinateSpace(name: Constants.coordinateSpace)
             } else {
                 ScrollView {
                     PasswordManagementItemListStackView()
                 }
             }
         }
-        
     }
-    
-//    private func calculateContentOffset(from outsideProxy: GeometryProxy, to insideProxy: GeometryProxy) -> CGFloat {
-//        return outsideProxy.frame(in: .global).minY - insideProxy.frame(in: .global).minY
-//    }
 
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202037446274716/f
Tech Design URL:
CC:

**Description**:

This PR removes the `GeometryReader` logic that was used to do some scroll-dependent opacity changes to a divider. This opacity feature wasn't requested in the design spec, instead it was a nice-to-have that I added and the design team were happy to keep.

However, we've had an issue recently where Gabe has had Autofill get stuck when scrolling. I was able to reproduce this one (and never since then), and when it was happening I was getting hundreds of errors in the Xcode console about the GeometryReader.

To be safe, the code is being removed. Gabe has had a build with this change since last week and has said it's working great, so let's put it into production and see if it holds up.

**Steps to test this PR**:
1. Open Autofill
1. Reset your Secure Vault data using the debug menu
1. Import data
1. Try scrolling the list and check that it works
1. Generally just test scrolling some more; add a new item, delete some stuff, make sure it's fine

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
