### PR TITLE
Making sure Spotlight search is always part of the Help menu

### DIFF
--- a/DuckDuckGo/Menus/MainMenu.swift
+++ b/DuckDuckGo/Menus/MainMenu.swift
@@ -100,6 +100,11 @@ final class MainMenu: NSMenu {
     override func update() {
         super.update()
 
+        // Make sure Spotlight search is part of Help menu
+        if NSApplication.shared.helpMenu != helpMenuItem?.submenu {
+            NSApplication.shared.helpMenu = helpMenuItem?.submenu
+        }
+
         if !WKWebView.canPrint {
             printMenuItem?.removeFromParent()
             printSeparatorItem?.removeFromParent()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202151865161710/f
CC: @brindy 

**Description**:
In some cases, AppKit added the Spotlight menu search into Develop menu item instead of Help menu item. This is the fix of the issue.

**Steps to test this PR**:
1. Open the app and make sure there is a search menu item in Help menu
2. Quit the app and repeat the test 10x


<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
