### PR TITLE
Autoconsent: prompt only if an actual cookie popup is found

### DIFF
--- a/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -120,7 +120,15 @@ final class AutoconsentUserScript: NSObject, UserScriptWithAutoconsent {
                 self.actionInProgress = false
                 return
             }
-            os_log("popup found from %s", log: .autoconsent, type: .info, String(describing: cmp.ruleName))
+            os_log("CMP found: %s", log: .autoconsent, type: .info, String(describing: cmp.ruleName))
+
+            guard await Self.background.isPopupOpen(in: self.tabId) else {
+                os_log("popup not open", log: .autoconsent, type: .debug)
+                self.actionInProgress = false
+                return
+            }
+            os_log("Open popup found: %s", log: .autoconsent, type: .info, String(describing: cmp.ruleName))
+
             // check if the user has explicitly enabled the feature
             self.checkUserWasPrompted { enabled in
                 guard enabled else {
@@ -170,12 +178,6 @@ final class AutoconsentUserScript: NSObject, UserScriptWithAutoconsent {
 
     @MainActor
     func runOptOut(for cmp: AutoconsentBackground.ActionResponse, on url: URL) async {
-        guard await Self.background.isPopupOpen(in: self.tabId) else {
-            os_log("popup not open", log: .autoconsent, type: .debug)
-            self.actionInProgress = false
-            return
-        }
-        
         let optOutSuccessful = await Self.background.doOptOut(in: self.tabId)
         guard optOutSuccessful else {
             os_log("opt out failed: %s", log: .autoconsent, type: .error, String(describing: cmp.ruleName))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1202088718678388/f
Tech Design URL:
CC:

**Description**:

Previously we showed the prompt after detecting a CMP. Now we wait until there's an actual visible popup.

**Steps to test this PR**:
1. Open https://babaa.es/ from the US, and observe no popups/prompts
1. Open https://babaa.es/ from the EU, and observe the prompt

**Testing checklist**:

* [x] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [x] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
