### PR TITLE
Address bar crash fixed

### DIFF
--- a/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -94,7 +94,13 @@ extension URL {
     }
 
     static func makeURL(fromSuggestionPhrase phrase: String) -> URL? {
-        guard let url = URL(trimmedAddressBarString: phrase), url.isValid else { return nil }
+        guard let url = URL(trimmedAddressBarString: phrase),
+              let scheme = url.scheme.map(NavigationalScheme.init),
+              NavigationalScheme.hypertextSchemes.contains(scheme),
+              url.isValid else {
+            return nil
+        }
+
         return url
     }
 

--- a/Unit Tests/Common/Extensions/URLExtensionTests.swift
+++ b/Unit Tests/Common/Extensions/URLExtensionTests.swift
@@ -103,4 +103,17 @@ final class URLExtensionTests: XCTestCase {
         }
     }
 
+    func testWhenMakingUrlFromSuggestionPhaseContainingColon_ThenVerifyHypertextScheme() {
+        let validUrl = URL.makeURL(fromSuggestionPhrase: "http://duckduckgo.com")
+        XCTAssert(validUrl != nil)
+        XCTAssertEqual(validUrl?.scheme, "http")
+
+        let anotherValidUrl = URL.makeURL(fromSuggestionPhrase: "duckduckgo.com")
+        XCTAssert(anotherValidUrl != nil)
+        XCTAssertNotNil(validUrl?.scheme)
+
+        let notURL = URL.makeURL(fromSuggestionPhrase: "type:pdf")
+        XCTAssertNil(notURL)
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203461357547808/f
CC:

**Description**:
Address bar suggestion logic was not correctly making navigational URL from suggestion phrase. As a result, address bar crashed when trying to select the full phrase.

**Steps to test this PR**:
1. Type "type:p" into the address bar and make sure the app doesn't crash.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
