### PR TITLE
Fix wrong selector sent when Close Tab menu item is selected

### DIFF
--- a/DuckDuckGo/Tab Bar/View/TabBarViewItem.swift
+++ b/DuckDuckGo/Tab Bar/View/TabBarViewItem.swift
@@ -175,12 +175,12 @@ final class TabBarViewItem: NSCollectionViewItem {
 
     private var lastKnownIndexPath: IndexPath?
 
-    @IBAction func closeButtonAction(_ sender: NSButton) {
+    @IBAction func closeButtonAction(_ sender: Any) {
         // due to async nature of NSCollectionView views removal
         // leaving window._lastLeftHit set to the button will prevent
         // continuous clicks on the Close button
         // this should be removed when the Tab Bar is redone without NSCollectionView
-        sender.window?.evilHackToClearLastLeftHitInWindow()
+        (sender as? NSButton)?.window?.evilHackToClearLastLeftHitInWindow()
 
         guard let indexPath = self.collectionView?.indexPath(for: self) else {
             // doubleclick event arrived at point when we're already removed


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1202049975066624/f
CC: @tomasstrba 

**Description**:
Fix exception fired when a Tab is closed using context menu Close Tab item caused by sender being an NSMenuItem instead of the close button

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate Right Click Tab->Close Tab doesn‘t fire exception
2. Validate quick closing tabs works


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
