### PR TITLE
Fix issues with printing websites

### DIFF
--- a/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
+++ b/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
@@ -210,8 +210,6 @@ extension WKWebView {
 
             printInfo.horizontalPagination = .automatic
             printInfo.verticalPagination = .automatic
-            printInfo.isVerticallyCentered = false
-            printInfo.isHorizontallyCentered = false
             printInfo.leftMargin = 0
             printInfo.rightMargin = 0
             printInfo.topMargin = 0


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202292509853509/f
Tech Design URL:
CC:

**Description**:

This PR uses a custom `NSPrintInfo` instance when printing webpages. The print info returned via `NSPrintInfo.shared` clips content pretty badly by default, so the new instance takes a copy of that, removes the margins, and then scales the content down slightly.

To be totally honest: I don't really understand NSPrintInfo. Its margin properties don't change the position or size of the content. If anyone has a better suggestion, I'm totally open to it. 🙂 

**Steps to test this PR**:
1. Test a number of webpages and compare their PDF previews to Safari. They won't match 100%, but use the Safari previews to verify that our browser's preview isn't being clipped in any way as that's the goal here.
1. Test a PDF. You can [use the PDF that was given when this issue was reported](https://cdn3.parksmedia.wdprapps.disney.com/media/rd/redesign/running-training-programs/runDisney-Dopey-Challenge-Training-Plan.pdf).

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
