### PR TITLE
Reading of stderr from Bitwarden proxy removed

### DIFF
--- a/DuckDuckGo/Password Managers/Bitwarden/Services/BWCommunicator.swift
+++ b/DuckDuckGo/Password Managers/Bitwarden/Services/BWCommunicator.swift
@@ -64,17 +64,12 @@ final class BWCommunicator: BWCommunication {
         let outHandle = outputPipe.fileHandleForReading
         outHandle.readabilityHandler = receiveData(_:)
 
-        let errorPipe = Pipe()
-        let errorHandle = errorPipe.fileHandleForReading
-        errorHandle.readabilityHandler = receiveErrorData(_:)
-
         let inputPipe = Pipe()
         let inputHandle = inputPipe.fileHandleForWriting
 
         process.executableURL = URL(fileURLWithPath: Self.appPath)
         process.arguments = ["chrome-extension://bitwarden"]
         process.standardOutput = outputPipe
-        process.standardError = errorPipe
         process.standardInput = inputPipe
         process.terminationHandler = processDidTerminate(_:)
 
@@ -166,13 +161,6 @@ final class BWCommunicator: BWCommunication {
                 self.delegate?.bitwardenCommunicator(self, didReceiveMessageData: messageData)
             }
         } while availableData.count >= 2 /*EOF*/
-    }
-
-    private func receiveErrorData(_ fileHandle: FileHandle) {
-        // Stderr is too verbose. Uncomment if necessary
-        // if let stderrOutput = String(data: fileHandle.availableData, encoding: .utf8) {
-        //     os_log("Stderr output:\n %s", log: .bitwarden, type: .error, stderrOutput)
-        // }
     }
 
     private func fromByteArray<T>(_ value: [UInt8], _: T.Type) -> T {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203502619948167/f
CC: @shorlander @samsymons 

**Description**:
Fix of the issue with high CPU usage when Bitwarden password manager is enabled.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the application, enable Bitwarden and finish handshake. Make sure communication with Bitwarden and autofill of credentials works
2. Check the usage of CPU and make sure it is not 100 percent

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
