### PR TITLE
Fix inserting selected tab into a scrollable tab collection

### DIFF
--- a/DuckDuckGo/Tab Bar/View/TabBarViewController.swift
+++ b/DuckDuckGo/Tab Bar/View/TabBarViewController.swift
@@ -417,6 +417,7 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
         collectionView.animator().insertItems(at: indexPathSet)
         if selected {
             collectionView.selectItems(at: indexPathSet, scrollPosition: .centeredHorizontally)
+            collectionView.scrollToSelected()
         }
 
         updateTabMode()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1202608828742665/f

**Description**:
If the item was inserted outside of collection's visible content rect, the collection needs
an explicit API call to scroll to reveal it.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. best to use a mouse with a middle click
1. open https://news.ycombinator.com/
1. open multiple new child tabs (e.g. by using middle click)
1. open a new selected child tab (middle click + shift)
1. verify that the new tab is shown

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
