### PR TITLE
Fix auto-consent preferences on opened tabs

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/UserScripts.swift
+++ b/DuckDuckGo/Browser Tab/Model/UserScripts.swift
@@ -50,14 +50,10 @@ final class UserScripts {
         contentScopeUserScript = ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs)
         autofillScript = WebsiteAutofillUserScript(scriptSourceProvider: sourceProvider.autofillSourceProvider!)
         if #available(macOS 11, *) {
-            if PrivacySecurityPreferences.shared.autoconsentEnabled != false {
-                autoconsentUserScript = AutoconsentUserScript(scriptSource: sourceProvider,
-                                                              config: sourceProvider.privacyConfigurationManager.privacyConfig)
-                userScripts.append(autoconsentUserScript!)
-            } else {
-                os_log("Autoconsent is disabled", log: .autoconsent, type: .debug)
-                autoconsentUserScript = nil
-            }
+            autoconsentUserScript = AutoconsentUserScript(scriptSource: sourceProvider,
+                                                          config: sourceProvider.privacyConfigurationManager.privacyConfig)
+            userScripts.append(autoconsentUserScript!)
+            
         } else {
             autoconsentUserScript = nil
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202688773645648/f

**Description**:
This fixes an issue where only new tabs would respect the cookie auto-consent preferences

**Steps to test this PR**:
Details on how to reproduce the bug without the fix [here](https://app.asana.com/0/0/1202669983881256/1202681745198038/f)
Test page: http://privacy-test-pages.glitch.me/features/autoconsent/

***With Settings/Privacy/Cookie Consent pop-ups OFF***
1. Open test page 
2. Validate that cookie consent wasn't managed
3. Open settings and enable cookie consent
4. Open new tab with the same test page
5. Validate that cookie was managed
6. Go back to the first tab, reload, validate that cookie was managed

***With Settings/Privacy/Cookie Consent pop-ups ON***
1. Open test page 
2. Validate that cookie consent was managed
3. Open settings and disable cookie consent
4. Open new tab with the same test page
5. Validate that cookie wasn't managed
6. Go back to the first tab, reload, validate that cookie wasn't managed

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs
* [x] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
