### PR TITLE
Fix of SwiftUI crash

### DIFF
--- a/DuckDuckGo/Home Page/Model/HomePageFavoritesModel.swift
+++ b/DuckDuckGo/Home Page/Model/HomePageFavoritesModel.swift
@@ -77,7 +77,7 @@ extension HomePage.Models {
 
         @Published private(set) var visibleModels: [FavoriteModel] = []
 
-        @available(macOS, obsoleted: 11.0, message: "Use visibleModels and LazyVGrid instead")
+        @available(macOS, obsoleted: 12.0, message: "Use visibleModels and LazyVGrid instead")
         @Published private(set) var rows: [[FavoriteModel]] = []
 
         let open: (Bookmark, OpenTarget) -> Void
@@ -122,7 +122,7 @@ extension HomePage.Models {
         }
 
         private func updateVisibleModels() {
-            if #available(macOS 11.0, *) {
+            if #available(macOS 12.0, *) {
                 visibleModels = showAllFavorites ? models : Array(models.prefix(HomePage.favoritesRowCountWhenCollapsed * HomePage.favoritesPerRow))
             } else {
                 rows = models.chunked(into: HomePage.favoritesPerRow)

--- a/DuckDuckGo/Home Page/View/FavoritesView.swift
+++ b/DuckDuckGo/Home Page/View/FavoritesView.swift
@@ -32,7 +32,7 @@ struct Favorites: View {
 
     var body: some View {
 
-        if #available(macOS 11.0, *) {
+        if #available(macOS 12.0, *) {
             LazyVStack(spacing: 4) {
                 FavoritesGrid(isHovering: $isHovering)
             }
@@ -66,7 +66,7 @@ struct FavoritesGrid: View {
 
     var body: some View {
 
-        if #available(macOS 11.0, *) {
+        if #available(macOS 12.0, *) {
             LazyVGrid(
                 columns: Array(repeating: GridItem(.fixed(GridDimensions.itemWidth), spacing: GridDimensions.horizontalSpacing), count: HomePage.favoritesPerRow),
                 spacing: GridDimensions.verticalSpacing


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203481412486290/f

**Description**:
PR addresses crashes caused by SwiftUI we receive from macOS Big Sur specifically. The idea of the fix is to avoid usage of LazyVStack.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Export the build in release configuration using GitHub actions . (We can't run the latest Xcode on Big Sur)

On Big Sur testing machine
1. Remove data (rm -rf ~Library/Containers/com.duckduckgo.macos.browser)
2. Run the app
3. Open Bookmarks
4. Import large bookmark HTML file (ping me if you need one)
5. Right after importing open a new tab using CMD + T

**Testing checklist**:

* [ ] Test with Release configuration

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
