### PR TITLE
Fire a pixel when WebKit terminates

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -1429,6 +1429,10 @@ extension Tab: WKNavigationDelegate {
         guard frame.isMainFrame else { return }
         self.mainFrameLoadState = .finished
     }
+    
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        Pixel.fire(.debug(event: .webKitDidTerminate))
+    }
 
 }
 // universal download event handlers for Legacy _WKDownload and modern WKDownload

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -230,6 +230,8 @@ extension Pixel {
             case adAttributionLogicRequestingAttributionTimedOut
             case adAttributionLogicWrongVendorOnSuccessfulCompilation
             case adAttributionLogicWrongVendorOnFailedCompilation
+            
+            case webKitDidTerminate
         }
 
     }
@@ -513,6 +515,9 @@ extension Pixel.Event.Debug {
             return "ad_attribution_logic_wrong_vendor_on_successful_compilation"
         case .adAttributionLogicWrongVendorOnFailedCompilation:
             return "ad_attribution_logic_wrong_vendor_on_failed_compilation"
+            
+        case .webKitDidTerminate:
+            return "webkit_did_terminate"
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1203044296270964/f
Tech Design URL:
CC:

**Description**:

This PR adds conformance to WebKit's [`webViewWebContentProcessDidTerminate(_:)`](https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455639-webviewwebcontentprocessdidtermi) method and uses it to fire a pixel.

I'll add a graph for this pixel to the problem indicators once it has been merged.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Unfortunately, I don't know of a way to trigger WebKit termination. This PR matches [the iOS implementation](https://github.com/duckduckgo/iOS/blob/develop/DuckDuckGo/TabViewController.swift#L2038), which we do know to function correctly and send pixel data. To verify this PR, check that the function name matches the protocol exactly.

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs
* [x] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
