### PR TITLE
Fix cmd+left/right opening new tab

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -1137,7 +1137,7 @@ extension Tab: WKNavigationDelegate {
 
         let isLinkActivated = webView === sourceWebView
             && !isRedirect
-            && (navigationAction.navigationType == .linkActivated || navigationAction.isUserInitiated)
+            && (navigationAction.navigationType == .linkActivated || (navigationAction.navigationType == .other && navigationAction.isUserInitiated))
 
         let isNavigatingAwayFromPinnedTab: Bool = {
             let isNavigatingToAnotherDomain = navigationAction.request.url?.host != url?.host


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203778310036003/f

**Description**:
Fix new Tab being opened on Cmd+Left/Right back-forward navigation

**Steps to test this PR**:
1. Navigate somewhere twice
2. Hit Cmd+Left, Cmd+Right - back/forward navigation should happen in the same tab
3. Validate opening links (normal and javascript:window.location.href=..) with cmd[+opt+shift) opens new tab/window - as needed

