### PR TITLE
Fix favorite URL editing from the new tab page

### DIFF
--- a/DuckDuckGo/Home Page/View/FavoritesView.swift
+++ b/DuckDuckGo/Home Page/View/FavoritesView.swift
@@ -302,7 +302,7 @@ struct Favorite: View {
     // Maintain separate copies of bookmark metadata required by the view, in order to ensure that SwiftUI re-renders correctly.
     private let bookmarkTitle: String
     private let bookmarkURL: URL
-    
+
     init(bookmark: Bookmark) {
         self.bookmark = bookmark
         self.bookmarkTitle = bookmark.title


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203558178464160/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue where edits to favorites on the new tab page would not take effect on that page, despite taking effect correctly everywhere else.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Favorite a bookmark
2. Edit its URL to some other value
3. Open the edit modal again, and check that the values reflect the previous edit you just made

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
