### PR TITLE
Update App Store build number based on TestFlight state

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,6 +138,19 @@ platform :mac do
     end
   end
 
+  private_lane :get_username do |options|
+    if options[:username]
+      options[:username]
+    elsif is_ci
+      nil # don't make assumptions in CI
+    else
+      git_user_email = Action.sh("git", "config", "user.email").chomp
+      if git_user_email.end_with? "@duckduckgo.com"
+        git_user_email
+      end
+    end
+  end
+
   # Synchronizes certificates and provisioning profiles for App Store distribution.
   #
   # - runs in read-only mode in CI.
@@ -145,7 +158,7 @@ platform :mac do
   private_lane :do_sync_signing do |options|
     sync_code_signing(
       api_key: get_api_key,
-      username: options[:username],
+      username: get_username(options),
       readonly: is_ci
     )
   end
@@ -209,7 +222,7 @@ platform :mac do
       app_identifier: "com.duckduckgo.mobile.ios",
       initial_build_number: -1,
       platform: "osx",
-      username: options[:username]
+      username: get_username(options)
     ) + 1
   end
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1203840530848079/f

**Description**:
* Get latest build number from TestFlight and increment it by 1 to use for App Store build.
* If not provided in `options[:username]`, try guessing username (Apple ID) from `git config user.email`.

**Steps to test this PR**:
1. ensure `git config user.email` returns your DDG email address.
1. run `bundle exec fastlane sync_signing` and verify that you haven’t been asked for your email.
1. edit Fastfile: replace `DEFAULT_BRANCH = 'develop'` with `DEFAULT_BRANCH = 'dominik/appstore-build-number'`
1. commit changes
1. run `bundle exec fastlane code_freeze version:0.32.0`
1. wait for unit tests to pass
1. verify that the topmost commit bumps version to `0.32.0 (6)` (because last TestFlight build number for version 0.32.0 is 5).
1. delete newly created remote branch `release/0.32.0`.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
