### PR TITLE
Fix permission icon overlap

### DIFF
--- a/DuckDuckGo/Navigation Bar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/Navigation Bar/View/AddressBarButtonsViewController.swift
@@ -620,20 +620,24 @@ final class AddressBarButtonsViewController: NSViewController {
         }
 
         guard let selectedTabViewModel = tabCollectionViewModel.selectedTabViewModel else { return }
+        
+        if controllerMode == .editing(isUrl: false) {
+            [geolocationButton, cameraButton, microphoneButton, popupsButton, externalSchemeButton].forEach {
+                $0?.buttonState = .none
+            }
+        } else {
+            geolocationButton.buttonState = selectedTabViewModel.usedPermissions.geolocation
 
-        geolocationButton.buttonState = selectedTabViewModel.usedPermissions.geolocation
+            let (camera, microphone) = PermissionState?.combineCamera(selectedTabViewModel.usedPermissions.camera,
+                                                                      withMicrophone: selectedTabViewModel.usedPermissions.microphone)
+            cameraButton.buttonState = camera
+            microphoneButton.buttonState = microphone
 
-        let (camera, microphone) = PermissionState?.combineCamera(selectedTabViewModel.usedPermissions.camera,
-                                                                  withMicrophone: selectedTabViewModel.usedPermissions.microphone)
-        cameraButton.buttonState = camera
-        microphoneButton.buttonState = microphone
-
-        popupsButton.buttonState = selectedTabViewModel.usedPermissions.popups?.isRequested == true // show only when there're popups blocked
-            ? selectedTabViewModel.usedPermissions.popups
-            : nil
-        externalSchemeButton.buttonState = selectedTabViewModel.usedPermissions.externalScheme
-
-        showOrHidePermissionPopoverIfNeeded()
+            popupsButton.buttonState = selectedTabViewModel.usedPermissions.popups?.isRequested == true // show only when there're popups blocked
+                ? selectedTabViewModel.usedPermissions.popups
+                : nil
+            externalSchemeButton.buttonState = selectedTabViewModel.usedPermissions.externalScheme
+        }
     }
 
     private func showOrHidePermissionPopoverIfNeeded() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202676418340779/f

**Description**:
Fix permission icons overlap with ghost text in the address bar

**Steps to test this PR**:
(Images examples in the Asana task)
1. Go to a site that uses location (e.g. [homedepot.com](https://homedepot.com/))
2. Focus address bar, clear out all text
3. Click someplace else on the toolbar to remove focus from address bar

----
1. Test other permissions like microphone ( https://online-voice-recorder.com/ )

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
