### PR TITLE
Use local DDG icon for DDG url favicon

### DIFF
--- a/DuckDuckGo/Browser Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Browser Tab/ViewModel/TabViewModel.swift
@@ -277,7 +277,7 @@ final class TabViewModel {
             favicon = Favicon.bookmarks
             return
         case .url (let url):
-            if url.host == DDGURL.domain {
+            if url.host == URL.duckDuckGo.host {
                 favicon = Favicon.home
                 return
             }
@@ -341,8 +341,4 @@ extension TabViewModel: TabDataClearing {
         tab.prepareForDataClearing(caller: caller)
     }
 
-}
-
-private enum DDGURL {
-    static let domain = "duckduckgo.com"
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202444402883584/f

**Description**:
Use local DDG icon for DDG tabs favicon to make sure it's consistent with the home screen tab

**Steps to test this PR**:
1. Open a new home screen
2. Open a new tab with duckduckgo
3. Compare the favicons
4. Make sure other websites favicons are working as expected

