### PR TITLE
Do not store HTTP redirects in history

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -211,6 +211,8 @@ final class Tab: NSObject, Identifiable {
 
     var isLazyLoadingInProgress = false
 
+    private var isBeingRedirected: Bool = false
+
     @Published private(set) var content: TabContent {
         didSet {
             handleFavicon(oldContent: oldValue)
@@ -889,6 +891,14 @@ extension Tab: WKNavigationDelegate {
         }
     }
 
+    func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+        isBeingRedirected = true
+    }
+
+    func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        isBeingRedirected = false
+    }
+
     struct Constants {
         static let webkitMiddleClick = 4
     }
@@ -1109,6 +1119,11 @@ extension Tab: WKNavigationDelegate {
 
     @MainActor
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if !isBeingRedirected, let url = webView.url {
+            addVisit(of: url)
+        }
+
+        isBeingRedirected = false
         invalidateSessionStateData()
         webViewDidFinishNavigationPublisher.send()
         if isAMPProtectionExtracting { isAMPProtectionExtracting = false }
@@ -1119,6 +1134,7 @@ extension Tab: WKNavigationDelegate {
         // https://app.asana.com/0/1199230911884351/1200381133504356/f
         //        hasError = true
 
+        isBeingRedirected = false
         webViewDidFailNavigationPublisher.send()
         invalidateSessionStateData()
     }
@@ -1133,6 +1149,7 @@ extension Tab: WKNavigationDelegate {
         }
 
         self.error = error
+        isBeingRedirected = false
         webViewDidFailNavigationPublisher.send()
     }
 

--- a/DuckDuckGo/Browser Tab/ViewModel/WebViewStateObserver.swift
+++ b/DuckDuckGo/Browser Tab/ViewModel/WebViewStateObserver.swift
@@ -90,13 +90,7 @@ final class WebViewStateObserver: NSObject {
         }
 
         switch keyPath {
-        case #keyPath(WKWebView.url):
-            if let url = webView.url {
-                tabViewModel.tab.setContent(.contentFromURL(url))
-                tabViewModel.tab.addVisit(of: url)
-            }
-            updateTitle() // The title might not change if webView doesn't think anything is different so update title here as well
-
+        case #keyPath(WKWebView.url): handleURLChange(in: webView, tabViewModel: tabViewModel)
         case #keyPath(WKWebView.canGoBack): tabViewModel.updateCanGoBack()
         case #keyPath(WKWebView.canGoForward): tabViewModel.updateCanGoForward()
         case #keyPath(WKWebView.isLoading): tabViewModel.isWebViewLoading = webView.isLoading
@@ -110,6 +104,16 @@ final class WebViewStateObserver: NSObject {
             os_log("%s: keyPath %s not handled", type: .error, className, keyPath)
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
+    }
+
+    private func handleURLChange(in webView: WKWebView, tabViewModel: TabViewModel) {
+        if let url = webView.url {
+            tabViewModel.tab.setContent(.contentFromURL(url))
+            if !webView.isLoading {
+                tabViewModel.tab.addVisit(of: url)
+            }
+        }
+        updateTitle() // The title might not change if webView doesn't think anything is different so update title here as well
     }
 
     private func updateTitle() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202220970350463/f
CC: @tomasstrba 

**Description**:
Add `Tab.isBeingRedirected` that defaults to false, but is set to true when a server redirect occurs
(decided based on a respective `WKNavigationDelegate` callback), and then cleared when the actual
navigation starts, or when an error happens.
`Tab.addVisit` is now called:
* on webView didFinishNavigation callback
* on URL change, but only when webView is not currently loading (filters out server redirects)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Burn all data
1. Visit https://duck.com, verify that the new tab page does not show https://duck.com
1. When in Europe, visit https://cnn.com, be redirected to https://edition.cnn.com and verify that the new tab page does not show https://cnn.com
1. Verify that client-side redirects (JS and meta refresh) add the redirecting page to the new tab page feed:
    1. http://kapusta.s3-website.eu-central-1.amazonaws.com/meta.html
    1. http://kapusta.s3-website.eu-central-1.amazonaws.com/js.html
    1. http://kapusta.s3-website.eu-central-1.amazonaws.com/js-async.html
    1. http://kapusta.s3-website.eu-central-1.amazonaws.com/js-immediate.html

**Extra testing**:

There are no unit tests, but if you want, you can manually verify that `isBeingRedirected` is set to false on navigation errors:
* Prerequisites: Docker
* Add a debug print in `didSet` for `Tab.isBeingRedirected`:
```swift
private var isBeingRedirected: Bool = false {
    didSet {
        Swift.print("isBeingRedirected", isBeingRedirected)
    }
}
```
* Create a file called `nginx.conf` with the following content:

```nginx
server {
    rewrite ^/redirect$ https://dev.null/nope permanent;
}
```

* Run the following command:
```
$ docker run -p 8000:80 -v "${PWD}/nginx.conf":/etc/nginx/conf.d/default.conf:ro nginx:mainline-alpine
```

* Run the browser and go to http://localhost:8000/redirect. Verify that you're being redirected to a non-existent website and `isBeingRedirected` is false.
* Disconnect internet and visit the same URL. Verify that `isBeingRedirected` is set to false after a navigation that fails due to network error.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
