### PR TITLE
Set useCapture in contextmenu listener to fix opening links on foxnews.com

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/ContextMenuUserScript.swift
+++ b/DuckDuckGo/Browser Tab/Model/ContextMenuUserScript.swift
@@ -136,7 +136,7 @@ final class ContextMenuUserScript: NSObject, StaticUserScript {
         }
 
         webkit.messageHandlers.contextMenu.postMessage(context);
-    });
+    }, true);
 
 }) ();
 """


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/569473074191537/1203021366422403/f

**Description**:
As suggested by @jonathanKingston, set `useCapture` flag on the `contextmenu` listener.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Go to foxnews.com
1. Right click on any link
1. Verify that "Open Link in New Tab" and "Open Link in New Window" actions work as expected.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
