### PR TITLE
Update the history save failure pixel

### DIFF
--- a/DuckDuckGo/History/Services/HistoryStore.swift
+++ b/DuckDuckGo/History/Services/HistoryStore.swift
@@ -202,7 +202,7 @@ final class HistoryStore: HistoryStoring {
                 do {
                     try self.context.save()
                 } catch {
-                    Pixel.fire(.debug(event: .historyCleanEntriesFailed, error: error))
+                    Pixel.fire(.debug(event: .historySaveFailed, error: error))
                     promise(.failure(HistoryStoreError.savingFailed))
                     return
                 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1203386050668201/f
Tech Design URL:
CC:

**Description**:

This PR updates the pixel fired when failing to save history. The pixel it was using was `historyCleanEntriesFailed`, but this is in use elsewhere, and it turns out there was an unused `historySaveFailed` pixel - it seems like this was a typo.
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Turn pixel logging on in `Logging.swift`
1. Add a forced failure to line 203 of `HistoryStore.swift`. Something like `throw HistoryStoreError.savingFailed`
1. Check the console for this log entry: `[Pixel] m.mac.debug.history.save.failed`

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
