### PR TITLE
Fix a possible tab user alert crash

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -439,12 +439,9 @@ final class Tab: NSObject, Identifiable, ObservableObject {
     var userInteractionDialog: UserDialog? {
         didSet {
             guard let request = userInteractionDialog?.request else { return }
-            request.addCompletionHandler { [weak self, weak request] result in
-                // This check prevents a deadlock that can occur when accessing `userInteractionDialog` while the user dialog is being deinitialized.
-                if case let .failure(failure) = result, failure == .deinitialized { return }
-
-                if self?.userInteractionDialog?.request === request {
-                    self?.userInteractionDialog = nil
+            request.addCompletionHandler { [weak self, weak request] _ in
+                if let self, let request, self.userInteractionDialog?.request === request {
+                    self.userInteractionDialog = nil
                 }
             }
         }

--- a/DuckDuckGo/Browser Tab/Model/UserDialogRequest.swift
+++ b/DuckDuckGo/Browser Tab/Model/UserDialogRequest.swift
@@ -73,7 +73,11 @@ final class UserDialogRequest<Info, Output>: UserDialogRequestProtocol {
     }
 
     deinit {
-        callback?(.failure(.deinitialized))
+        guard let callback else { return }
+
+        DispatchQueue.main.async {
+            callback(.failure(.deinitialized))
+        }
     }
 
 }


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199230911884351/1203597545933056/f
Tech Design URL:
CC:

**Description**:

This PR fixes a race condition that can occur when a user interaction dialog is set to nil while it's still active.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
I wasn't able to reproduce this without modifications, but can prove that setting the user interaction dialog to `nil` while it's active causes the same stack trace as the crash referenced in the task above.

Go to `Tab+UIDelegate.swift` and add the following block at the end of `runJavaScriptAlertPanelWithMessage`:

```
DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
    self.userInteractionDialog = nil
}
```

Next, visit a site that shows a JS alert, such as [this](https://www.javatpoint.com/oprweb/test.jsp?filename=javascript-alert1), and present the alert. After 1 second, the alert should be dismissed automatically. If you add this block onto the `develop` branch, you'll see the deadlock when this happens instead.

The stack trace from the crashes shows [this line](https://github.com/more-duckduckgo-org/macos-browser/blob/develop/DuckDuckGo/Browser%20Tab/Model/Tab.swift#L1438) as the cause.

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
