### PR TITLE
Fix issue when unplugging external monitor

### DIFF
--- a/DuckDuckGo/Main/View/MainWindowController.swift
+++ b/DuckDuckGo/Main/View/MainWindowController.swift
@@ -56,25 +56,6 @@ final class MainWindowController: NSWindowController {
         subscribeToShouldPreventUserInteraction()
         subscribeToResolutionChange()
     }
-    
-    private func subscribeToResolutionChange() {
-        NotificationCenter.default.addObserver(forName: NSApplication.didChangeScreenParametersNotification,
-                                               object: NSApplication.shared,
-                                               queue: OperationQueue.main) { [weak self] _ in
-            self?.resizeWindowIfNeeded()
-        }
-    }
-    
-    private func resizeWindowIfNeeded() {
-        
-        if let visibleWindowFrame = window?.screen?.visibleFrame,
-           let windowFrame = window?.frame {
-            
-            if windowFrame.width > visibleWindowFrame.width || windowFrame.height > visibleWindowFrame.height {
-                window?.performZoom(nil)
-            }
-        }
-    }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -85,6 +66,24 @@ final class MainWindowController: NSWindowController {
         window?.setFrameAutosaveName(Self.windowFrameSaveName)
         
         NotificationCenter.default.addObserver(self, selector: #selector(dismissLockScreen), name: .macWaitlistLockScreenDidUnlock, object: nil)
+    }
+    
+    private func subscribeToResolutionChange() {
+        NotificationCenter.default.addObserver(forName: NSApplication.didChangeScreenParametersNotification,
+                                               object: NSApplication.shared,
+                                               queue: OperationQueue.main) { [weak self] _ in
+            self?.resizeWindowIfNeeded()
+        }
+    }
+    
+    private func resizeWindowIfNeeded() {
+        if let visibleWindowFrame = window?.screen?.visibleFrame,
+           let windowFrame = window?.frame {
+            
+            if windowFrame.width > visibleWindowFrame.width || windowFrame.height > visibleWindowFrame.height {
+                window?.performZoom(nil)
+            }
+        }
     }
     
     @objc


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1202221763590692/f

**Description**:

When using the browser on an external monitor that's wider/taller than the macbook screen and the external monitor is unplugged the browser window kept its original dimensions, forcing the user to manually resize it.
This fix aims to fix this problem automatically zooming the window to fix the user screen if wither height or width is bigger than the current screen.


**Steps to test this PR**:
1. Open the browser on an external monitor that's wider and/or taller than the macbook screen
2. Double click the tabbar to zoom the window to it's maximum size
3. Unplug the external monitor and check if the window is not overflowing the macbook window 

---- 
1 Test actual fullscreen (green traffic light button) to make sure no issues were introduced

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
