### PR TITLE
Fix burning Duck Player entries

### DIFF
--- a/DuckDuckGo/Home Page/Model/HomePageRecentlyVisitedModel.swift
+++ b/DuckDuckGo/Home Page/Model/HomePageRecentlyVisitedModel.swift
@@ -156,14 +156,23 @@ final class RecentlyVisitedSiteModel: ObservableObject {
     let maxPageListSize = 10
 
     let domain: String
-    
+
     var url: URL? {
         return baseURL ?? domain.url
     }
+
+    var domainToDisplay: String {
+        domainPlaceholder ?? domain
+    }
+
+    var isRealDomain: Bool {
+        domainPlaceholder == nil
+    }
     
     private let baseURL: URL?
+    private let domainPlaceholder: String?
+    private let privatePlayer: PrivatePlayer
 
-    @Published var isRealDomain: Bool = true
     @Published var isFavorite: Bool
     @Published var isFireproof: Bool
     @Published var blockedEntities = [String]()
@@ -177,18 +186,17 @@ final class RecentlyVisitedSiteModel: ObservableObject {
 
     init?(originalURL: URL,
           bookmarkManager: BookmarkManager = LocalBookmarkManager.shared,
-          fireproofDomains: FireproofDomains = FireproofDomains.shared) {
+          fireproofDomains: FireproofDomains = FireproofDomains.shared,
+          privatePlayer: PrivatePlayer = PrivatePlayer.shared) {
         guard let domain = originalURL.host?.droppingWwwPrefix() else {
             return nil
         }
 
-        if let privatePlayer = PrivatePlayer.shared.domainForRecentlyVisitedSite(with: originalURL) {
-            self.domain = privatePlayer
-            isRealDomain = false
-        } else {
-            self.domain = domain
-        }
-        
+        self.privatePlayer = privatePlayer
+
+        self.domain = domain
+        self.domainPlaceholder = privatePlayer.domainForRecentlyVisitedSite(with: originalURL)
+
         var components = URLComponents()
         components.scheme = originalURL.scheme
         components.host = originalURL.host
@@ -237,7 +245,7 @@ final class RecentlyVisitedSiteModel: ObservableObject {
                     urlsToRemove.append($0.url)
                 }
 
-            } else if let displayTitle = PrivatePlayer.shared.title(for: $0) {
+            } else if let displayTitle = privatePlayer.title(for: $0) {
 
                 $0.displayTitle = displayTitle
 

--- a/DuckDuckGo/Home Page/View/RecentlyVisitedView.swift
+++ b/DuckDuckGo/Home Page/View/RecentlyVisitedView.swift
@@ -120,12 +120,12 @@ struct RecentlyVisitedSite: View {
                 VStack(alignment: .leading, spacing: 6) {
 
                     if site.isRealDomain {
-                        HyperLink(site.domain, textColor: Color("HomeFeedItemTitleColor")) {
+                        HyperLink(site.domainToDisplay, textColor: Color("HomeFeedItemTitleColor")) {
                             model.open(site)
                         }
                         .font(.system(size: 15, weight: .semibold, design: .default))
                     } else {
-                        Text(site.domain)
+                        Text(site.domainToDisplay)
                             .foregroundColor(Color("HomeFeedItemTitleColor"))
                             .font(.system(size: 15, weight: .semibold, design: .default))
                     }
@@ -381,7 +381,7 @@ struct SiteIconAndConnector: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(isHovering ? mouseOverColor : backgroundColor)
 
-            FaviconView(domain: site.domain, size: 22)
+            FaviconView(domain: site.domainToDisplay, size: 22)
         }
         .link {
             self.isHovering = $0
@@ -403,7 +403,7 @@ struct SiteIconAndConnector: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(backgroundColor)
 
-            FaviconView(domain: site.domain, size: 22)
+            FaviconView(domain: site.domainToDisplay, size: 22)
         }
         .frame(width: 32, height: 32)
     }

--- a/Unit Tests/Home Page/RecentlyVisitedSiteModelTests.swift
+++ b/Unit Tests/Home Page/RecentlyVisitedSiteModelTests.swift
@@ -38,10 +38,35 @@ class RecentlyVisitedSiteModelTests: XCTestCase {
         assertModelWithURL(URL(string: "http://www.example.com")!, matches: URL(string: "http://www.example.com")!, expectedDomain: "example.com")
     }
 
+    func testWhenPrivatePlayerIsEnabled_ThenPrivatePlayerURLSetsDomainPlaceholder() {
+        let model = HomePage.Models.RecentlyVisitedSiteModel(
+            originalURL: .effectivePrivatePlayer("abcde12345"),
+            privatePlayer: .mock(withMode: .enabled)
+        )
+        XCTAssertEqual(model?.isRealDomain, false)
+        XCTAssertEqual(model?.domainToDisplay, PrivatePlayer.commonName)
+    }
+
+    func testWhenPrivatePlayerIsDisabled_ThenPrivatePlayerURLDoesNotSetDomainPlaceholder() {
+        let url = URL.effectivePrivatePlayer("abcde12345")
+        let model = HomePage.Models.RecentlyVisitedSiteModel(originalURL: url, privatePlayer: .mock(withMode: .disabled))
+        XCTAssertEqual(model?.isRealDomain, true)
+        XCTAssertEqual(model?.domainToDisplay, model?.domain)
+    }
+
     private func assertModelWithURL(_ url: URL, matches expectedURL: URL, expectedDomain: String) {
         let model = HomePage.Models.RecentlyVisitedSiteModel(originalURL: url)
+        XCTAssertEqual(model?.isRealDomain, true)
         XCTAssertEqual(model?.domain, expectedDomain)
         XCTAssertEqual(model?.url, expectedURL)
     }
+}
 
+private extension PrivatePlayer {
+
+    static func mock(withMode mode: PrivatePlayerMode = .enabled) -> PrivatePlayer {
+        let preferencesPersistor = PrivatePlayerPreferencesPersistorMock(privatePlayerMode: mode, youtubeOverlayInteracted: true)
+        let preferences = PrivatePlayerPreferences(persistor: preferencesPersistor)
+        return PrivatePlayer(preferences: preferences)
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1203322325220637/f

**Description**:
Duck Player puts "Duck Player" in place of the domain on the New Tab Page Privacy Feed.
It was stored in `RecentlyVisitedSiteModel.domain` while setting `RecentlyVisitedSiteModel.isRealDomain` to `false`.
As a consequence, the domain string (equal to "Duck Player") would be passed to the burn function, causing
Duck Player entries to persist burning.

This change updates `RecentlyVisitedSiteModel` to always store the actual domain in `domain`, and adds
private `domainPlaceholder` (that defaults to `nil`) and public `domainToDisplay` computed property that
takes `domainPlaceholder` if it exists, or falls back to `domain`. This way, the proper functionality of burning
from the Privacy Feed is restored (and any new functionality based on `RecentlyVisitedSiteModel.domain`
should work properly).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open Duck Player to create a Duck Player entry in the New Tab Page Privacy Feed
1. Burn Duck Player using fire button on the right hand side of the Privacy Feed item; verify that the entry is burned and gone from the feed
1. Repeat step 1 and disable Duck Player in Settings – Duck Player entry will now display youtube-nocookie.com 
1. Burn this one and verify that it's gone
1. If you can, test all of the above on Big Sur – fwiw, I've tested this on Catalina and it worked fine, and the logic is the same on Catalina and Big Sur (Duck Player uses a different URL with `duck://` scheme, not replacing it with youtube-nocookie.com).

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
