### PR TITLE
Fix of homepage history feed issue after burning

### DIFF
--- a/DuckDuckGo/Home Page/Model/HomePageRecentlyVisitedModel.swift
+++ b/DuckDuckGo/Home Page/Model/HomePageRecentlyVisitedModel.swift
@@ -29,7 +29,7 @@ final class RecentlyVisitedModel: ObservableObject {
         return f
     } ()
 
-    private let fire = Fire()
+    private let fire: Fire
 
     @UserDefaultsWrapper(key: .homePageShowPagesOnHover, defaultValue: false)
     private static var showPagesOnHoverSetting: Bool
@@ -44,8 +44,10 @@ final class RecentlyVisitedModel: ObservableObject {
 
     let open: (URL) -> Void
 
-    init(open: @escaping (URL) -> Void) {
+    init(open: @escaping (URL) -> Void,
+         fire: Fire = FireCoordinator.fireViewModel.fire) {
         self.open = open
+        self.fire = fire
         showPagesOnHover = Self.showPagesOnHoverSetting
     }
 

--- a/DuckDuckGo/Home Page/View/HomePageViewController.swift
+++ b/DuckDuckGo/Home Page/View/HomePageViewController.swift
@@ -22,11 +22,10 @@ import SwiftUI
 
 final class HomePageViewController: NSViewController {
 
-    private let fire = Fire()
-
     private let tabCollectionViewModel: TabCollectionViewModel
     private var bookmarkManager: BookmarkManager
     private let historyCoordinating: HistoryCoordinating
+    private let fireViewModel: FireViewModel
 
     private weak var host: NSView?
 
@@ -45,11 +44,13 @@ final class HomePageViewController: NSViewController {
     init?(coder: NSCoder,
           tabCollectionViewModel: TabCollectionViewModel,
           bookmarkManager: BookmarkManager,
-          historyCoordinating: HistoryCoordinating = HistoryCoordinator.shared) {
+          historyCoordinating: HistoryCoordinating = HistoryCoordinator.shared,
+          fireViewModel: FireViewModel = FireCoordinator.fireViewModel) {
 
         self.tabCollectionViewModel = tabCollectionViewModel
         self.bookmarkManager = bookmarkManager
         self.historyCoordinating = historyCoordinating
+        self.fireViewModel = fireViewModel
 
         super.init(coder: coder)
     }
@@ -78,6 +79,7 @@ final class HomePageViewController: NSViewController {
         self.host = host
 
         subscribeToBookmarks()
+        subscribeToBurningData()
     }
 
     override func viewDidAppear() {
@@ -194,6 +196,17 @@ final class HomePageViewController: NSViewController {
         view.window?.addChildWindow(window, ordered: .above)
         window.setFrame(windowFrame, display: true)
         window.makeKey()
+    }
+
+    private var burningDataCancellable: AnyCancellable?
+    private func subscribeToBurningData() {
+        burningDataCancellable = fireViewModel.fire.$burningData
+            .dropFirst()
+            .sink { [weak self] burningData in
+                if burningData == nil {
+                    self?.refreshModels()
+                }
+            }
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202472796284065/f

**Description**:
This PR fixes a privacy issue of homepage history feed. In few cases, the feed was not refreshed after burning and contained burned domains

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open a new window
1. Visit [wikipedia.org](https://wikipedia.org/)
1. Open a new tab and visit [www.instagram.com](https://www.instagram.com/)
1. Open another tab and make sure [instagram.com](https://instagram.com/) is part of the homepage history feed
1. Click on the fire button, choose burn window, select [instagram.com](https://instagram.com/) only and confirm clearing
1. Make sure [instagram.com](https://instagram.com/) is not part of the homepage feed

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
