### PR TITLE
Close dashboard when closing tab with cmd + w

### DIFF
--- a/DuckDuckGo/Navigation Bar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/Navigation Bar/View/AddressBarButtonsViewController.swift
@@ -518,6 +518,7 @@ final class AddressBarButtonsViewController: NSViewController {
             self?.subscribeToUrl()
             self?.subscribeToPermissions()
             self?.subscribeToTrackerAnimationTrigger()
+            self?.closePopover()
         }
     }
 
@@ -776,7 +777,11 @@ final class AddressBarButtonsViewController: NSViewController {
         updatePrivacyEntryPointIcon()
         updatePermissionButtons()
     }
-
+    
+    private func closePopover() {
+        privacyDashboardPopover.close()
+    }
+    
     private func stopAnimations(trackerAnimations: Bool = true, shieldAnimations: Bool = true) {
         func stopAnimation(_ animationView: AnimationView) {
             if animationView.isAnimationPlaying || !animationView.isHidden {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202374074682574/f

**Description**:
When closing the tab with cmd + W the privacy dashboard would stay open.

**Steps to test this PR**:
Make sure to test this in release configuration since the popover style is different on debug mode

1. Open one tab with a random website
2. Open a second tab with another random website
3. Open the privacy dashboard
4. Press cmd + W, check if the tab was closed and if the dashboard was also closed

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
