### PR TITLE
Fix tooltip on short screens

### DIFF
--- a/DuckDuckGo/Youtube Player/Resources/youtube_player_template.html
+++ b/DuckDuckGo/Youtube Player/Resources/youtube_player_template.html
@@ -905,16 +905,16 @@
                     let icon = Tooltip.icon()
                     let rect = icon && icon.getBoundingClientRect();
 
-                    if (rect && rect.top) {
-                        let iconTop = rect.top + window.pageYOffset;
-                        let spaceBelowIcon = window.innerHeight - iconTop;
-
-                        if (spaceBelowIcon < 125) {
-                            return true;
-                        }
+                    if (!rect || !rect.top) {
+                        return false;
                     }
 
-                    return false;
+                    let iconTop = rect.top + window.scrollY;
+                    let spaceBelowIcon = window.innerHeight - iconTop;
+
+                    if (spaceBelowIcon < 125) {
+                        return true;
+                    }
                 },
 
                 /**


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/970019368605465/1203143483845415

**Description**:
Positions the Duck Player tooltip above the icon, when user has a short screen.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open Duck Player in a large window
2. Hover the tooltip. Make sure it displays **below** the icon
3. Resize the window height to a short screen (for example, window height 500px)
4. Hover the tooltip. Make sure it displays **above** the icon
5. Resize again to a large window.
6. Hover the tooltip. Make sure it displays **below** the icon


**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
