### PR TITLE
Don't close tab on download redirect

### DIFF
--- a/DuckDuckGo/Browser Tab/Model/Tab.swift
+++ b/DuckDuckGo/Browser Tab/Model/Tab.swift
@@ -1479,16 +1479,6 @@ extension Tab: WKNavigationDelegate {
     @objc(webView:navigationResponse:didBecomeDownload:)
     func webView(_ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload) {
         FileDownloadManager.shared.add(download, delegate: self, location: .auto, postflight: .none)
-
-        // Note this can result in tabs being left open, e.g. download button on this page:
-        // https://en.wikipedia.org/wiki/Guitar#/media/File:GuitareClassique5.png
-        // Safari closes new tabs that were opened and then create a download instantly.
-        if self.webView.backForwardList.currentItem == nil,
-           self.parentTab != nil {
-            DispatchQueue.main.async { [weak self] in
-                self?.delegate?.closeTab(self!)
-            }
-        }
     }
 
     @objc(_webView:didStartProvisionalLoadWithRequest:inFrame:)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203875008953384/f
Tech Design URL:
CC:

**Description**:

There was a subsequent bug found where the download panel is dismissed immediately when trying to download an inline image in an Asana description.

The problem is that dialogs are a property of tabs, but certain downloads result in a new tab being opened. We then close this tab again immediately and start the download... unless we have the "always prompt..." preference on. Then we just show the save prompt dialog but close the tab immediately along with the dialog.

Tab L:1489 seems to be where the root cause is (cc [@Alex M](https://app.asana.com/0/profile/1202406491309505)).

However, contrary to the comment, on checking Safari I found that the opened tab does stay open. I've just removed this code, but perhaps this is different / more of an issue on different OS versions.

**Steps to test this PR**:
1. Ensure Preferences -> Downloads > Always ask... is switched on
2. Go to https://app.asana.com/0/1175293949586521/1203887861763209
3. Try to download the image inline

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
