### PR TITLE
bring the updater window to the front if already open

### DIFF
--- a/DuckDuckGo/App Delegate/UpdateController.swift
+++ b/DuckDuckGo/App Delegate/UpdateController.swift
@@ -32,6 +32,13 @@ final class UpdateController: NSObject {
     }
 
     func checkForUpdates(_ sender: Any!) {
+        NSApp.windows.forEach {
+            if let controller = $0.windowController, "\(type(of: controller))" == "SUUpdateAlert" {
+                $0.orderFrontRegardless()
+                $0.makeKey()
+                $0.makeMain()
+            }
+        }
         updater.checkForUpdates(sender)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203287845619834/f
Tech Design URL:
CC:

**Description**:
If the updater is *already* open, then bring it to the front when the user selects check for updates and it's already there. 

**Steps to test this PR**:
1. Set the browser version to something older
1. Launch the app and check for updates
1. Bring the browser to the front without closing the updater
1. Check for updates and the window should come to the front automatically

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
