### PR TITLE
update the menu once the favicons have loaded

### DIFF
--- a/DuckDuckGo/Favicons/Model/FaviconManager.swift
+++ b/DuckDuckGo/Favicons/Model/FaviconManager.swift
@@ -48,6 +48,8 @@ final class FaviconManager: FaviconManagement {
     
     private let faviconURLSession = URLSession(configuration: .ephemeral)
 
+    @Published var faviconsLoaded = false
+
     func loadFavicons() {
         imageCache.loadFavicons { _ in
             self.imageCache.cleanOldExcept(fireproofDomains: FireproofDomains.shared,
@@ -55,6 +57,7 @@ final class FaviconManager: FaviconManagement {
                 self.referenceCache.loadReferences { _ in
                     self.referenceCache.cleanOldExcept(fireproofDomains: FireproofDomains.shared,
                                                        bookmarkManager: LocalBookmarkManager.shared)
+                    self.faviconsLoaded = true
                 }
             }
         }

--- a/DuckDuckGo/Menus/MainMenu.swift
+++ b/DuckDuckGo/Menus/MainMenu.swift
@@ -123,9 +123,30 @@ final class MainMenu: NSMenu {
         #endif
 
         subscribeToBookmarkList()
+        subscribeToFavicons()
     }
 
     // MARK: - Bookmarks
+
+    var faviconsCancellable: AnyCancellable?
+    private func subscribeToFavicons() {
+        faviconsCancellable = FaviconManager.shared.$faviconsLoaded
+            .receive(on: DispatchQueue.main).sink(receiveValue: { [weak self] loaded in
+                if loaded {
+                    self?.updateFavicons(self?.bookmarksMenuItem)
+                    self?.updateFavicons(self?.favoritesMenuItem)
+                }
+        })
+    }
+
+    private func updateFavicons(_ menuItem: NSMenuItem?) {
+        if let bookmark = menuItem?.representedObject as? Bookmark {
+            menuItem?.image = BookmarkViewModel(entity: bookmark).menuFavicon
+        }
+        menuItem?.submenu?.items.forEach { menuItem in
+            updateFavicons(menuItem)
+        }
+    }
 
     var bookmarkListCancellable: AnyCancellable?
     private func subscribeToBookmarkList() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202835408626035/f
Tech Design URL:
CC:

**Description**:

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Add a bunch of bookmarks
3. Launch the app
1. Ensure the bookmarks in the menu have their favicons
1. A more advance version of this is to add some kind of sleep to the loadFavicons call in `FaviconManager` and watch the favicons update in the menu when then the favicons manager loads

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
