### PR TITLE
Refactor NSView.addAndLayout to use autoresizing mask

### DIFF
--- a/DuckDuckGo/Common/Extensions/NSViewExtension.swift
+++ b/DuckDuckGo/Common/Extensions/NSViewExtension.swift
@@ -29,14 +29,11 @@ extension NSView {
     }
 
     func addAndLayout(_ subView: NSView) {
-        subView.translatesAutoresizingMaskIntoConstraints = false
+        subView.frame = bounds
+        subView.autoresizingMask = [.height, .width]
+        subView.translatesAutoresizingMaskIntoConstraints = true
         addSubview(subView)
-
-        subView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        subView.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        subView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-        subView.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
-    }
+   }
 
     func wrappedInContainer(padding: CGFloat = 0) -> NSView {
         return wrappedInContainer(padding: NSEdgeInsets(top: padding, left: padding, bottom: padding, right: padding))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203414775466509/f

**Description**:
Replace constraint-based layout code with autoresizing mask for a simple embedding one view inside another.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Test everything that uses `NSView.addAndLayout`:
1. Address Bar tracker icons animation
1. Address Bar buttons (e.g. bookmark button)
1. Opening Home Page (via ⌘T and using new tab button)
1. Opening Preferences
1. Autofill (displaying ContentOverlayViewController)
1. Onboarding (navigate to `about:welcome`)
1. Opening Privacy Dashboard
1. Web View Snapshot: pin a tab and open two windows with that pinned tab selected

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
