### PR TITLE
Fix issue with fullscreen playback

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -228,6 +228,7 @@ final class Tab: NSObject, Identifiable, ObservableObject {
         }
         webView.stopLoading()
         webView.stopMediaCapture()
+        webView.stopAllMediaPlayback()
         webView.fullscreenWindowController?.close()
         userContentController.removeAllUserScripts()
 

--- a/DuckDuckGo/Common/Extensions/WKWebView+Private.h
+++ b/DuckDuckGo/Common/Extensions/WKWebView+Private.h
@@ -54,7 +54,7 @@ typedef NS_OPTIONS(NSUInteger, _WKCaptureDevices) {
 - (void)setMicrophoneCaptureState:(WKMediaCaptureState)state completionHandler:(void (^)(void))completionHandler API_AVAILABLE(macos(12.0), ios(15.0));
 - (void)setCameraCaptureState:(WKMediaCaptureState)state completionHandler:(void (^)(void))completionHandler API_AVAILABLE(macos(12.0), ios(15.0));
 - (void)_stopMediaCapture;
-
+- (void)_stopAllMediaPlayback;
 - (_WKMediaMutedState)_mediaMutedState;
 - (void)_setPageMuted:(_WKMediaMutedState)mutedState;
 

--- a/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
+++ b/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
@@ -126,7 +126,15 @@ extension WKWebView {
         }
         self._stopMediaCapture()
     }
-
+    
+    func stopAllMediaPlayback() {
+        guard self.responds(to: #selector(_stopAllMediaPlayback)) else {
+            assertionFailure("WKWebView does not respond to _stopAllMediaPlayback")
+            return
+        }
+        self._stopAllMediaPlayback()
+    }
+    
     func setPermissions(_ permissions: [PermissionType], muted: Bool) {
         for permission in permissions {
             switch permission {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202777389422475/f

**Description**:
Stop all media playback when tab is closed

**Steps to test this PR**:

1. Play a video which has sound (YouTube and Twitter videos both work)
2. Make video fullscreen
3. Press cmd+W to close the tab

----

1. Play a video which has sound (YouTube and Twitter videos both work)
2. Make video fullscreen
3. Go back to the browser
4. Select another tab
5. Close the tab that is playing the fullscreen content

----- 

1. Play a video which has sound (YouTube and Twitter videos both work)
2. Press cmd+W to close the tab


**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
