### PR TITLE
Ensure that we don’t trip an assertion failure when Fireproofing.

### DIFF
--- a/DuckDuckGo/Secure Vault/View/SaveCredentialsViewController.swift
+++ b/DuckDuckGo/Secure Vault/View/SaveCredentialsViewController.swift
@@ -103,6 +103,8 @@ final class SaveCredentialsViewController: NSViewController {
             Pixel.fire(.fireproof(kind: .pwm, suggested: .pwm))
             FireproofDomains.shared.add(domain: account.domain)
         } else {
+            // If the Fireproof checkbox has been unchecked, and the domain is Fireproof, then un-Fireproof it.
+            guard FireproofDomains.shared.isFireproof(fireproofDomain: account.domain) else { return }
             FireproofDomains.shared.remove(domain: account.domain)
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202118895326543/f
Tech Design URL:
CC:

**Description**:

This PR adds an additional check that was missed in https://github.com/more-duckduckgo-org/macos-browser/pull/555. I've re-used the same Asana task as a reference, since this is directly a part of those changes, which themselves have not yet shipped.

**Steps to test this PR**:
1. Use the Debug menu to show the Save Credentials view controller
1. Make sure you don't have the example domain already Fireproof, and then save it, checking that no assertion is tripped

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
