### PR TITLE
Revert "don't draw webview background to avoid flashes"

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -135,8 +135,6 @@ final class Tab: NSObject {
         configuration.applyStandardConfiguration()
 
         webView = WebView(frame: CGRect.zero, configuration: configuration)
-        webView.setValue(false, forKey: "drawsBackground")
-
         permissions = PermissionModel(webView: webView)
 
         super.init()


### PR DESCRIPTION
Simple revert. This PR doesn’t work on some websites where they don’t have their own background color (eg hacker news ycombinator)

Reverts more-duckduckgo-org/macos-browser#545