### PR TITLE
Prevent inactive tabs from presenting alerts

### DIFF
--- a/DuckDuckGo/Browser Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Browser Tab/View/BrowserTabViewController.swift
@@ -907,8 +907,8 @@ extension BrowserTabViewController: WKUIDelegate {
                  initiatedByFrame frame: WKFrameInfo,
                  completionHandler: @escaping () -> Void) {
 
-        guard let window = view.window else {
-            os_log("%s: Window is nil", type: .error, className)
+        guard webView === self.webView, let window = view.window else {
+            os_log("%s: Could not display JS alert panel", type: .error, className)
             completionHandler()
             return
         }
@@ -924,8 +924,8 @@ extension BrowserTabViewController: WKUIDelegate {
                  initiatedByFrame frame: WKFrameInfo,
                  completionHandler: @escaping (Bool) -> Void) {
 
-        guard let window = view.window else {
-            os_log("%s: Window is nil", type: .error, className)
+        guard webView === self.webView, let window = view.window else {
+            os_log("%s: Could not display JS confirmation panel", type: .error, className)
             completionHandler(false)
             return
         }
@@ -942,8 +942,8 @@ extension BrowserTabViewController: WKUIDelegate {
                  initiatedByFrame frame: WKFrameInfo,
                  completionHandler: @escaping (String?) -> Void) {
 
-        guard let window = view.window else {
-            os_log("%s: Window is nil", type: .error, className)
+        guard webView === self.webView, let window = view.window else {
+            os_log("%s: Could not display JS text input panel", type: .error, className)
             completionHandler(nil)
             return
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202569779116574/f
Tech Design URL:
CC:

**Description**:

This PR adds checks to the JavaScript alert presentation callbacks to verify that the webview requesting it is the same one that is visible on the BrowserTabViewController.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open [this JSFiddle](https://jsfiddle.net/samsymons/p9bt5je6/) in a tab, running on this branch
1. Click the alert button, and wait 2 seconds to check that the alert appears
1. Click the alert button again and then immediately select another tab, verify that no alert appears
1. Perform the same test on other tab types, such as the new tab page

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
