### PR TITLE
Update BSK with autofill 6.2.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7987,8 +7987,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 38.0.0;
+				kind = revision;
+				revision = 06475e1719dda23453368ad7a57db262d84d67ff;
 			};
 		};
 		3706FDD7293F661700E42796 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {
@@ -8019,8 +8019,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 43.1.0;
+				kind = revision;
+				revision = 06475e1719dda23453368ad7a57db262d84d67ff;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203845335740047/1203845335740047
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.2.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/222

## Description
Updates Autofill to version [6.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.2.0).

### Autofill 6.2.0 release notes
## What's Changed
* Send autofill pixels on macOS by @sixers in https://github.com/duckduckgo/duckduckgo-autofill/pull/249


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.1.2...6.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).