### PR TITLE
Bump ssh-agent version to a Node-16 based version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         cp $REVIEW_PP_PATH $RELEASE_PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
     - name: Register SSH keys for submodules access
-      uses: webfactory/ssh-agent@v0.5.4
+      uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FIND_IN_PAGE }}


### PR DESCRIPTION
Task/Issue URL: N/A

**Description**:
Bump ssh-agent GHA action from a deprecated version.

More info: https://github.com/webfactory/ssh-agent/releases/tag/v0.6.0

**Steps to test this PR**:
1. Run a "Make release build" workflow from this branch and verify that it completes successfully.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
