### PR TITLE
Remove Punycode reference after recent bump of BSK

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -5780,8 +5780,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 12.2.7;
+				kind = exactVersion;
+				version = 12.2.8;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
…endency

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1202182497492668
Tech Design URL:
CC:

**Description**:
Following merge of https://github.com/duckduckgo/BrowserServicesKit/pull/91 and https://github.com/duckduckgo/BrowserServicesKit/pull/90 we no longer need Punycode referenced directly.

Also pinned exact version of BSK dependency to 12.2.8

**Steps to test this PR**:

General smoke tests related to sites with non-ascii characters in domain name and setting local unprotected sites.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
