### PR TITLE
Optimize new tab page performance on macOS 11+

### DIFF
--- a/DuckDuckGo/Home Page/View/FavoritesView.swift
+++ b/DuckDuckGo/Home Page/View/FavoritesView.swift
@@ -32,7 +32,75 @@ struct Favorites: View {
 
     var body: some View {
 
-        let addButton = ZStack(alignment: .top) {
+        if #available(macOS 11.0, *) {
+            LazyVStack(spacing: 4) {
+                FavoritesGrid(isHovering: $isHovering)
+            }
+            .frame(maxWidth: .infinity)
+            .onHover { isHovering in
+                self.isHovering = isHovering
+            }
+        } else {
+            VStack(spacing: 4) {
+                FavoritesGrid(isHovering: $isHovering)
+            }
+            .frame(maxWidth: .infinity)
+            .onHover { isHovering in
+                self.isHovering = isHovering
+            }
+        }
+
+    }
+
+}
+    
+struct FavoritesGrid: View {
+    
+    @EnvironmentObject var model: HomePage.Models.FavoritesModel
+    
+    @Binding var isHovering: Bool
+    
+    var rowIndices: Range<Int> {
+        model.showAllFavorites ? model.rows.indices : model.rows.indices.prefix(HomePage.favoritesRowCountWhenCollapsed)
+    }
+
+    var body: some View {
+
+        ForEach(rowIndices, id: \.self) { index in
+
+            HStack(alignment: .top, spacing: 20) {
+                ForEach(model.rows[index], id: \.id) { favorite in
+
+                    switch favorite.favoriteType {
+                    case .bookmark(let bookmark):
+                        Favorite(bookmark: bookmark)
+
+                    case .addButton:
+                        FavoritesGridAddButton()
+
+                    case .ghostButton:
+                        FavoritesGridGhostButton()
+                    }
+                }
+            }
+            
+        }
+
+        MoreOrLess(isExpanded: $model.showAllFavorites)
+            .padding(.top, 2)
+            .visibility(model.rows.count > HomePage.favoritesRowCountWhenCollapsed && isHovering ? .visible : .invisible)
+
+    }
+    
+}
+    
+private struct FavoritesGridAddButton: View {
+    
+    @EnvironmentObject var model: HomePage.Models.FavoritesModel
+
+    var body: some View {
+        
+        ZStack(alignment: .top) {
             FavoriteTemplate(title: UserText.addFavorite, domain: nil)
             ZStack {
                 Image("Add")
@@ -43,47 +111,24 @@ struct Favorites: View {
         .link {
             model.addNew()
         }
-
-        let ghostButton = VStack {
+        
+    }
+    
+}
+    
+private struct FavoritesGridGhostButton: View {
+    
+    var body: some View {
+        
+        VStack {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color("HomeFavoritesGhostColor"), style: StrokeStyle(lineWidth: 1.5, dash: [4.0, 2.0]))
                 .frame(width: 64, height: 64)
-        }.frame(width: 64)
-
-        VStack(spacing: 4) {
-
-            ForEach(rowIndices, id: \.self) { index in
-
-                HStack(alignment: .top, spacing: 20) {
-                    ForEach(model.rows[index], id: \.id) { favorite in
-
-                        switch favorite.favoriteType {
-                        case .bookmark(let bookmark):
-                            Favorite(bookmark: bookmark)
-
-                        case .addButton:
-                            addButton
-
-                        case .ghostButton:
-                            ghostButton
-                        }
-                    }
-                }
-                
-            }
-
-            MoreOrLess(isExpanded: $model.showAllFavorites)
-                .padding(.top, 2)
-                .visibility(model.rows.count > HomePage.favoritesRowCountWhenCollapsed && isHovering ? .visible : .invisible)
-
         }
-        .frame(maxWidth: .infinity)
-        .onHover { isHovering in
-            self.isHovering = isHovering
-        }
-
+        .frame(width: 64)
+        
     }
-
+    
 }
 
 struct FavoriteTemplate: View {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1202866210837773/f
Tech Design URL:
CC:

**Description**:

This PR updates the new tab page to use a LazyVStack on macOS 11 and up. This dramatically increases performance for users who have 1000+ bookmarks.

To make this easier, I pulled a couple small custom buttons out into their own views, and then did the same with the main VStack code.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the browser on the new tab page with a large number of bookmarks
1. Verify that scrolling and hovering over items performs well

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
