### PR TITLE
Prevent background tabs from clearing tab selection

### DIFF
--- a/DuckDuckGo/Tab Bar/View/TabBarViewController.swift
+++ b/DuckDuckGo/Tab Bar/View/TabBarViewController.swift
@@ -687,7 +687,10 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
         }
         updateTabMode(for: collectionView.numberOfItems(inSection: 0) + 1)
 
-        collectionView.clearSelection()
+        if selected {
+            collectionView.clearSelection()
+        }
+
         if tabMode == .divided {
             collectionView.animator().insertItems(at: lastIndexPathSet)
             if selected {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1202801432128120/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue where tabs opened in the background would cause the current tab selection to be cleared.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Test all tab operations and verify that selection state is correct (including with pinned tabs)
1. Test opening tabs in the background with Command+Click, from the New Tab page and from regular websites

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs
* [x] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
