### PR TITLE
Fix loading YouTube videos from Duck Player URL when Duck Player is disabled

### DIFF
--- a/DuckDuckGo/Youtube Player/PrivatePlayer.swift
+++ b/DuckDuckGo/Youtube Player/PrivatePlayer.swift
@@ -131,10 +131,11 @@ extension PrivatePlayer {
 
             // When the feature is disabled but the webView still gets a Private Player URL,
             // convert it back to a regular YouTube video URL.
-            if navigationAction.request.url?.isPrivatePlayer == true,
+            if navigationAction.request.url?.isPrivatePlayerScheme == true,
                 let (videoID, timestamp) = navigationAction.request.url?.youtubeVideoParams {
 
                 tab.webView.load(.youtube(videoID, timestamp: timestamp))
+                return .cancel
             }
             return nil
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1203320293109631/f

**Description**:
When converting Duck Player URL to Youtube video URL if Duck Player is disabled,
check for Duck Player scheme rather than .isPrivatePlayer (the latter would instead check
for youtube-nocookie.com host on macOS 12+), and actually cancel current navigation
to allow loading youtube.com.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Disable Duck Player in Settings
1. Open new tab and go to `duck://player/DLzxrzFCyOs?t=43s`
1. Verify that you've been redirected to youtube.com video page (and not to SERP).

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
