### PR TITLE
Fix the bookmarks popover not appearing when bookmarking from the address bar

### DIFF
--- a/DuckDuckGo/Navigation Bar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/Navigation Bar/View/AddressBarButtonsViewController.swift
@@ -280,7 +280,7 @@ final class AddressBarButtonsViewController: NSViewController {
         }
 
         let bookmarkPopover = bookmarkPopoverCreatingIfNeeded()
-        if bookmarkPopover.isShown {
+        if !bookmarkPopover.isShown {
             bookmarkButton.isHidden = false
             bookmarkPopover.viewController.bookmark = bookmark
             bookmarkPopover.show(relativeTo: bookmarkButton.bounds, of: bookmarkButton, preferredEdge: .maxY)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1203591896442254/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue where the bookmarks popover was not appearing when you bookmark a page from the address bar.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Visit a website
1. Click the bookmark button in the address bar
1. Verify that the popover appears

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
