### PR TITLE
Bug: Privacy Dashboard inaccessible after being dismissed during rules recompilation

### DIFF
--- a/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/Privacy Dashboard/View/PrivacyDashboardViewController.swift
@@ -63,7 +63,7 @@ final class PrivacyDashboardViewController: NSViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] tokens in
                 dispatchPrecondition(condition: .onQueue(.main))
-                guard let self = self else { return }
+                guard let self = self, !self.pendingUpdates.isEmpty else { return }
 
                 var didUpdate = false
                 for token in tokens {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202821817932095/f

**Description**:

We have some internal state, `pendingUpdates`, where we recorded completion tokens
following a click on 'toggle protections' in the dashboard.

We added an entry to this dictionary when the button is clicked -> this is how we determined
`isPendingUpdates`. A none-empty dictionary means we've performed an action, but we haven't
received confirmation that it was successful.

When we observe an event from `userContentBlockingAssets`, we look at our internal state
and remove the entry if it matches: this works fine if you stay on the **same tab**.

There's a 🐛 though: the dashboard's webview can be dismissed **before** the completion event
is observed if you switch tabs quickly enough -> this cancels all subscriptions and we don't get
a chance to remove the completion token from our own internal state (because we never 'see'
the event telling us it was successful 😭😭😭).

We end up in a 🧟  zombie state 🧟  with a token being stored internally (which causes
`isPendingUpdates` to always be `true`) and therefore we don't allow the dashboard to be opened
on subsequent clicks, until the app is restarted.

This change ties rules recompilation subscription to the lifetime of Privacy Dashboard
(and not its current tabViewModel), so that rules recompilation completion can be properly
handled even when PD popover has been dismissed).

**Steps to test this PR**:
1. Open 2 tabs.
1. Show Privacy Dashboard on one tab.
1. Disable protections and quickly switch to another tab (this will cause PD popover to close)
1. Quickly try opening dashboard on that tab.
1. Verify that dashboard can't be opened while rules are being recompiled.
1. Verify that after rules recompilation completes, the other tab (now inactive) reloads.
1. Verify that after rules recompilation completes, you're able to open Privacy Dashboard in another tab.
1. Go back to the original tab and verify that Privacy Dashboard can be opened.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
