### PR TITLE
Avoid using quackdev in DEBUG mode

### DIFF
--- a/DuckDuckGo/Email/EmailUrlExtensions.swift
+++ b/DuckDuckGo/Email/EmailUrlExtensions.swift
@@ -25,16 +25,8 @@ extension EmailUrls {
         static let emailProtectionLink = "https://duckduckgo.com/email"
     }
 
-    private struct DevUrl {
-        static let emailProtectionLink = "https://quackdev.duckduckgo.com/email"
-    }
-
     var emailProtectionLink: URL {
-        #if DEBUG
-        return URL(string: DevUrl.emailProtectionLink)!
-        #else
         return URL(string: Url.emailProtectionLink)!
-        #endif
     }
 
     func isDuckDuckGoEmailProtection(url: URL) -> Bool {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203695370650863/f
Tech Design URL:
CC:

**Description**:

This PR removes the `quackdev` email URL that was being used in DEBUG mode. It no longer makes sense to use this as we're using our production accounts day to day, and `quackdev` should only be used in the case where we have WIP changes deployed to the dev server.

The other issue is that BSK wasn't using `quackdev`, so the auth token wouldn't work when refreshing aliases.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Sign into email protection using your main Duck address
2. Check that you can generate a new alias
3. Verify that signing out works

**Testing checklist**:

* [ ] Test with Release configuration
* [ ] Test proper deallocation of tabs
* [ ] Make sure committed submodule changes are desired
* [ ] Make sure configuration is changed only in xcconfig files, not in the Xcode project file directly

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
