### PR TITLE
Allow cmd+1..9 to select pinned tabs

### DIFF
--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -401,10 +401,10 @@ extension MainViewController {
             return
         }
         let index = keyEquivalent - 1
-        if keyEquivalent == 9, !tabCollectionViewModel.tabCollection.tabs.isEmpty {
+        if keyEquivalent == 9 {
             tabCollectionViewModel.select(at: .last(in: tabCollectionViewModel))
-        } else if index < tabCollectionViewModel.tabCollection.tabs.count {
-            tabCollectionViewModel.select(at: .unpinned(index))
+        } else if index < tabCollectionViewModel.allTabsCount {
+            tabCollectionViewModel.select(at: .at(index, in: tabCollectionViewModel))
         }
     }
 

--- a/Unit Tests/Tab Bar/Model/TabIndexTests.swift
+++ b/Unit Tests/Tab Bar/Model/TabIndexTests.swift
@@ -100,6 +100,18 @@ final class TabIndexTests: XCTestCase {
         XCTAssertEqual(TabIndex.unpinned(1).next(in: viewModel), .unpinned(0))
     }
 
+    func testWhenViewModelHasNoUnpinnedTabsThenNextInViewModelCyclesThroughPinnedTabs() {
+        let viewModel = TabCollectionViewModel(
+            tabCollection: tabCollection(tabsCount: 0),
+            pinnedTabsManager: pinnedTabsManager(tabsCount: 3)
+        )
+        viewModel.remove(at: .unpinned(0))
+
+        XCTAssertEqual(TabIndex.pinned(0).next(in: viewModel), .pinned(1))
+        XCTAssertEqual(TabIndex.pinned(1).next(in: viewModel), .pinned(2))
+        XCTAssertEqual(TabIndex.pinned(2).next(in: viewModel), .pinned(0))
+    }
+
     func testThatPreviousInViewModelCyclesThroughPinnedAndUnpinnedTabs() {
         let viewModel = TabCollectionViewModel(
             tabCollection: tabCollection(tabsCount: 2),
@@ -160,6 +172,53 @@ final class TabIndexTests: XCTestCase {
 
         XCTAssertEqual(TabIndex.unpinned(0).sanitized(for: viewModel), .pinned(4))
         XCTAssertEqual(TabIndex.unpinned(5).sanitized(for: viewModel), .pinned(4))
+    }
+
+    func testThatAtPositionInViewModelReturnsExistingTab() {
+        let viewModel = TabCollectionViewModel(
+            tabCollection: tabCollection(tabsCount: 2),
+            pinnedTabsManager: pinnedTabsManager(tabsCount: 3)
+        )
+
+        XCTAssertEqual(TabIndex.at(0, in: viewModel), .pinned(0))
+        XCTAssertEqual(TabIndex.at(1, in: viewModel), .pinned(1))
+        XCTAssertEqual(TabIndex.at(2, in: viewModel), .pinned(2))
+        XCTAssertEqual(TabIndex.at(3, in: viewModel), .unpinned(0))
+        XCTAssertEqual(TabIndex.at(4, in: viewModel), .unpinned(1))
+        XCTAssertEqual(TabIndex.at(5, in: viewModel), .unpinned(1))
+        XCTAssertEqual(TabIndex.at(42, in: viewModel), .unpinned(1))
+        XCTAssertEqual(TabIndex.at(-5, in: viewModel), .pinned(0))
+    }
+
+    func testThatAtPositionInViewModelReturnsExistingTabWhenThereAreNoPinnedTabs() {
+        let viewModel = TabCollectionViewModel(
+            tabCollection: tabCollection(tabsCount: 4),
+            pinnedTabsManager: pinnedTabsManager(tabsCount: 0)
+        )
+
+        XCTAssertEqual(TabIndex.at(0, in: viewModel), .unpinned(0))
+        XCTAssertEqual(TabIndex.at(1, in: viewModel), .unpinned(1))
+        XCTAssertEqual(TabIndex.at(2, in: viewModel), .unpinned(2))
+        XCTAssertEqual(TabIndex.at(3, in: viewModel), .unpinned(3))
+        XCTAssertEqual(TabIndex.at(5, in: viewModel), .unpinned(3))
+        XCTAssertEqual(TabIndex.at(42, in: viewModel), .unpinned(3))
+        XCTAssertEqual(TabIndex.at(-5, in: viewModel), .unpinned(0))
+    }
+
+    func testThatAtPositionInViewModelReturnsExistingTabWhenThereAreNoUnpinnedTabs() {
+        let viewModel = TabCollectionViewModel(
+            tabCollection: tabCollection(tabsCount: 0),
+            pinnedTabsManager: pinnedTabsManager(tabsCount: 4)
+        )
+        viewModel.remove(at: .unpinned(0))
+
+        XCTAssertEqual(TabIndex.at(0, in: viewModel), .pinned(0))
+        XCTAssertEqual(TabIndex.at(1, in: viewModel), .pinned(1))
+        XCTAssertEqual(TabIndex.at(2, in: viewModel), .pinned(2))
+        XCTAssertEqual(TabIndex.at(3, in: viewModel), .pinned(3))
+        XCTAssertEqual(TabIndex.at(5, in: viewModel), .pinned(3))
+        XCTAssertEqual(TabIndex.at(42, in: viewModel), .pinned(3))
+        XCTAssertEqual(TabIndex.at(-5, in: viewModel), .pinned(0))
     }
 
     // MARK: -


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1202659052151493/f

**Description**:
Add TabIndex API that "converts" an integer index into TabIndex for a given TabCollectionViewModel.
Make showTab main menu action aware of pinned tabs, and use this API to select correct tab.
This patch also adds extra assertions to `TabIndex.first(in:)` and `TabIndex.last(in:)` and
fixes `TabIndex.next(in:)` when there are only pinned tabs.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open multiple tabs
1. Pin a tab, Verify that cmd+1 selects the pinned tab, and cmd+2 selects the first unpinned tab
1. Pin more tabs, verify that cmd+1..9 select proper tabs
1. Have more than 9 tabs in total, verify that cmd+9 selects always the last tab
1. Have a couple of pinned tabs, close all unpinned tabs, verify that cmd+9 selects the last pinned tab
1. Unpin all tabs (you can use Debug -> Reset pinned tabs), verify that cmd+1..9 works correctly without pinned tabs.

**Testing checklist**:

* [x] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
