### PR TITLE
Select tabs when browser is not focused

### DIFF
--- a/DuckDuckGo/Tab Bar/View/TabBarViewController.swift
+++ b/DuckDuckGo/Tab Bar/View/TabBarViewController.swift
@@ -76,6 +76,9 @@ final class TabBarViewController: NSViewController {
         updateEmptyTabArea()
         tabCollectionViewModel.delegate = self
         reloadSelection()
+        
+        // Detect if tabs are clicked when the window is not in focus
+        // https://app.asana.com/0/1177771139624306/1202033879471339
         addMouseMonitors()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202033879471339/f

**Description**:
Allow selection of tabs when the window is not in focus

Example:
Before:

https://user-images.githubusercontent.com/782316/176740908-9a027169-ad74-451e-a563-37c4ea27ba62.mov


After:

https://user-images.githubusercontent.com/782316/176740928-285cd954-e1db-40bc-85b3-aec23493445b.mov


**Steps to test this PR**:
1. Add multiple tabs
2. Click on another app outside the browser window, like finder.
3. Click on a tab, make sure the tab is selected

obs: Would be good to test with a small number of tabs, and a large number of tabs as well.

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs

