### PR TITLE
don't draw webview background to avoid flashes

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -135,6 +135,8 @@ final class Tab: NSObject {
         configuration.applyStandardConfiguration()
 
         webView = WebView(frame: CGRect.zero, configuration: configuration)
+        webView.setValue(false, forKey: "drawsBackground")
+
         permissions = PermissionModel(webView: webView)
 
         super.init()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1134184788074706/1200211347172220/f
Tech Design URL:
CC:

**Description**:

Disables background drawing in the web view to avoid white screen flash in dark mode.

**Steps to test this PR**:
1. Set theme to dark
1. Open new tab page
3. Perform a search - should be no 'white screen' before the results appear
5. Smoke test browsing a few sites 

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
