### PR TITLE
POC implement locale on macos

### DIFF
--- a/DuckDuckGo/Privacy Dashboard/Model/PrivacyDashboardUserScript.swift
+++ b/DuckDuckGo/Privacy Dashboard/Model/PrivacyDashboardUserScript.swift
@@ -210,6 +210,19 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
         evaluate(js: "window.onChangeProtectionStatus(\(protectionStatusJson))", in: webView)
     }
 
+    struct LocaleSettings: Encodable {
+        let locale: String
+    }
+
+    func setLocale(_ locale: String, webView: WKWebView) {
+        let locale = LocaleSettings(locale: locale);
+        guard let localSettingsJson = try? JSONEncoder().encode(locale).utf8String() else {
+            assertionFailure("Can't encode LocaleSettings into JSON")
+            return
+        }
+        evaluate(js: "window.onChangeLocale(\(localSettingsJson))", in: webView)
+    }
+
     func setUpgradedHttps(_ upgradedHttps: Bool, webView: WKWebView) {
         evaluate(js: "window.onChangeUpgradedHttps(\(upgradedHttps))", in: webView)
     }

--- a/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
@@ -180,6 +180,11 @@ final class PrivacyDashboardViewController: NSViewController {
         self.privacyDashboardScript.setProtectionStatus(protectionStatus, webView: self.webView)
     }
 
+    private func sendLocale() {
+        let locale = Locale.current.languageCode ?? "en";
+        self.privacyDashboardScript.setLocale(locale, webView: self.webView)
+    }
+
     private func sendPendingUpdates() {
         guard let domain = tabViewModel?.tab.content.url?.host else {
             assertionFailure("PrivacyDashboardViewController: no domain available")
@@ -294,6 +299,7 @@ extension PrivacyDashboardViewController: WKNavigationDelegate {
         subscribeToConnectionUpgradedTo()
         subscribeToServerTrust()
         sendProtectionStatus()
+        sendLocale()
         sendPendingUpdates()
         sendParentEntity()
         subscribeToConsentManaged()


### PR DESCRIPTION
I put this together to save you some time, I wasn't sure where you wanted to store the locale, or if you even want to communicate it yet.

Either way this works again the latest privacy dashboard on `main`, I hope it helps :)

relevant docs https://duckduckgo.github.io/privacy-dashboard/example/docs/functions/macOS_integration.onChangeLocale.html