### PR TITLE
Remove local history of the remaining window's tab collection after burning all data

### DIFF
--- a/DuckDuckGo/Fire/Model/Fire.swift
+++ b/DuckDuckGo/Fire/Model/Fire.swift
@@ -329,6 +329,7 @@ final class Fire {
             } else {
                 tabCollectionViewModel.appendNewTab(forceChange: true)
             }
+            tabCollectionViewModel.tabCollection.localHistoryOfRemovedTabs.removeAll()
 
             completion()
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202309934776042/f

**Description**:
When all data is burned, it closes all windows and clears tabs in the active one.
The "Current window" fire button mode takes the list of domains to be burned
from tab collection's `localHistoryOfRemovedTabs`. This one wasn't getting wiped
in the active window when all data was cleared.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open a couple of tabs, ideally create a history in one of the tabs (open a website and then open another website in the same tab)
1. Open Fire popover, verify that domains are listed in "Clear All Data" as well as in "Clear Current Window" modes
1. Clear all data
1. Open Fire popover again, verify that there is "No data to clear" in "Clear Current Window" mode
1. Repeat the same, but log in on one of the websites and fireproof it, verify that after burning all data you are still logged in on that website.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
