### PR TITLE
Update selectedTabViewModel only when it actually changes

### DIFF
--- a/DuckDuckGo/Tab Bar/ViewModel/TabCollectionViewModel.swift
+++ b/DuckDuckGo/Tab Bar/ViewModel/TabCollectionViewModel.swift
@@ -614,8 +614,10 @@ final class TabCollectionViewModel: NSObject {
             break
         }
 
-        selectedTabViewModel?.tab.lastSelectedAt = Date()
-        self.selectedTabViewModel = selectedTabViewModel
+        if self.selectedTabViewModel !== selectedTabViewModel {
+            selectedTabViewModel?.tab.lastSelectedAt = Date()
+            self.selectedTabViewModel = selectedTabViewModel
+        }
     }
 }
 

--- a/Unit Tests/Tab Bar/ViewModel/TabCollectionViewModelTests+WithoutPinnedTabsManager.swift
+++ b/Unit Tests/Tab Bar/ViewModel/TabCollectionViewModelTests+WithoutPinnedTabsManager.swift
@@ -434,6 +434,29 @@ extension TabCollectionViewModelTests {
         XCTAssertEqual(firstTabViewModel?.tab.url, tabCollectionViewModel.tabViewModel(at: 1)?.tab.url)
     }
 
+    // MARK: - Publishers
+
+    func test_WithoutPinnedTabsManager_WhenSelectionIndexIsUpdatedWithTheSameValueThenSelectedTabViewModelIsOnlyPublishedOnce() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let firstTabViewModel = tabCollectionViewModel.tabViewModel(at: 0)
+        firstTabViewModel?.tab.url = URL.duckDuckGo
+
+        var events: [TabViewModel?] = []
+        let cancellable = tabCollectionViewModel.$selectedTabViewModel
+            .sink { tabViewModel in
+                events.append(tabViewModel)
+            }
+
+        tabCollectionViewModel.select(at: .unpinned(0))
+        tabCollectionViewModel.select(at: .unpinned(0))
+        tabCollectionViewModel.select(at: .unpinned(0))
+        tabCollectionViewModel.select(at: .unpinned(0))
+
+        cancellable.cancel()
+
+        XCTAssertEqual(events.count, 1)
+        XCTAssertIdentical(events[0], tabCollectionViewModel.selectedTabViewModel)
+    }
 }
 
 fileprivate extension TabCollectionViewModel {

--- a/Unit Tests/Tab Bar/ViewModel/TabCollectionViewModelTests.swift
+++ b/Unit Tests/Tab Bar/ViewModel/TabCollectionViewModelTests.swift
@@ -17,6 +17,7 @@
 //
 
 import XCTest
+import Combine
 @testable import DuckDuckGo_Privacy_Browser
 
 // MARK: - Tests for TabCollectionViewModel with PinnedTabsManager but without pinned tabs
@@ -433,6 +434,29 @@ final class TabCollectionViewModelTests: XCTestCase {
         XCTAssertEqual(firstTabViewModel?.tab.url, tabCollectionViewModel.tabViewModel(at: 1)?.tab.url)
     }
 
+    // MARK: - Publishers
+
+    func testWhenSelectionIndexIsUpdatedWithTheSameValueThenSelectedTabViewModelIsOnlyPublishedOnce() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let firstTabViewModel = tabCollectionViewModel.tabViewModel(at: 0)
+        firstTabViewModel?.tab.url = URL.duckDuckGo
+
+        var events: [TabViewModel?] = []
+        let cancellable = tabCollectionViewModel.$selectedTabViewModel
+            .sink { tabViewModel in
+                events.append(tabViewModel)
+            }
+
+        tabCollectionViewModel.select(at: .unpinned(0))
+        tabCollectionViewModel.select(at: .unpinned(0))
+        tabCollectionViewModel.select(at: .unpinned(0))
+        tabCollectionViewModel.select(at: .unpinned(0))
+
+        cancellable.cancel()
+
+        XCTAssertEqual(events.count, 1)
+        XCTAssertIdentical(events[0], tabCollectionViewModel.selectedTabViewModel)
+    }
 }
 
 fileprivate extension TabCollectionViewModel {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202668155654614/f

**Description**:
TL;DR: This patch limits the number of events published from `TabCollectionViewModel.selectedTabViewModel`
to reduce number of calls to `BrowserTabViewController.showTabContent`.

Before this fix, when you navigated between tabs using cmd+[], `showTabContent` would be called once
for every unpinned tab, but twice for every pinned tab. This is because two observable streams are activated after TabCollectionViewModel updates its `selectionIndex` after a call to `selectNext`/`selectPrevious`:
* TabCollectionViewModel updates PinnedTabsViewModel's `selectedItem` via a subscription in TabBarViewController,
* PinnedTabsViewModel tries to update TabCollectionViewModel's `selectionIndex` again (to the same pinned tab index) via a subscription in TabBarViewController.

Both subscriptions are currently required, because the latter is needed to support clicking pinned tabs with a mouse,
when the action originates in PinnedTabView that knows nothing about TabCollectionViewModel, so it calls PinnedTabsViewModel. By updating `selectedTabViewModel` only when the new value is a different instance
we can ensure that subscribers are not getting duplicate events (it can't be easily solved with `removingDuplicates`, because TabViewModel is a reference type, plus it's better to solve the publisher itself).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Since input freezing now occurs rarely and we don't have steps to reproduce, I suggest to limit
testing to smoke testing tab selection (with a mouse and with a keyboard) plus verifying that `showTabContent`
is in fact only called once:
1. Add a print statement in `BrowserTabViewController.showTabContent`, such as `print(#function, tabViewModel?.tab.content.url)`
1. Open at least 2 pinned tabs and 1 unpinned tab with different websites
1. Navigate through tabs using mouse and keyboard
1. Verify that with every selected tab `showTabContent` is called exactly once.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
