### PR TITLE
Use Duck Player hardcoded favicon for Duck Player bookmarks

### DIFF
--- a/DuckDuckGo/Bookmarks/Model/Bookmark.swift
+++ b/DuckDuckGo/Bookmarks/Model/Bookmark.swift
@@ -141,6 +141,9 @@ final class Bookmark: BaseBookmarkEntity {
     var oldFavicon: NSImage?
     let faviconManagement: FaviconManagement
     func favicon(_ sizeCategory: Favicon.SizeCategory) -> NSImage? {
+        if let privatePlayerFavicon = PrivatePlayer.shared.image(for: self) {
+            return privatePlayerFavicon
+        }
         return faviconManagement.getCachedFavicon(for: url, sizeCategory: sizeCategory)?.image ?? oldFavicon
     }
 

--- a/DuckDuckGo/Youtube Player/PrivatePlayer.swift
+++ b/DuckDuckGo/Youtube Player/PrivatePlayer.swift
@@ -208,6 +208,12 @@ extension PrivatePlayer {
         return .privatePlayer
     }
 
+    func image(for bookmark: Bookmark) -> NSImage? {
+        // Bookmarks to Duck Player pages retain duck:// URL even when Duck Player is disabled,
+        // so we keep the Duck Player favicon even if Duck Player is currently disabled
+        return bookmark.url.isPrivatePlayerScheme ? .privatePlayer : nil
+    }
+
     func domainForRecentlyVisitedSite(with url: URL) -> String? {
         guard isAvailable, mode != .disabled else {
             return nil


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1203155844310490/f

**Description**:
Duck Player bookmarks would always display Duck Player favicon, also when Duck Player is disabled.
This is because bookmark URLs don't change when Duck Player is disabled (contrary to Privacy Feed entries
that are replaced with `youtube-nocookie.com` URLs).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open a video Duck Player
1. Bookmark it (e.g. using ⌘D, because bookmark button is not present in the address bar)
1. Verify that the Duck Player bookmark displays Duck Player favicon (in Bookmark Management, Bookmarks Panel, Bookmarks Menu and Bookmarks Bar)
1. Disable Duck Player in Settings
1. Verify that the Duck Player bookmark still displays Duck Player favicon

Note that opening Duck Player bookmarks when Duck Player is disabled will have no effect until #825 is merged.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
