### PR TITLE
Issue with default browser prompt not hiding resolved

### DIFF
--- a/DuckDuckGo/Home Page/View/HomePageViewController.swift
+++ b/DuckDuckGo/Home Page/View/HomePageViewController.swift
@@ -94,6 +94,7 @@ final class HomePageViewController: NSViewController {
         guard !AppDelegate.isRunningTests else { return }
         refreshFavoritesModel()
         refreshRecentlyVisitedModel()
+        refreshDefaultBrowserModel()
     }
 
     func createRecentlyVisitedModel() -> HomePage.Models.RecentlyVisitedModel {
@@ -133,6 +134,10 @@ final class HomePageViewController: NSViewController {
 
     func refreshRecentlyVisitedModel() {
         recentlyVisitedModel.refreshWithHistory(historyCoordinating.history ?? [])
+    }
+
+    func refreshDefaultBrowserModel() {
+        defaultBrowserModel.isDefault = DefaultBrowserPreferences().isDefault
     }
 
     func subscribeToBookmarks() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202041516752977/f

**Description**:
This PR contains a fix of default browser prompt visibility. After setting the browser as default during the onboarding, the promt on the home page remained visible

**Steps to test this PR**:
1. Set Safari as your default browser in System Preferences.
1. Navigate to about:welcome
2. During the onboarding, make DDG browser as default
3. When the onboarding finishes, click on + button to open the homepage
4. Make sure the prompt to set DDG as default is not visible 

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
