### PR TITLE
Delay modal cancellation handler on dialog set

### DIFF
--- a/DuckDuckGo/Browser Tab/View/ModalSheetCancellable.swift
+++ b/DuckDuckGo/Browser Tab/View/ModalSheetCancellable.swift
@@ -44,13 +44,19 @@ final class ModalSheetCancellable: Cancellable {
               condition() == true
         else { return }
 
-        if let returnCode = returnCode {
-            ownerWindow.endSheet(modalSheet, returnCode: returnCode)
-        } else {
-            ownerWindow.endSheet(modalSheet)
-        }
+        DispatchQueue.main.async { [cancellationHandler, returnCode, weak ownerWindow, weak modalSheet] in
+            guard let ownerWindow, let modalSheet,
+                  ownerWindow.sheets.contains(modalSheet)
+            else { return }
 
-        cancellationHandler?()
+            if let returnCode = returnCode {
+                ownerWindow.endSheet(modalSheet, returnCode: returnCode)
+            } else {
+                ownerWindow.endSheet(modalSheet)
+            }
+
+            cancellationHandler?()
+        }
     }
 
     deinit {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203872613153566/f
Tech Design URL:
CC:

**Description**:

There is a crash that is happening when a JS alert attempts to be displayed while another WebKit dialog is displayed (e.g printing). This likely happens when any dialog attempts to be displayed while another is already showing. There's timing issue where a completion handler which nils the property on deinit of the old dialog is called just after the new dialog is set. To prevent this, this PR dispatches the completion handler async, adding it to the next run loop, preventing the timing issue.

(Thanks @mallexxx for the tip... again ;))

**Steps to test this PR**:
1. Go to https://privacy-test-pages.glitch.me/features/js-alerts.html
2. Show an alert with 4s delay
3. Cmd + P to show print dialog
4. Wait for the alert to show beneath the print dialog

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
