### PR TITLE
Safari version warning label hidden if it's version is higher or equal to 15

### DIFF
--- a/DuckDuckGo/Data Import/View/BrowserImportViewController.swift
+++ b/DuckDuckGo/Data Import/View/BrowserImportViewController.swift
@@ -174,16 +174,3 @@ extension NSPopUpButton {
     }
 
 }
-
-private extension SafariVersionReader {
-
-    static func getMajorVersion() -> Int? {
-        if let safariVersionString = SafariVersionReader.getVersion(),
-           let majorVersion = safariVersionString.components(separatedBy: ".")[safe: 0] {
-            return Int(majorVersion)
-        } else {
-            return nil
-        }
-    }
-
-}

--- a/DuckDuckGo/User Agent/Services/SafariVersionReader.swift
+++ b/DuckDuckGo/User Agent/Services/SafariVersionReader.swift
@@ -32,4 +32,13 @@ struct SafariVersionReader {
         return versionNumber
     }
 
+    static func getMajorVersion() -> Int? {
+        if let safariVersionString = SafariVersionReader.getVersion(),
+           let majorVersion = safariVersionString.components(separatedBy: ".")[safe: 0] {
+            return Int(majorVersion)
+        } else {
+            return nil
+        }
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202116285049224/f

**Description**:
The import flow doesn't contain the Safari version warning if the current version requirement is met.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. On macOS Monterey: Go to "Import bookmarks and Passwords..", choose "Safari". Make sure there is no warning "Requires Safari 15 or later"
1. On older macOS with Safari version 14 or older: Go to "Import bookmarks and Passwords..", choose "Safari". Make sure the warning "Requires Safari 15 or later" is present

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
