### PR TITLE
Fix archive script cert team_id env setup

### DIFF
--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -105,7 +105,7 @@ create_dmg_preflight() {
 set_up_environment() {
 	workdir="${PWD}/release"
 	archive="${workdir}/DuckDuckGo.xcarchive"
-	team_id=$(security find-certificate -c "Developer ID Application:" | grep "alis" | awk 'NF { print $NF }' | tr -d \(\)\")
+	team_id=$(security find-certificate -c "Developer ID Application: Duck" | grep "alis" | awk 'NF { print $NF }' | tr -d \(\)\")
 
 	if [[ -z $CI ]]; then
 		export_options_plist="${cwd}/assets/ExportOptions.plist"


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

**Description**:
Fix issue where the archive.sh script was using the wrong team_id in case you have more than one developer cert in your machine.


**Steps to test this PR**:
1. Run the `./scripts/archive.sh review` script and check if it's working as expected.


###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
