### PR TITLE
Don't store settings URLs in history

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -776,8 +776,6 @@ final class Tab: NSObject, Identifiable, ObservableObject {
             return
         }
 
-        guard url != .homePage else { return }
-
         // Add to global history
         historyCoordinating.addVisit(of: url)
 
@@ -1180,7 +1178,7 @@ extension Tab: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         isBeingRedirected = false
-        if let url = webView.url {
+        if content.isUrl, let url = webView.url {
             addVisit(of: url)
         }
         webViewDidCommitNavigationPublisher.send()

--- a/DuckDuckGo/Browser Tab/ViewModel/WebViewStateObserver.swift
+++ b/DuckDuckGo/Browser Tab/ViewModel/WebViewStateObserver.swift
@@ -108,10 +108,12 @@ final class WebViewStateObserver: NSObject {
 
     private func handleURLChange(in webView: WKWebView, tabViewModel: TabViewModel) {
         if let url = webView.url {
-            if !webView.isLoading {
+            let content = Tab.TabContent.contentFromURL(url)
+
+            if content.isUrl, !webView.isLoading {
                 tabViewModel.tab.addVisit(of: url)
             }
-            tabViewModel.tab.setContent(.contentFromURL(url))
+            tabViewModel.tab.setContent(content)
         }
         updateTitle() // The title might not change if webView doesn't think anything is different so update title here as well
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1203129899119665/f

**Description**:
Store visits only for tabs with `isURL` content (ie. urls and private player).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open Duck Player (go to youtube.com, click on a video, click on Watch in Duck Player)
1. Click the gear (Settings) icon
1. Verify that Duck Player Settings page opens, and that `about:preferences/duckplayer` is not added to history (e.g. via History menu).
1. Verify that regular URLs are stored in History as usual.

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs
* [x] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
