### PR TITLE
Update the Autofill tooltip to use the correct appearance

### DIFF
--- a/DuckDuckGo/Autofill/ContentOverlayViewController.swift
+++ b/DuckDuckGo/Autofill/ContentOverlayViewController.swift
@@ -47,7 +47,6 @@ public final class ContentOverlayViewController: NSViewController, EmailManagerR
         addTrackingArea()
 
         appearanceCancellable = NSApp.publisher(for: \.effectiveAppearance).map { $0 as NSAppearance? }.sink { [weak self] appearance in
-            print("DEBUG: Got new appearance \(appearance)")
             self?.webView.appearance = appearance
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1202734293280990/f
Tech Design URL:
CC:

**Description**:

This PR updates the Autofill web view to inherit the app's appearance. This is something that should happen by default, but something about the view hierarchy was preventing it from happening. Now the appearance is set explicitly when the tooltip appears.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. This isn't straightforward to test since the webview isn't doing anything with the appearance yet. I ended up hardcoding the tooltip to load a Codepen that shows information about the browser's appearance support; you can copy the code block below, put it into a file named `appearance_testing.patch`, and then run `git apply appearance_testing.patch` to apply it. Then just visit a page that presents an Autofill form, and you should get an Autofill overlay that loads the Codepen showing the correct appearance information. Change the system/browser theme to test it.

```
diff --git a/DuckDuckGo/Autofill/ContentOverlayViewController.swift b/DuckDuckGo/Autofill/ContentOverlayViewController.swift
index ace7242d..ad731008 100644
--- a/DuckDuckGo/Autofill/ContentOverlayViewController.swift
+++ b/DuckDuckGo/Autofill/ContentOverlayViewController.swift
@@ -83,7 +83,9 @@ public final class ContentOverlayViewController: NSViewController, EmailManagerR

         let url = Autofill.bundle.url(forResource: "assets/TopAutofill", withExtension: "html")
         if let url = url {
-            webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+            // webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+            let testURL = URL(string: "https://codepen.io/kleinfreund/pen/NmpKZM")!
+            webView.load(testURL)
             return
         }
     }
@@ -191,8 +193,8 @@ public final class ContentOverlayViewController: NSViewController, EmailManagerR
     }

     private enum Constants {
-        static let minWidth: CGFloat = 315
-        static let minHeight: CGFloat = 56
+        static let minWidth: CGFloat = 1280
+        static let minHeight: CGFloat = 800
     }

     public func requestResizeToSize(_ size: CGSize) {
@@ -210,7 +212,7 @@ public final class ContentOverlayViewController: NSViewController, EmailManagerR

 extension ContentOverlayViewController: OverlayAutofillUserScriptPresentationDelegate {
     public func overlayAutofillUserScript(_ overlayAutofillUserScript: OverlayAutofillUserScript, requestResizeToSize: CGSize) {
-        self.requestResizeToSize(requestResizeToSize)
+        self.requestResizeToSize(CGSize(width: 1280, height: 800))
     }
 }
```

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
