### PR TITLE
Respect user setting for automatically hiding menu bar in full screen

### DIFF
--- a/DuckDuckGo/Main/View/MainWindowController.swift
+++ b/DuckDuckGo/Main/View/MainWindowController.swift
@@ -192,11 +192,6 @@ final class MainWindowController: NSWindowController {
 
 extension MainWindowController: NSWindowDelegate {
 
-    func window(_ window: NSWindow,
-                willUseFullScreenPresentationOptions: NSApplication.PresentationOptions) -> NSApplication.PresentationOptions {
-        return [.fullScreen, .autoHideMenuBar]
-    }
-
     func windowDidBecomeKey(_ notification: Notification) {
         mainViewController.windowDidBecomeMain()
         mainViewController.navigationBarViewController.windowDidBecomeMain()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202141914944248/f

**Description**:
Respect user setting for automatically hiding menu bar in full screen

**Steps to test this PR**:
1. Open settings and go to Dock & Menu Bar
2. Check if both options are off under Menu bar
3. Run the app in fullscreen and confirm the status bar is **not** automatically hidden

----
1. Open settings and go to Dock & Menu Bar
2. Check  "Automatically hide and show the menu bar in fullscreen"  to make it on under Menu bar
3. Run the app in fullscreen and confirm the status bar is automatically hidden

ps. You need to leave fullscreen and re-enter fullscreen for the settings to have an effect

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
