### PR TITLE
Use localized compare to sort autofill items

### DIFF
--- a/DuckDuckGo/Secure Vault/Model/PasswordManagementListSection.swift
+++ b/DuckDuckGo/Secure Vault/Model/PasswordManagementListSection.swift
@@ -50,7 +50,14 @@ struct PasswordManagementListSection {
                          order: SecureVaultSorting.SortOrder) -> [PasswordManagementListSection] {
         
         let itemsByFirstCharacter: [String: [SecureVaultItem]] = Dictionary(grouping: items) { $0[keyPath: keyPath] }
-        let sortFunction: (String, String) -> Bool = order == .ascending ? (<) : (>)
+        let sortFunction: (String, String) -> Bool = {
+            switch order {
+            case .ascending:
+                return { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            case .descending:
+                return { $0.localizedCaseInsensitiveCompare($1) == .orderedDescending }
+            }
+        }()
         let sortedKeys = itemsByFirstCharacter.keys.sorted(by: sortFunction)
         
         return sortedKeys.map { key in

--- a/Unit Tests/Secure Vault/PasswordManagementListSectionTests.swift
+++ b/Unit Tests/Secure Vault/PasswordManagementListSectionTests.swift
@@ -33,6 +33,17 @@ final class PasswordManagementListSectionTests: XCTestCase {
         login(named: "Zulu Two")
     ]
 
+    private lazy var nonASCIIAccounts = [
+        login(named: "a"),
+        login(named: "b"),
+        login(named: "c"),
+        login(named: "s"),
+        login(named: "ą"),
+        login(named: "ć"),
+        login(named: "ś"),
+        login(named: "š")
+    ]
+
     override func setUp() {
         super.setUp()
     }
@@ -50,7 +61,13 @@ final class PasswordManagementListSectionTests: XCTestCase {
         XCTAssertEqual(sections.first!.items.map(\.title), ["Alfa", "Alfa Two"])
         XCTAssertEqual(sections.last!.items.map(\.title), ["Zulu", "Zulu Two"])
     }
-    
+
+    func testWhenSortingItemsByTitle_AndItemsAreNonASCII_ThenSectionsAreSortedUsingLocalizedComparison() {
+        let sections = PasswordManagementListSection.sections(with: nonASCIIAccounts, by: \.firstCharacter, order: .ascending)
+        XCTAssertEqual(sections.count, 8)
+        XCTAssertEqual(sections.map(\.title), ["A", "Ą", "B", "C", "Ć", "S", "Ś", "Š"])
+    }
+
     func testWhenSortingItemsByTitle_AndOrderIsDescending_ThenSectionsAreReverseAlphabetical() {
         let sections = PasswordManagementListSection.sections(with: accounts, by: \.firstCharacter, order: .descending)
         XCTAssertEqual(sections.count, 5)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1202723762657601/f

**Description**:
Use `localizedCaseInsensitiveCompare` instead of generic string comparison.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Add items containing non-ASCII characters to Autofill
1. Verify that `ą` comes after `a` and before `b`, etc.
1. Use Reversed Alphabetical sorting and verify that `ą` comes after `b` and before `a`, etc.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
