### PR TITLE
Don't require 'www' when showing full URL

### DIFF
--- a/DuckDuckGo/Browser Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Browser Tab/ViewModel/TabViewModel.swift
@@ -178,7 +178,7 @@ final class TabViewModel {
         addressBarString = url.absoluteString
 
         if AppearancePreferences.shared.showFullURL {
-            passiveAddressBarString = url.toString(decodePunycode: false, dropScheme: false, needsWWW: true, dropTrailingSlash: true)
+            passiveAddressBarString = url.toString(decodePunycode: false, dropScheme: false, dropTrailingSlash: true)
         } else {
             passiveAddressBarString = host.drop(prefix: URL.HostPrefix.www.separated())
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199178362774117/1202127560661448/f

**Description**:
Don't require 'www' when showing full URL

**Steps to test this PR**:
1. enable "Show full URL" in Appearance Settings
1. open `theguardian.com`, verify that it's rewritten to `www.theguardian.com` (server-side, expected)
1. open `app.asana.com`, verify that it's not rewritten to `www.app.asana.com`

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
