### PR TITLE
update internal user agent to be consistent

### DIFF
--- a/DuckDuckGo/User Agent/Model/UserAgent.swift
+++ b/DuckDuckGo/User Agent/Model/UserAgent.swift
@@ -70,7 +70,7 @@ enum UserAgent {
     static func duckDuckGoUserAgent(appVersion: String = AppVersion.shared.versionNumber,
                                     appID: String = AppVersion.shared.identifier,
                                     systemVersion: String = ProcessInfo.processInfo.operatingSystemVersionString) -> String {
-        return "ddg_macos/\(appVersion) (\(appID); macOS \(systemVersion))"
+        return "ddg_mac/\(appVersion) (\(appID); macOS \(systemVersion))"
     }
 
     static func `for`(_ url: URL?) -> String {

--- a/Unit Tests/User Agent/Model/UserAgentTests.swift
+++ b/Unit Tests/User Agent/Model/UserAgentTests.swift
@@ -45,7 +45,7 @@ final class UserAgentTests: XCTestCase {
         let systemVersion = "system_version"
         let userAgent = UserAgent.duckDuckGoUserAgent(appVersion: appVersion, appID: appID, systemVersion: systemVersion)
         
-        XCTAssertEqual(userAgent, "ddg_macos/\(appVersion) (\(appID); macOS \(systemVersion))")
+        XCTAssertEqual(userAgent, "ddg_mac/\(appVersion) (\(appID); macOS \(systemVersion))")
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
* https://app.asana.com/0/1177771139624306/1203151745887797/f
* https://app.asana.com/0/1199230911884351/1203141842727102/f

Tech Design URL:
CC:

**Description**:

Simple change to rationalise our internal user agent.

**Steps to test this PR**:
1. Check that suggestions and configuration downloading use a user agent that starts with ddg_mac NOT ddg_macos
3. Check existing API calls (ATB, Pixels, etc) still use ddg_mac

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
