### PR TITLE
Ignore downloads that return error HTTP status codes

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -1084,9 +1084,13 @@ extension Tab: WKNavigationDelegate {
                 }
                 currentDownload = navigationResponse.response.url
             }
-            // register the navigationResponse for legacy _WKDownload to be called back on the Tab
-            // further download will be passed to webView:navigationResponse:didBecomeDownload:
-            return .download(navigationResponse, using: webView)
+
+            let isSuccessfulResponse = (navigationResponse.response as? HTTPURLResponse)?.validateStatusCode(statusCode: 200..<300) == nil
+            if isSuccessfulResponse {
+                // register the navigationResponse for legacy _WKDownload to be called back on the Tab
+                // further download will be passed to webView:navigationResponse:didBecomeDownload:
+                return .download(navigationResponse, using: webView)
+            }
         }
 
         return .allow


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202223638967660/f
CC: @mallexxx 

**Description**:
Check for HTTP response status code and only allow downloads when it's HTTP 2xx. The fix is inspired by [a similar issue observed on iOS](https://app.asana.com/0/414709148257752/1202062173646716/f).

**Steps to test this PR**:
1. Go to `https://duckduckgo-my.sharepoint.com/:x:/p/kfowle/EaxuledKoGlKjJ6XUjap7iABq9lkDb7latKds5HlM1fOMQ?e=Ymyn6m` and verify that no files are automatically downloaded
1. Go to e.g. https://github.com/duckduckgo/BrowserServicesKit/releases/tag/12.2.9 and try to download any of the artifacts to verify that regular downloads work as expected.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
