### PR TITLE
Remove 'error' sound when closing Find in Page UI with Esc key

### DIFF
--- a/DuckDuckGo/Main/View/MainViewController.swift
+++ b/DuckDuckGo/Main/View/MainViewController.swift
@@ -340,8 +340,15 @@ extension MainViewController {
 
         switch Int(event.keyCode) {
         case kVK_Escape:
-            findInPageViewController?.findInPageDone(self)
-            return navigationBarViewController.addressBarViewController?.escapeKeyDown() ?? false
+            var isHandled = false
+            if !findInPageContainerView.isHidden {
+                findInPageViewController?.findInPageDone(self)
+                isHandled = true
+            }
+            if let addressBarVC = navigationBarViewController.addressBarViewController {
+                isHandled = isHandled || addressBarVC.escapeKeyDown()
+            }
+            return isHandled
 
         // Handle critical Main Menu actions before WebView
         case kVK_ANSI_1, kVK_ANSI_2, kVK_ANSI_3, kVK_ANSI_4, kVK_ANSI_5, kVK_ANSI_6,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202193534645253/f

**Description**:
Mark Esc key press handled when it causes Find in Page UI to close. Also avoid overriding isHandled flag
by address bar not being in focus (when Esc caused Find in Page to close).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open a URL tab, type cmd+f to bring up Find in Page UI
1. Press Esc and verify that no sound is played
1. Invoke Find in Page again, move focus away, press Esc – verify that no sound is played
1. Focus the address bar, press Esc – verify that no sound is played
1. Press Esc when Find in Page is hidden and address bar is not focused – verify that no sound is played


**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
