### PR TITLE
Do not call makeKey on windows created in windows deallocation test

### DIFF
--- a/Unit Tests/App/DeallocationTests.swift
+++ b/Unit Tests/App/DeallocationTests.swift
@@ -54,6 +54,8 @@ final class DeallocationTests: XCTestCase {
 
     func testWindowsDeallocation() {
         autoreleasepool {
+
+            // `showWindow: false` would still open a window, but not activate it, which seems to upset CI
             weak var window1: NSWindow! = WindowsManager.openNewWindow(showWindow: false)
             weak var window2: NSWindow! = WindowsManager.openNewWindow(showWindow: false)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1201037661562251/1202063488767828/f

**Description**:
My hypothesis is that making windows "key" is problematic in the CI. Setting `showWindow` to `false`
seems to be fixing the problem. Note a bit unfortunate wording here, as `showWindow: false` still
displays a window, just not activated – the test remains meaningful though.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Ensure that tests pass in CI

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
