### PR TITLE
Monitoring of the update dialog

### DIFF
--- a/DuckDuckGo/App Delegate/UpdateController.swift
+++ b/DuckDuckGo/App Delegate/UpdateController.swift
@@ -77,4 +77,20 @@ extension UpdateController: SPUUpdaterDelegate {
         Pixel.fire(.debug(event: .updaterAborted, error: error))
     }
 
+    func updater(_ updater: SPUUpdater,
+                 userDidMake choice: SPUUserUpdateChoice,
+                 forUpdate updateItem: SUAppcastItem,
+                 state: SPUUserUpdateState) {
+        switch choice {
+        case .skip:
+            Pixel.fire(.debug(event: .userSelectedToSkipUpdate))
+        case .install:
+            Pixel.fire(.debug(event: .userSelectedToInstallUpdate))
+        case .dismiss:
+            Pixel.fire(.debug(event: .userSelectedToDismissUpdate))
+        @unknown default:
+            break
+        }
+    }
+
 }

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -199,7 +199,9 @@ extension Pixel {
             case bitwardenSharedKeyInjectionFailed
 
             case updaterAborted
-
+            case userSelectedToSkipUpdate
+            case userSelectedToInstallUpdate
+            case userSelectedToDismissUpdate
         }
 
     }
@@ -435,6 +437,12 @@ extension Pixel.Event.Debug {
 
         case .updaterAborted:
             return "updater_aborted"
+        case .userSelectedToSkipUpdate:
+            return "user_selected_to_skip_update"
+        case .userSelectedToInstallUpdate:
+            return "user_selected_to_install_update"
+        case .userSelectedToDismissUpdate:
+            return "user_selected_to_dismiss_update"
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1203927973101670/f

**Description**:
After the migration to Sparkle 2.0, some users aren't updating to the latest version. To understand what is happening in the background, let's expand the monitoring and add few more pixels. 

**Steps to test this PR**:
1. Set `pixelLoggingEnabled` to true in `Logging`
2. Run the app
3. Go to DuckDuckGo -> Check for updates...
4. In the following dialog select various options and make sure appropriate pixel is fired

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
