### PR TITLE
Fire autofill pixel from content overlay

### DIFF
--- a/DuckDuckGo/Autofill/ContentOverlayViewController.swift
+++ b/DuckDuckGo/Autofill/ContentOverlayViewController.swift
@@ -197,7 +197,7 @@ extension ContentOverlayViewController: SecureVaultManagerDelegate {
     }
 
     public func secureVaultManager(_: SecureVaultManager, didAutofill type: AutofillType, withObjectId objectId: Int64) {
-        // No-op, Tab.swift handles this functionality
+        Pixel.fire(.formAutofilled(kind: type.formAutofillKind))
     }
     
     public func secureVaultManagerShouldAutomaticallyUpdateCredentialsWithoutUsername(_: SecureVaultManager) -> Bool {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1202411700616458
Tech Design URL:
CC:

**Description**:

Add the autofill pixel to the content overlay.

**Steps to test this PR**:
1. Edit Logging.swift and turn on Pixel logging
1. Launch the browser, and autofill some details on a website (e.g. netflix.com)
1. Observe pixel log in Xcode console

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
