### PR TITLE
Fixes a freeze on quit due to a completion callback never being called

### DIFF
--- a/DuckDuckGo/Statistics/RulesCompilationMonitor.swift
+++ b/DuckDuckGo/Statistics/RulesCompilationMonitor.swift
@@ -57,6 +57,7 @@ final class AbstractContentBlockingAssetsCompilationTimeReporter<Caller: Hashabl
     private func report(waitTime: TimeInterval, result: Pixel.Event.WaitResult, completionHandler: @escaping ((Error?) -> Void) = { _ in }) {
         // report only once
         isFinished = true
+        completionHandler(nil)
         
         /**
         This is temporarily disabled:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203276203211603/f
Tech Design URL:
CC:

## Description:

Fixes a freeze that can be triggered when the quitting.

This method was never calling the completion callback:

https://github.com/more-duckduckgo-org/macos-browser/blob/9b2de05fa68e863f1862f8fc79a61465b671395b/DuckDuckGo/Statistics/RulesCompilationMonitor.swift#L57-L68

Which was causing the App termination to freeze here, because the completion callback was never run:

https://github.com/more-duckduckgo-org/macos-browser/blob/9b2de05fa68e863f1862f8fc79a61465b671395b/DuckDuckGo/Statistics/RulesCompilationMonitor.swift#L93-L103

There's space to improve this more by just removing the unused code, but that could delay the fix, so this PR aims to offer the quickest and simplest fix to ensure we can merge it and know the application won't freeze.

## Testing:

The easiest way to test this is to artificially reproduce the conditions that make the crash trigger.

1. Remove the first two conditions from the guard:

https://github.com/more-duckduckgo-org/macos-browser/blob/9b2de05fa68e863f1862f8fc79a61465b671395b/DuckDuckGo/Statistics/RulesCompilationMonitor.swift#L94-L95

3. Run the application.
4. Quit.

Make sure that the application doesn't freeze (or that it does freeze if you're testing this in `develop`).

### Testing checklist:

* [ ] Test with Release configuration
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
