### PR TITLE
Fix memory leak when closing a popup window

### DIFF
--- a/DuckDuckGo/Recently Closed/Model/RecentlyClosedCoordinator.swift
+++ b/DuckDuckGo/Recently Closed/Model/RecentlyClosedCoordinator.swift
@@ -70,7 +70,10 @@ final class RecentlyClosedCoordinator: RecentlyClosedCoordinating {
     private func subscribeToPinnedTabCollection(of pinnedTabsManager: PinnedTabsManager) {
         let tabCollection = pinnedTabsManager.tabCollection
         tabCollection.didRemoveTabPublisher
-            .sink { [weak self] (tab, index) in
+            .sink { [weak self, weak tabCollection] (tab, index) in
+                guard let tabCollection = tabCollection else {
+                    return
+                }
                 self?.cacheTabContent(tab, of: tabCollection, at: .pinned(index))
             }
             .store(in: &cancellables)
@@ -79,7 +82,10 @@ final class RecentlyClosedCoordinator: RecentlyClosedCoordinating {
     private func subscribeToTabCollection(of mainWindowController: MainWindowController) {
         let tabCollection = mainWindowController.mainViewController.tabCollectionViewModel.tabCollection
         tabCollection.didRemoveTabPublisher
-            .sink { [weak self] (tab, index) in
+            .sink { [weak self, weak tabCollection] (tab, index) in
+                guard let tabCollection = tabCollection else {
+                    return
+                }
                 self?.cacheTabContent(tab, of: tabCollection, at: .unpinned(index))
             }
             .store(in: &cancellables)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1202672053569151/f
CC: @samsymons

**Description**:
RecentlyClosedCoordinator has been capturing TabCollection strongly inside sink closures.
Capture it weakly to break the retain cycle.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open https://www.rnz.co.nz/, select Listen Now, any station
1. Click play in the popup window that has opened
1. Close the popup window
1. Verify that audio has stopped playing

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
