### PR TITLE
Make archive.sh return an error when failed to retrieve current app version

### DIFF
--- a/scripts/helpers/version.sh
+++ b/scripts/helpers/version.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-get_app_version() {
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+_get_marketing_version() {
     local scheme="$1"
 
 	xcrun xcodebuild \
@@ -8,6 +10,23 @@ get_app_version() {
 		-showBuildSettings 2>/dev/null \
 		| grep MARKETING_VERSION \
 		| awk '{print $3;}'
+}
+
+get_app_version() {
+    local scheme="$1"
+	local version
+
+	if ! version="$(_get_marketing_version "${scheme}")"; then
+		read -r -d '' reason <<- EOF
+		Failed to retrieve app version from Xcode project settings.
+		Make sure that the following command works:
+		    xcrun xcodebuild -scheme "${scheme}" -showBuildSettings
+
+		EOF
+		die "${reason}"
+	fi
+
+	echo "${version}"
 }
 
 bump_version() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1203301625297703/1203301625297699/f
CC: @tomasstrba 

**Description**:
Check return code of `xcodebuild -showBuildSettings` and report error when the code is non-zero.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run "Make Release build" workflow from this branch and confirm that it works.
1. You can break `xcodebuild -showBuildSettings` call in `scripts/helpers/version.sh` (e.g. prepend it with `ls`), rerun the workflow and confirm that it fails with an error message stating that it failed to retrieve app version (that's how I tested it).


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
