### PR TITLE
Ensure that the bookmarks bar recalculates itself correctly after resizing

### DIFF
--- a/DuckDuckGo/Bookmarks Bar/View/BookmarksBarViewController.swift
+++ b/DuckDuckGo/Bookmarks Bar/View/BookmarksBarViewController.swift
@@ -104,8 +104,11 @@ final class BookmarksBarViewController: NSViewController {
     
     @objc
     private func frameChangeNotification() {
-        viewModel.clipOrRestoreBookmarksBarItems()
-        refreshClippedIndicator()
+        // Wait until the frame change has taken effect for subviews before calculating changes to the list of items.
+        DispatchQueue.main.async {
+            self.viewModel.clipOrRestoreBookmarksBarItems()
+            self.refreshClippedIndicator()
+        }
     }
     
     override func removeFromParent() {

--- a/DuckDuckGo/Bookmarks Bar/View/BookmarksBarViewModel.swift
+++ b/DuckDuckGo/Bookmarks Bar/View/BookmarksBarViewModel.swift
@@ -180,13 +180,18 @@ final class BookmarksBarViewModel: NSObject {
         }
 
         if bookmarksBarItemsTotalWidth >= clipThreshold {
-            if clipLastBarItem() {
-                delegate?.bookmarksBarViewModelReloadedData()
+            while bookmarksBarItemsTotalWidth >= clipThreshold {
+                if !clipLastBarItem() {
+                    // Short circuit the while loop in the case that clipping the last item doesn't succeed.
+                    break
+                }
             }
-        } else if let nextRestorableClippedItem = clippedItems.first {
+
+            delegate?.bookmarksBarViewModelReloadedData()
+        } else if !clippedItems.isEmpty {
             var restoredItem = false
 
-            while true {
+            while let nextRestorableClippedItem = clippedItems.first {
                 if !restoreNextClippedItemToBookmarksBarIfPossible(item: nextRestorableClippedItem) {
                     break
                 }
@@ -223,11 +228,11 @@ final class BookmarksBarViewModel: NSObject {
             textSizeCalculationLabel.stringValue = buttonTitle
             textSizeCalculationLabel.sizeToFit()
 
-            let cappedTitleWidth = min(Constants.maximumButtonWidth, textSizeCalculationLabel.frame.width)
+            let cappedTitleWidth = ceil(min(Constants.maximumButtonWidth, textSizeCalculationLabel.frame.width))
             let calculatedWidth = min(Constants.maximumButtonWidth, textSizeCalculationLabel.frame.width) + Constants.additionalItemWidth
             collectionViewItemSizeCache[buttonTitle] = cappedTitleWidth
             
-            return calculatedWidth
+            return ceil(calculatedWidth)
         }
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202798453559093/f
Tech Design URL:
CC:

**Description**:

This PR fixes some calculations used to determine how many items should render in the bookmarks bar. Two issues were fixed:

1. The collection view size that is used to determine how many items to show was wrong after entering full screen; it seems like a timing issue. I ended up falling back to our old friend `DispatchQueue.main.async` to ensure that views had finished their layout in response to entering full screen. It's not a perfect approach, but much improved.
2. The calculation used to determine how many items to clip when shrinking the window was wrong in two ways: first, it only clipped the last item, so if the view resized such that two items should have been clipped, only one would have been. Second, it wasn't using the correct item titles when determining the width of the item to clip... this was just a straight up oversight. 🙂 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Add enough bookmarks to fill the width of your display
1. Enter full screen, check that it updates after entering full screen to fill the bookmarks bar
1. Exit full screen, check that no items overflow outside the width of the window
1. Resize the window manually and make sure that items clip or restore as expected. Additionally, test with a smaller set of bookmarks that doesn't always fill the screen to ensure that that case works well also. (And even with zero bookmarks.)

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
