### PR TITLE
shane/webkit-handler-names

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -6281,8 +6281,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "shane/webkit-handler-names";
-				kind = branch;
+				kind = exactVersion;
+				version = 32.1.0;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198964220583541/1203132186153126/f

**Description**:
Exposes webkit handler names to Autofill UserScripts


**Steps to test this PR**:
1. Autofill works as normal on macOS catalina
1. Autofill works as normal on macOS > catalina

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
