### PR TITLE
Avoid the data import button being disabled too frequently

### DIFF
--- a/DuckDuckGo/Data Import/View/DataImportViewController.swift
+++ b/DuckDuckGo/Data Import/View/DataImportViewController.swift
@@ -180,13 +180,8 @@ final class DataImportViewController: NSViewController {
         let source = validSources.first(where: { $0.importSourceName == item.title })!
 
         switch source {
-        case .csv, .lastPass, .onePassword:
-            let interactionState: InteractionState = (dataImporter is CSVImporter) ? .ableToImport : .unableToImport
-            self.viewState = ViewState(selectedImportSource: source, interactionState: interactionState)
-
-        case .bookmarksHTML:
-            let interactionState: InteractionState = (dataImporter is BookmarkHTMLImporter) ? .ableToImport : .unableToImport
-            self.viewState = ViewState(selectedImportSource: source, interactionState: interactionState)
+        case .csv, .lastPass, .onePassword, .bookmarksHTML:
+            self.viewState = ViewState(selectedImportSource: source, interactionState: .unableToImport)
 
         case .chrome, .firefox, .brave, .edge, .safari:
             let interactionState: InteractionState
@@ -196,6 +191,7 @@ final class DataImportViewController: NSViewController {
             case (_, true):
                 interactionState = .moreInfoAvailable
             }
+
             self.viewState = ViewState(selectedImportSource: source, interactionState: interactionState)
         }
 
@@ -265,13 +261,16 @@ final class DataImportViewController: NSViewController {
             if case .permissionsRequired([.logins]) = interactionState {
                 let viewController = FileImportViewController.create(importSource: .safari)
                 viewController.delegate = self
-                return viewController
 
+                return viewController
             } else if case .ableToImport = interactionState,
-                      let fileImportViewController = currentChildViewController as? FileImportViewController {
+                      let fileImportViewController = currentChildViewController as? FileImportViewController,
+                      fileImportViewController.importSource == .safari {
                 fileImportViewController.importSource = importSource
+
                 return nil
             }
+
             fallthrough
         case .brave, .chrome, .edge, .firefox:
             if case let .completedImport(summary) = interactionState {

--- a/DuckDuckGo/Data Import/View/FileImportViewController.swift
+++ b/DuckDuckGo/Data Import/View/FileImportViewController.swift
@@ -58,6 +58,10 @@ final class FileImportViewController: NSViewController {
 
     var importSource: DataImport.Source = .csv {
         didSet {
+            if oldValue != importSource {
+                currentImportState = .awaitingFileSelection
+            }
+
             renderCurrentState()
         }
     }
@@ -176,7 +180,7 @@ final class FileImportViewController: NSViewController {
                 switch importSource {
                 case .bookmarksHTML:
                     delegate?.fileImportViewController(self, didSelectBookmarksFileWithURL: selectedURL)
-                case .csv, .onePassword, .lastPass:
+                case .csv, .onePassword, .lastPass, .safari:
                     delegate?.fileImportViewController(self, didSelectCSVFileWithURL: selectedURL)
                 default:
                     break


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202637004056115/f
Tech Design URL:
CC:

**Description**:

This PR fixes two issues:

1. The import button was disabled in some cases, like when selecting a file for CSV import then changing import type
1. When selecting LastPass or 1Password and then changing to Safari, the Safari import state was skipping the checkbox selection step

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

To test the Safari selection bug:
1. Select LastPass or 1Password as an import source
1. Change to Safari and verify that you get put back on the checkbox selection state

To test the disabled import button bug:
1. Test import for LastPass, 1Password, and Safari - select a CSV file, import it, verify that the button works as expected

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
