### PR TITLE
Revert removal of History context lazy load

### DIFF
--- a/DuckDuckGo/History/Services/HistoryStore.swift
+++ b/DuckDuckGo/History/Services/HistoryStore.swift
@@ -32,9 +32,9 @@ protocol HistoryStoring {
 
 final class HistoryStore: HistoryStoring {
 
-    private let context: NSManagedObjectContext
-
-    init(context: NSManagedObjectContext = Database.shared.makeContext(concurrencyType: .privateQueueConcurrencyType, name: "History")) {
+    init() {}
+    
+    init(context: NSManagedObjectContext) {
         self.context = context
     }
 
@@ -42,6 +42,8 @@ final class HistoryStore: HistoryStoring {
         case storeDeallocated
         case savingFailed
     }
+    
+    private lazy var context = Database.shared.makeContext(concurrencyType: .privateQueueConcurrencyType, name: "History")
 
     func removeEntries(_ entries: [HistoryEntry]) -> Future<Void, Error> {
         return Future { [weak self] promise in


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203560842625353/f
Tech Design URL:
CC:

**Description**:

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

There's been a rise in database.make.database.error Pixels 0.31.2. This could be due to a change in the timing of when the `HistoryStore` database gets initialised (it was previously lazy loaded, but it got moved into the initialiser).

It's not crazy dramatic (about 5-10 per day) but we should fix it soon as the consequences are pretty bad (History not working).

https://kibana.duckduckgo.com/goto/31bccf0cc29a5f1d59aca7f8ad6c3ef6
https://grafana.duckduckgo.com/goto/09-3tt54z?orgId=1

**Steps to test this PR**:
1. Test History still works as expected2. 
2. Post release, check that the database.make.database.error Pixel count goes down

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
