### PR TITLE
Add client ID header to DDG requests

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -1377,7 +1377,11 @@ extension Tab: WKNavigationDelegate {
             }
         }
         
-        if navigationAction.isTargetingMainFrame, navigationAction.request.url?.isDuckDuckGo == true, navigationAction.request.value(forHTTPHeaderField: Constants.ddgClientHeaderKey) == nil {
+        if navigationAction.isTargetingMainFrame,
+           navigationAction.request.url?.isDuckDuckGo == true,
+           navigationAction.request.value(forHTTPHeaderField: Constants.ddgClientHeaderKey) == nil,
+           navigationAction.navigationType != .backForward {
+            
             var request = navigationAction.request
             request.setValue(Constants.ddgClientHeaderValue, forHTTPHeaderField: Constants.ddgClientHeaderKey)
             _ = webView.load(request)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1121114553651782/1203346491700266
Tech Design URL:
CC:

**Description**:
- Add an additional HTTP header when the DDG macOS app makes requests to https://duckduckgo.com
Header name and value: `X-DuckDuckGo-Client: macos`

~From the task description, it seems we need this header to be added to a subsequent JS request and not just the page load (which it is currently limited to). Need to confirm this before merging.~
Confirmed that this is fine.
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open the Developer Tools and click the Network tab.
2. In the browser navigation bar, make a search.
3. In the Network tab, select the search request to duckduckgo.com.
4. Check that the request contains the header `X-DuckDuckGo-Client` with value `macos` 

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
