### PR TITLE
Fix open Duck Player in new tab from Context Menu

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -1234,7 +1234,26 @@ extension Tab: WKNavigationDelegate {
     @MainActor
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
-                
+
+        switch await contextMenuManager.decidePolicy(for: navigationAction) {
+        case .instantAllow:
+            return .allow
+        case .newTab(selected: let selected):
+            guard let url = navigationAction.request.url else { return .cancel }
+            self.delegate?.tab(
+                self,
+                requestedNewTabWith: .url(url),
+                selected: selected
+            )
+            return .cancel
+        case .cancel:
+            return .cancel
+        case .download:
+            return .download(navigationAction, using: webView)
+        case .none:
+            break
+        }
+
         if let policy = privatePlayer.decidePolicy(for: navigationAction, in: self) {
             return policy
         }
@@ -1253,22 +1272,8 @@ extension Tab: WKNavigationDelegate {
         let isMiddleButtonClicked = navigationAction.buttonNumber == Constants.webkitMiddleClick
 
         // to be modularized later on, see https://app.asana.com/0/0/1203268245242140/f
-        var isRequestingNewTab = (isLinkActivated && NSApp.isCommandPressed) || isMiddleButtonClicked || isNavigatingAwayFromPinnedTab
-        var shouldSelectNewTab = NSApp.isShiftPressed || (isNavigatingAwayFromPinnedTab && !isMiddleButtonClicked && !NSApp.isCommandPressed)
-
-        switch await contextMenuManager.decidePolicy(for: navigationAction) {
-        case .instantAllow:
-            return .allow
-        case .newTab(selected: let selected):
-            isRequestingNewTab = true
-            shouldSelectNewTab = shouldSelectNewTab || selected
-        case .cancel:
-            return .cancel
-        case .download:
-            return .download(navigationAction, using: webView)
-        case .none:
-            break
-        }
+        let isRequestingNewTab = (isLinkActivated && NSApp.isCommandPressed) || isMiddleButtonClicked || isNavigatingAwayFromPinnedTab
+        let shouldSelectNewTab = NSApp.isShiftPressed || (isNavigatingAwayFromPinnedTab && !isMiddleButtonClicked && !NSApp.isCommandPressed)
 
         // This check needs to happen before GPC checks. Otherwise the navigation type may be rewritten to `.other`
         // which would skip link rewrites.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1203425380945984/f
CC: @viktorjansson 

**Description**:
Fixes Duck Player opening in new tab from Context Menu

**Test steps**:
- Open [YouTube.com](https://youtube.com/)
- Make sure you have the setting Duck Player → Show option to use Duck Player... setting SET
- Right-click on one of the [Icon Overlays](https://app.asana.com/app/asana/-/get_asset?asset_id=1203425380945988) and select "Open in new tab"
- Expected: The video of the Icon Overlay opens in a new tab
- Validate other Context Menu items are working as before