### PR TITLE
Clear address bar suggestion after pasting a URL

### DIFF
--- a/DuckDuckGo/Navigation Bar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/Navigation Bar/View/AddressBarTextField.swift
@@ -230,6 +230,11 @@ final class AddressBarTextField: NSTextField {
         }
     }
 
+    fileprivate func handlePastedURL() {
+        handleTextDidChange()
+        selectToTheEnd(from: stringValueWithoutSuffix.count)
+    }
+
     private func addressBarEnterPressed() {
         suggestionContainerViewModel?.clearUserStringValue()
 
@@ -928,9 +933,16 @@ extension AddressBarTextField: NSTextViewDelegate {
 final class AddressBarTextEditor: NSTextView {
 
     override func paste(_ sender: Any?) {
+        guard let delegate = delegate as? AddressBarTextField else {
+            os_log("AddressBarTextEditor: unexpected kind of delegate")
+            super.paste(sender)
+            return
+        }
+
         // Fixes an issue when url-name instead of url is pasted
         if let urlString = NSPasteboard.general.string(forType: .URL) {
             string = urlString
+            delegate.handlePastedURL()
         } else {
             super.paste(sender)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1201770413336073/f

**Description**:
Call `handleTextDidChange` when pasting, which clears currently selected suggestion.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Keep a URL in clipboard
1. Start typing a URL or search term in the address bar
1. Paste clipboard contents
1. Verify that the URL is pasted and the cursor is at the end of the URL
1. Press enter
1. Verify that you're navigated to that URL
1. Verify that pasting regular text (not a URL) works as it used to, i.e. is appended to the current address bar content.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
