### PR TITLE
Bump ssh-agent to 0.7.0 in PR Checks workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Register SSH keys for submodules access
-      uses: webfactory/ssh-agent@v0.5.4
+      uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: |
           ${{ secrets.SSH_PRIVATE_KEY_FIND_IN_PAGE }}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1203390565918978/f

**Description**:
Update our GHA workflow dependency to silence Node-12-based actions deprecation notice
(such as one shown [here](https://github.com/more-duckduckgo-org/macos-browser/actions/runs/3486527452)). This has already been done for the release worklow, but not for the PR one.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open Summary page of the PR Checks workflow for this PR.
1. Verify that there is no deprecation warning in the Annotations section.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
