### PR TITLE
Fix external app scheme permission callback not called on query deinit

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab+UIDelegate.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab+UIDelegate.swift
@@ -103,14 +103,12 @@ extension Tab: WKUIDelegate, PrintingUserScriptDelegate {
         let url = navigationAction.request.url
         let domain = navigationAction.sourceFrame.request.url?.host ?? self.url?.host
         self.permissions.request([.popups], forDomain: domain, url: url).receive { [weak self] result in
-            guard let self, case .success(true) = result else {
+            guard let self, case .success(.granted) = result else {
                 completionHandler(nil)
                 return
             }
             let webView = self.createWebView(from: webView, with: configuration, for: navigationAction, of: .popup(size: windowFeatures.windowContentSize))
 
-            self.permissions.permissions.popups
-                .popupOpened(nextQuery: self.permissions.authorizationQueries.first(where: { $0.permissions.contains(.popups) }))
             completionHandler(webView)
         }
     }
@@ -172,9 +170,7 @@ extension Tab: WKUIDelegate, PrintingUserScriptDelegate {
             return
         }
 
-        self.permissions.permissions(permissions, requestedForDomain: origin.host) { granted in
-            decisionHandler(granted ? .grant : .deny)
-        }
+        self.permissions.permissions(permissions, requestedForDomain: origin.host, decisionHandler: decisionHandler)
     }
 
     // https://github.com/WebKit/WebKit/blob/9d7278159234e0bfa3d27909a19e695928f3b31e/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h#L126

--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -33,7 +33,7 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
     func tabDidStartNavigation(_ tab: Tab)
     func tab(_ tab: Tab, createdChild childTab: Tab, of kind: NewWindowPolicy)
 
-    func tab(_ tab: Tab, requestedOpenExternalURL url: URL, forUserEnteredURL userEntered: Bool) -> Bool
+    func removeFirstResponderFocusFromWebView(for tab: Tab)
     func tab(_ tab: Tab, promptUserForCookieConsent result: @escaping (Bool) -> Void)
 
     func tabPageDOMLoaded(_ tab: Tab)
@@ -1321,27 +1321,28 @@ extension Tab: WKNavigationDelegate {
             }
         }
 
