### PR TITLE
Remove tab content immediately when opening new tab from a navigation link

### DIFF
--- a/DuckDuckGo/Browser Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Browser Tab/View/BrowserTabViewController.swift
@@ -404,7 +404,7 @@ final class BrowserTabViewController: NSViewController {
             view.addAndLayout(homePageView)
 
         default:
-            break
+            removeAllTabContent()
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1177771139624306/1203672262429459/f

**Description**:
This change forces removal of any existing tab content when TabContent.none is being shown.
This is the case of opening link in new tab in foreground (with option+shift+click). Previous behavior
was that the new tab’s webview was loaded after a delay on some websites.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open DDG search
2. option+shift+click search results
3. verify that whenever a new tab is opened, webview area is immediately cleared and does not retain SERP for a fraction of a second (compare to the release app to see what the problem is).

**Testing checklist**:

* [x] Test with Release configuration
* [x] Test proper deallocation of tabs
* [x] Make sure committed submodule changes are desired
* [x] Make sure configuration is changed only in xcconfig files, not in the Xcode project file directly

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
