### PR TITLE
Update BSK with autofill 0.0.2_test

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -6292,8 +6292,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 33.1.0;
+				kind = revision;
+				revision = 3a7db436a7d6652a9a2037d5be6dfd91dece128c;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
**Task/Issue URL:** https://app.asana.com/0/1203285453324495/1203285453324495
**Autofill Release:** https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.2_test
**BSK PR:** https://github.com/duckduckgo/BrowserServicesKit/pull/162

## Description
Updates Autofill to version [0.0.2_test](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.2_test).

### Autofill 0.0.2_test release notes
A new test release. Hopefully the last for this cycle 🙂.

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).