### PR TITLE
Correctly display unprotected sites on dashboard

### DIFF
--- a/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
@@ -164,7 +164,7 @@ final class PrivacyDashboardViewController: NSViewController {
         }
 
         let configuration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig
-        let isProtected = !configuration.isUserUnprotected(domain: domain)
+        let isProtected = configuration.isProtected(domain: domain)
         self.privacyDashboardScript.setProtectionStatus(isProtected, webView: self.webView)
     }
 
@@ -222,7 +222,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardUserScriptDelegate {
         }
 
         let configuration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig
-        if isProtected {
+        if isProtected && configuration.isUserUnprotected(domain: domain) {
             configuration.userEnabledProtection(forDomain: domain)
         } else {
             configuration.userDisabledProtection(forDomain: domain)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202493705412589/f

**Description**:
Correctly display if sites on exception list are protected on the dashboard

**Steps to test this PR**:
1. Open a website from the [contentBlocking list](https://staticcdn.duckduckgo.com/trackerblocking/config/v1/macos-config.json) for example wp.pl;
2. Open the dashboard, check if the protections are off, it should;
3. Try switching it ON, it shouldn't work

------
1 . Open a website not in the contentBlocking list
2 . Check if the protection is on, it should
3. Turn off protection, it should work4. 

-----
1 . Test the [Blocking Test Pages](http://privacy-test-pages.glitch.me/privacy-protections/request-blocking/) turning the protection on and off

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
