### PR TITLE
Crash in FrameInfo.init (safeRequest property)

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8206,8 +8206,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 46.2.0;
+				kind = revision;
+				revision = 317a0c249a83b00bb153ac6b042a283c06f7c61e;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo/Common/Extensions/AVCaptureDevice+SwizzledAuthState.swift
+++ b/DuckDuckGo/Common/Extensions/AVCaptureDevice+SwizzledAuthState.swift
@@ -19,10 +19,7 @@
 import Foundation
 import AVFoundation
 
-@objc private protocol AVCaptureDevice_Swizzled {
-    static func swizzled_authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus
-}
-extension AVCaptureDevice: AVCaptureDevice_Swizzled {
+extension AVCaptureDevice {
     private static var authorizationStatusForMediaType: ((AVMediaType, inout AVAuthorizationStatus) -> Void)?
     private static var isSwizzled: Bool { authorizationStatusForMediaType != nil }
 
@@ -61,8 +58,8 @@ extension AVCaptureDevice: AVCaptureDevice_Swizzled {
         self.authorizationStatusForMediaType = nil
     }
 
-    static func swizzled_authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus {
-        var result = (self as AVCaptureDevice_Swizzled.Type).swizzled_authorizationStatus(for: mediaType)
+    @objc dynamic private static func swizzled_authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus {
+        var result = self.swizzled_authorizationStatus(for: mediaType) // call the original
         if Thread.isMainThread,
            let authorizationStatusForMediaType = Self.authorizationStatusForMediaType {
             authorizationStatusForMediaType(mediaType, &result)

--- a/Unit Tests/Common/WKWebViewMockingExtension.swift
+++ b/Unit Tests/Common/WKWebViewMockingExtension.swift
@@ -39,7 +39,7 @@ extension WKWebView {
         method_exchangeImplementations(originalLoad, swizzledLoad)
     }()
 
-    @objc class func swizzled_handlesURLScheme(_ urlScheme: String) -> Bool {
+    @objc dynamic private class func swizzled_handlesURLScheme(_ urlScheme: String) -> Bool {
         guard !customHandlerSchemes.contains(URL.NavigationalScheme(rawValue: urlScheme)) else { return false }
         return self.swizzled_handlesURLScheme(urlScheme) // call original
     }

--- a/Unit Tests/Permissions/PermissionModelTests.swift
+++ b/Unit Tests/Permissions/PermissionModelTests.swift
@@ -1134,7 +1134,7 @@ extension PermissionModelTests: WebViewPermissionsDelegate {
 
     @objc(_webView:requestGeolocationPermissionForFrame:decisionHandler:)
     func webView(_ webView: WKWebView, requestGeolocationPermissionFor frame: WKFrameInfo, decisionHandler: @escaping (Bool) -> Void) {
-        self.model.permissions(.geolocation, requestedForDomain: frame.request.url?.host, decisionHandler: decisionHandler)
+        self.model.permissions(.geolocation, requestedForDomain: frame.safeRequest?.url?.host, decisionHandler: decisionHandler)
     }
 
     @objc(_webView:requestGeolocationPermissionForOrigin:initiatedByFrame:decisionHandler:)
@@ -1143,7 +1143,7 @@ extension PermissionModelTests: WebViewPermissionsDelegate {
                  requestGeolocationPermissionFor origin: WKSecurityOrigin,
                  initiatedBy frame: WKFrameInfo,
                  decisionHandler: @escaping (WKPermissionDecision) -> Void) {
-        self.model.permissions(.geolocation, requestedForDomain: frame.request.url?.host) { granted in
+        self.model.permissions(.geolocation, requestedForDomain: frame.safeRequest?.url?.host) { granted in
             decisionHandler(granted ? .grant : .deny)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1203965979591356/f
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/234
Tech Design URL:
CC: @tomasstrba 

**Description**:
- Added WKFrameInfo.safeRequest property instead of wrongly-non-nullable .request
- Added runtime checks for WKFrameInfo.safeRequest and WKNavigationAction.sourceFrame usage in Debug config
- Fixed swizzled method original implementation calls by adding "dynamic" method dispatch modifier

**Steps to test this PR**:
0. Validate both Debug&Release builds
1. Go to https://www.seriouseats.com/ask-the-food-lab-do-i-need-to-use-kosher-salt
2. Click through the "Buy on ..." product links, validate there‘s no crash when WKFrameInfo.request is accessed
3. Validate microphone permission works on https://permission.site

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
