### PR TITLE
Prevent selecting Address Bar suffix with mouse click

### DIFF
--- a/DuckDuckGo/Navigation Bar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/Navigation Bar/View/AddressBarTextField.swift
@@ -988,6 +988,20 @@ extension AddressBarTextField: NSTextViewDelegate {
 
 final class AddressBarTextEditor: NSTextView {
 
+    override func mouseDown(with event: NSEvent) {
+        super.mouseDown(with: event)
+
+        guard let delegate = delegate as? AddressBarTextField else {
+            os_log("AddressBarTextEditor: unexpected kind of delegate")
+            return
+        }
+
+        if let currentSelection = selectedRanges.first as? NSRange {
+            let adjustedSelection = delegate.filterSuffix(fromSelectionRange: currentSelection, for: string)
+            setSelectedRange(adjustedSelection)
+        }
+    }
+
     override func paste(_ sender: Any?) {
         guard let delegate = delegate as? AddressBarTextField else {
             os_log("AddressBarTextEditor: unexpected kind of delegate")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203367623044094/f

**Description**:
On mouse down, call `filterSuffix` and update cursor as needed so that suffix
(e.g. " - Search with DuckDuckGo") is not selected.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Type text into address bar, observe " - Search with DuckDuckGo" being appended
1. Click the suffix with a mouse, verify that cursor stays at the end of your search phrase
1. Verify steps 1 and 2 with a URL (and " - Visit URL" suffix)
1. Verify steps 1 and 2 on the home page tab and on a regular URL tab
1. Verify that autocomplete and selecting suggestions still works as expected.

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
