### PR TITLE
Fix IconOverlays performance regression

### DIFF
--- a/DuckDuckGo/Youtube Player/Resources/youtube-inject-bundle.js
+++ b/DuckDuckGo/Youtube Player/Resources/youtube-inject-bundle.js
@@ -838,6 +838,7 @@
         }
       };
       const VideoThumbnail = {
+        hoverBoundElements: /* @__PURE__ */ new WeakMap(),
         isSingleVideoURL: (href) => {
           return href && (href.includes("/watch?v=") && !href.includes("&list=") || href.includes("/watch?v=") && href.includes("&list=") && href.includes("&index=")) && !href.includes("&pp=");
         },
@@ -856,7 +857,10 @@
             let linksInVideoPreview = Array.from(document.querySelectorAll("#preview a"));
             return linksInVideoPreview.indexOf(item) === -1;
           };
-          return Array.from(document.querySelectorAll('a[href^="/watch?v="]')).filter(linksToVideos).filter(linksWithoutSubLinks).filter(linksNotInVideoPreview).filter(linksWithImages);
+          const linksNotAlreadyBound = (item) => {
+            return !VideoThumbnail.hoverBoundElements.has(item);
+          };
+          return Array.from(document.querySelectorAll('a[href^="/watch?v="]')).filter(linksNotAlreadyBound).filter(linksToVideos).filter(linksWithoutSubLinks).filter(linksNotInVideoPreview).filter(linksWithImages);
         },
         bindEvents: (video) => {
           if (video) {
@@ -864,6 +868,7 @@
               IconOverlay.moveHoverOverlayToVideoElement(video);
             });
             addTrustedEventListener(video, "mouseout", IconOverlay.hideHoverOverlay);
+            VideoThumbnail.hoverBoundElements.set(video, true);
           }
         },
         bindEventsToAll: () => {

--- a/js/youtube-player/youtube-inject.js
+++ b/js/youtube-player/youtube-inject.js
@@ -90,6 +90,8 @@ function initWithEnvironment(environment, comms) {
         }
 
         const VideoThumbnail = {
+            hoverBoundElements: new WeakMap(),
+
             isSingleVideoURL: (href) => {
                 return href && (
                     (href.includes('/watch?v=') && !href.includes('&list=')) ||
@@ -121,7 +123,12 @@ function initWithEnvironment(environment, comms) {
                     return linksInVideoPreview.indexOf(item) === -1;
                 }
 
+                const linksNotAlreadyBound = item => {
+                    return !VideoThumbnail.hoverBoundElements.has(item);
+                }
+
                 return Array.from(document.querySelectorAll('a[href^="/watch?v="]'))
+                    .filter(linksNotAlreadyBound)
                     .filter(linksToVideos)
                     .filter(linksWithoutSubLinks)
                     .filter(linksNotInVideoPreview)
@@ -139,6 +146,8 @@ function initWithEnvironment(environment, comms) {
                     });
 
                     addTrustedEventListener(video, 'mouseout', IconOverlay.hideHoverOverlay);
+
+                    VideoThumbnail.hoverBoundElements.set(video, true);
                 }
             },
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/970019368605465/1203189525414524
Tech Design URL:
CC:

**Description**:
Fixes regression where we accidentally bind `moveHoverOverlay` multiple times to the same video thumbnail

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
