### PR TITLE
Use proper video title and youtube.com URL for sharing from Duck Player

### DIFF
--- a/DuckDuckGo/Menus/SharingMenu.swift
+++ b/DuckDuckGo/Menus/SharingMenu.swift
@@ -73,8 +73,9 @@ final class SharingMenu: NSMenu {
             return
         }
 
-        service.subject = tabViewModel.title
-        service.perform(withItems: [url])
+        let sharingData = PrivatePlayer.shared.sharingData(for: tabViewModel.title, url: url) ?? (tabViewModel.title, url)
+        service.subject = sharingData.title
+        service.perform(withItems: [sharingData.url])
     }
 
 }

--- a/DuckDuckGo/Youtube Player/PrivatePlayer.swift
+++ b/DuckDuckGo/Youtube Player/PrivatePlayer.swift
@@ -224,6 +224,17 @@ extension PrivatePlayer {
         return url.isPrivatePlayer ? PrivatePlayer.commonName : nil
     }
 
+    func sharingData(for title: String, url: URL) -> (title: String, url: URL)? {
+        guard isAvailable, mode != .disabled, url.isPrivatePlayerScheme, let (videoID, timestamp) = url.youtubeVideoParams else {
+            return nil
+        }
+
+        let title = title.dropping(prefix: Self.websiteTitlePrefix)
+        let sharingURL = URL.youtube(videoID, timestamp: timestamp)
+
+        return (title, sharingURL)
+    }
+
     func title(for page: HomePage.Models.RecentlyVisitedPageModel) -> String? {
         guard isAvailable, mode != .disabled else {
             return nil

--- a/Unit Tests/Youtube Player/PrivatePlayerTests.swift
+++ b/Unit Tests/Youtube Player/PrivatePlayerTests.swift
@@ -133,6 +133,16 @@ final class PrivatePlayerTests: XCTestCase {
         XCTAssertNil(privatePlayer.tabContent(for: .youtube("12345678", timestamp: "10m")))
     }
 
+    func testThatSharingDataStripsDuckPlayerPrefixFromTitleAndReturnsYoutubeURL() {
+        let sharingData = privatePlayer.sharingData(for: "Duck Player - sample video", url: "duck://player/12345678?t=10".url!)
+        XCTAssertEqual(sharingData?.title, "sample video")
+        XCTAssertEqual(sharingData?.url, URL.youtube("12345678", timestamp: "10"))
+    }
+
+    func testThatSharingDataForNonPrivatePlayerURLReturnsNil() {
+        XCTAssertNil(privatePlayer.sharingData(for: "Wikipedia", url: "https://wikipedia.org".url!))
+    }
+
     func testThatTitleForRecentlyVisitedPageIsGeneratedForPrivatePlayerFeedItems() {
         let feedItem = HomePage.Models.RecentlyVisitedPageModel(
             actualTitle: "Duck Player - A sample video title",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203611997317283/f

**Description**:
Strip “Duck Player - “ prefix from website title and convert duck:// URL to youtube.com before sharing a Duck Player website.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Enable Duck Player
2. Open a video in Duck Player
3. Use three dots menu -> Share -> e.g. Mail
4. Verify that title does not contain “Duck Player - “ prefix and the URL is a youtube.com URL (not duck://).

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
