### PR TITLE
Force bookmark calls to refresh, even when they encounter an error

### DIFF
--- a/DuckDuckGo/Bookmarks/Services/BookmarkStore.swift
+++ b/DuckDuckGo/Bookmarks/Services/BookmarkStore.swift
@@ -202,7 +202,7 @@ final class LocalBookmarkStore: BookmarkStore {
                 try self.context.save()
             } catch {
                 assertionFailure("LocalBookmarkStore: Saving of context failed")
-                DispatchQueue.main.async { completion(false, error) }
+                DispatchQueue.main.async { completion(true, error) }
                 return
             }
 
@@ -232,7 +232,7 @@ final class LocalBookmarkStore: BookmarkStore {
                 try self.context.save()
             } catch {
                 assertionFailure("LocalBookmarkStore: Saving of context failed")
-                DispatchQueue.main.async { completion(false, error) }
+                DispatchQueue.main.async { completion(true, error) }
             }
 
             DispatchQueue.main.async { completion(true, nil) }
@@ -405,7 +405,7 @@ final class LocalBookmarkStore: BookmarkStore {
                     assertionFailure("LocalBookmarkStore: Saving of context failed")
                 }
 
-                DispatchQueue.main.async { completion(false, error) }
+                DispatchQueue.main.async { completion(true, error) }
                 return
             }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1202871164562972/f
Tech Design URL:
CC: @brindy 

**Description**:

It's possible for the bookmarks store to return an error even when the actual save call succeeded, as Core Data can return errors unrelated to the object you're saving. In this case, the caller will not refresh itself, _even_ despite the data actually having successfully changed under the hood.

This PR updates the failure completion handlers to trigger a refresh regardless. There's more work to do here to track when and how failures happen at all, but this will solve the problem that Alex was seeing.

The issue that Alex is seeing is already repaired when you launch the app, but it's not repaired if an error is encountered at runtime. I'd like to fix that, but want to take more time to do it correctly, so I'll prepare another PR next week – this PR will be enough to get around his issue.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Test that bookmark operations work - save a new bookmark, mark one as favourite, etc.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
