### PR TITLE
Use macos-12 environment in GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   export-notarized-app:
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - name: Install Apple Developer ID Application certificate

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   unit-tests:
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - name: Register SSH keys for submodules access


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1200194497630846/1202179326307003/f

**Description**:
Bumping macos-latest (== macos-11) to macos-12 to use Xcode 13.3 (and newer) for running CI tasks.

**Steps to test this PR**:
1. Ensure that [unit tests workflow](https://github.com/more-duckduckgo-org/macos-browser/actions/runs/2224967508) passes
1. Ensure that notarized build workflows pass for [review](https://github.com/more-duckduckgo-org/macos-browser/actions/runs/2225129657) and [release](https://github.com/more-duckduckgo-org/macos-browser/actions/runs/2225131792) builds and that they generate working binaries.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
