### PR TITLE
Update BSK with autofill 0.0.1_test

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -6292,8 +6292,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 33.0.0;
+				kind = revision;
+				revision = 263273a81ac8880f5788d496c8b602172316f7bc;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
**Task/Issue URL:** 
**Autofill Release:** https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.1_test
**BSK PR:** https://github.com/duckduckgo/BrowserServicesKit/pull/161

## Description
Updates Autofill to version [0.0.1_test](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.1_test).

### Autofill 0.0.1_test release notes
A brand new test release.

- With bullet
- Points!

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).