### PR TITLE
If navigationAction does not target main frame open in new tab

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -908,7 +908,7 @@ extension Tab: WKNavigationDelegate {
                                                 if isRequestingNewTab || !navigationAction.isTargetingMainFrame {
                                                     self.delegate?.tab(self,
                                                                        requestedNewTabWith: .url(url),
-                                                                       selected: NSApp.isCommandPressed || !navigationAction.isTargetingMainFrame)
+                                                                       selected: NSApp.isShiftPressed || !navigationAction.isTargetingMainFrame)
                                                 } else {
                                                     webView.load(url)
                                                 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202174754994009/f
Tech Design URL:
CC: @brindy 

**Description**:
When rewriting tracking links we need to check `isTargetingMainFrame` and handle the action accordingly.

**Steps to test this PR**:
1. Send an email to yourself with this link: https://example.com/?utm_campaign=test
1. Open the link from a web email client like fastmail.com
2. Link should open in new tab and the tracking parameter removed

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs
* [x] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
