### PR TITLE
Fix opening Duck Player on a timestamp from youtu.be URL

### DIFF
--- a/DuckDuckGo/Youtube Player/PrivatePlayerURLExtension.swift
+++ b/DuckDuckGo/Youtube Player/PrivatePlayerURLExtension.swift
@@ -39,7 +39,7 @@ extension URL {
 
     static func youtubeNoCookie(_ videoID: String, timestamp: String? = nil) -> URL {
         let url = "https://www.youtube-nocookie.com/embed/\(videoID)".url!
-        return url.addingTimestamp(timestamp)
+        return url.addingTimestamp(timestamp, forKey: "start")
     }
 
     static func youtube(_ videoID: String, timestamp: String? = nil) -> URL {
@@ -113,8 +113,9 @@ extension URL {
         }
 
         if isPrivatePlayer {
+            let timestampKey = isYoutubeNocookie ? "start" : "t"
             let unsafeVideoID = lastPathComponent
-            let timestamp = getParameter(named: "t")
+            let timestamp = getParameter(named: timestampKey)
             return (unsafeVideoID.removingCharacters(in: .youtubeVideoIDNotAllowed), timestamp)
         }
 
@@ -139,14 +140,18 @@ extension URL {
         host?.droppingWwwPrefix() == "youtube.com" && path == "/watch"
     }
 
-    private func addingTimestamp(_ timestamp: String?) -> URL {
+    private var isYoutubeNocookie: Bool {
+        host?.droppingWwwPrefix() == "youtube-nocookie.com"
+    }
+
+    private func addingTimestamp(_ timestamp: String?, forKey key: String = "t") -> URL {
         guard let timestamp = timestamp,
               let regex = try? NSRegularExpression.init(pattern: "^(\\d+[smh]?)+$"),
               timestamp.matches(regex)
         else {
             return self
         }
-        return appendingParameter(name: "t", value: timestamp)
+        return appendingParameter(name: key, value: timestamp)
     }
 }
 

--- a/DuckDuckGo/Youtube Player/Resources/youtube_player_template.html
+++ b/DuckDuckGo/Youtube Player/Resources/youtube_player_template.html
@@ -546,7 +546,8 @@
                 getSanitizedTimestamp: () => {
                     if (window.location && window.location.search) {
                         let parameters = new URLSearchParams(window.location.search);
-                        let timeParameter = parameters.get('t');
+                        // check both 't' and 'start' in case we're at the youtube-nocookie.com URL
+                        let timeParameter = parameters.get('t') || parameters.get('start');
 
                         if (timeParameter) {
                             return Comms.getTimestampInSeconds(timeParameter);
@@ -579,6 +580,8 @@
                         for (unit in units) {
                             if (part.includes(unit)) {
                                 return total + (parseInt(part) * units[unit]);
+                            } else {
+                                return total + parseInt(part);
                             }
                         }
                     }, 0);

--- a/Unit Tests/Youtube Player/PrivatePlayerURLExtensionTests.swift
+++ b/Unit Tests/Youtube Player/PrivatePlayerURLExtensionTests.swift
@@ -90,7 +90,7 @@ final class PrivatePlayerURLExtensionTests: XCTestCase {
         XCTAssertEqual(params?.videoID, "abcdef12345")
         XCTAssertEqual(params?.timestamp, nil)
 
-        let paramsWithTimestamp = "https://www.youtube-nocookie.com/embed/abcdef12345?t=23s".url!.youtubeVideoParams
+        let paramsWithTimestamp = "https://www.youtube-nocookie.com/embed/abcdef12345?start=23s".url!.youtubeVideoParams
         XCTAssertEqual(paramsWithTimestamp?.videoID, "abcdef12345")
         XCTAssertEqual(paramsWithTimestamp?.timestamp, "23s")
     }
@@ -128,13 +128,13 @@ final class PrivatePlayerURLExtensionTests: XCTestCase {
 
     func testYoutubeNoCookieURLTimestampValidation() {
         XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: nil).absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345")
-        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "23s").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?t=23s")
-        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "5m5s").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?t=5m5s")
-        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "12h400m100s").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?t=12h400m100s")
-        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "12h2s2h").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?t=12h2s2h")
-        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "5m5m5m").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?t=5m5m5m")
+        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "23s").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?start=23s")
+        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "5m5s").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?start=5m5s")
+        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "12h400m100s").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?start=12h400m100s")
+        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "12h2s2h").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?start=12h2s2h")
+        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "5m5m5m").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?start=5m5m5m")
 
-        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "5").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?t=5")
+        XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "5").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345?start=5")
         XCTAssertEqual(URL.youtubeNoCookie("abcdef12345", timestamp: "10d").absoluteString, "https://www.youtube-nocookie.com/embed/abcdef12345")
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203515132705819/f
CC: @viktorjansson 

**Description**:
Fix timestamp parameter handling for youtube-nocookie.com URLs on the native side
to actually set `start` and not `t`. Update HTML template to check for `start` parameter too,
and fix computing timestamp for unit-less timestamp parameter.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Enable Duck Player in Settings.
1. Go to https://youtu.be/dQw4w9WgXcQ&t=160 (note no unit in the timestamp parameter).
1. Verify that it opens the video on the timestamp.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
