### PR TITLE
Fix opening new tab for user-initated actions

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -1167,7 +1167,7 @@ extension Tab: WKNavigationDelegate {
 
         let isLinkActivated = webView === sourceWebView
             && !isRedirect
-            && navigationAction.navigationType == .linkActivated
+            && (navigationAction.navigationType == .linkActivated || navigationAction.isUserInitiated)
 
         let isNavigatingAwayFromPinnedTab: Bool = {
             let isNavigatingToAnotherDomain = navigationAction.request.url?.host != url?.host


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: -

**Description**:
- Fixes open in new tab for non-linkActivated but userInitiated navigation actions

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Pin a Tab with a SERP page open
2. Click a link: should open a new tab and not navigate inside the pinned tab
3. Cmd+Click a link on a SERP page: should open a new tab