-        guard self.delegate?.tab(self, requestedOpenExternalURL: url, forUserEnteredURL: userEnteredUrl) == true else {
-            // search if external URL can‘t be opened but entered by user
+        // Another way of detecting whether an app is installed to handle a protocol is described in Asana:
+        // https://app.asana.com/0/1201037661562251/1202055908401751/f
+        guard NSWorkspace.shared.urlForApplication(toOpen: url) != nil else {
             if userEnteredUrl {
+                // search if external URL can‘t be opened but entered by user
                 searchForExternalUrl()
             }
             return
         }
+        delegate?.removeFirstResponderFocusFromWebView(for: self)
 
         let permissionType = PermissionType.externalScheme(scheme: url.scheme ?? "")
-
-        permissions.permissions([permissionType], requestedForDomain: host, url: url) { [weak self, userEnteredUrl] granted in
-            guard granted, let self else {
+        permissions.permissions([permissionType], requestedForDomain: host, url: url) { [userEnteredUrl] (decision: PermissionDecision) in
+            switch decision {
+            case .granted:
+                NSWorkspace.shared.open(url)
+            case .denied where userEnteredUrl:
                 // search if denied but entered by user
-                if userEnteredUrl {
-                    searchForExternalUrl()
-                }
-                return
+                searchForExternalUrl()
+            case .denied, .cancelled:
+                break
             }
-            // handle opening extenral URL
-            NSWorkspace.shared.open(url)
-            self.permissions.permissions[permissionType].externalSchemeOpened()
         }
     }
 

--- a/DuckDuckGo/Browser Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Browser Tab/View/BrowserTabViewController.swift
@@ -493,15 +493,10 @@ extension BrowserTabViewController: TabDelegate {
         }
     }
 
-    func tab(_ tab: Tab, requestedOpenExternalURL url: URL, forUserEnteredURL userEntered: Bool) -> Bool {
-        // Another way of detecting whether an app is installed to handle a protocol is described in Asana:
-        // https://app.asana.com/0/1201037661562251/1202055908401751/f
-        guard NSWorkspace.shared.urlForApplication(toOpen: url) != nil else {
-            return false
+    func removeFirstResponderFocusFromWebView(for tab: Tab) {
+        if tabViewModel?.tab == tab {
+            self.view.makeMeFirstResponder()
         }
-        self.view.makeMeFirstResponder()
-
-        return true
     }
 
     func tabPageDOMLoaded(_ tab: Tab) {

--- a/DuckDuckGo/Permissions/Model/PermissionAuthorizationQuery.swift
+++ b/DuckDuckGo/Permissions/Model/PermissionAuthorizationQuery.swift
@@ -26,11 +26,7 @@ struct PermissionAuthorizationQueryInfo {
     var shouldShowAlwaysAllowCheckbox: Bool = false
     var shouldShowCancelInsteadOfDeny: Bool = false
 }
-enum PermissionAuthorizationQueryDecision {
-    case granted(PermissionAuthorizationQuery)
-    case denied(PermissionAuthorizationQuery)
-}
-typealias PermissionAuthorizationQueryOutput = (decision: PermissionAuthorizationQueryDecision, remember: Bool?)
+typealias PermissionAuthorizationQueryOutput = (granted: Bool, remember: Bool?)
 
 typealias PermissionAuthorizationQuery = UserDialogRequest<PermissionAuthorizationQueryInfo, PermissionAuthorizationQueryOutput>
 extension PermissionAuthorizationQuery {
@@ -57,7 +53,7 @@ extension PermissionAuthorizationQuery {
     }
 
     func handleDecision(grant: Bool, remember: Bool? = nil) {
-        self.submit( (decision: grant ? .granted(self): .denied(self), remember: remember) )
+        self.submit( (granted: grant, remember: remember) )
     }
 
 }

--- a/Unit Tests/Permissions/PermissionModelTests.swift
+++ b/Unit Tests/Permissions/PermissionModelTests.swift
@@ -309,7 +309,7 @@ final class PermissionModelTests: XCTestCase {
 
         let e = expectation(description: "Permission granted")
         e.isInverted = true
-        model.permissions([.externalScheme(scheme: "mailto")], requestedForDomain: "test@example.com") { _ in
+        model.permissions([.externalScheme(scheme: "mailto")], requestedForDomain: "test@example.com") { (_: Bool) in
             e.fulfill()
         }
 
@@ -750,7 +750,6 @@ final class PermissionModelTests: XCTestCase {
         permissionManagerMock.setPermission(.allow, forDomain: URL.duckDuckGo.host!, permissionType: .externalScheme(scheme: "asdf"))
 
         webView.urlValue = URL.duckDuckGo
-        model.permissions.popups.popupOpened(nextQuery: nil)
         model.revoke(.popups)
 
         XCTAssertEqual(permissionManagerMock.permission(forDomain: URL.duckDuckGo.host!, permissionType: .popups),
@@ -766,8 +765,6 @@ final class PermissionModelTests: XCTestCase {
         permissionManagerMock.setPermission(.allow, forDomain: URL.duckDuckGo.host!, permissionType: .externalScheme(scheme: "sdfg"))
 
         webView.urlValue = URL.duckDuckGo
-        model.permissions[.externalScheme(scheme: "asdf")].externalSchemeOpened()
-        model.permissions[.externalScheme(scheme: "sdfg")].externalSchemeOpened()
 
         model.revoke(.externalScheme(scheme: "asdf"))
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: - in scope of Navigation refactoring -
CC: @tomasstrba @ayoy @Bunn 

**Description**:
Fixes Permission Authorization flow breaking PermissionModel properties encapsulation and never calling callback on query deinit for External Scheme permission
Improved code readability

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate permissions work (permission.site, zoom links)
