### PR TITLE
Fix of the destination folder check in case of App Store build and requested destination

### DIFF
--- a/DuckDuckGo/App Delegate/AppDelegate.swift
+++ b/DuckDuckGo/App Delegate/AppDelegate.swift
@@ -32,12 +32,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     static var isRunningTests: Bool { false }
 #endif
 
-#if APPSTORE
-    static var isAppStoreBuild = true
-#else
-    static var isAppStoreBuild = false
-#endif
-
 #if DEBUG
     let disableCVDisplayLinkLogs: Void = {
         // Disable CVDisplayLink logs

--- a/DuckDuckGo/File Download/Model/FileDownloadManager.swift
+++ b/DuckDuckGo/File Download/Model/FileDownloadManager.swift
@@ -163,7 +163,7 @@ extension FileDownloadManager: WebKitDownloadTaskDelegate {
                 let folderUrl = url.deletingLastPathComponent()
                 guard self.verifyAccessToDestinationFolder(folderUrl,
                                                            destinationRequested: preferences.alwaysRequestDownloadLocation,
-                                                           isAppStoreBuild: AppDelegate.isAppStoreBuild) else {
+                                                           isSandboxed: NSApp.isSandboxed) else {
                     completion(nil, nil)
                     return
                 }
@@ -194,7 +194,7 @@ extension FileDownloadManager: WebKitDownloadTaskDelegate {
                 let folderUrl = url.deletingLastPathComponent()
                 guard self.verifyAccessToDestinationFolder(folderUrl,
                                                            destinationRequested: self.preferences.alwaysRequestDownloadLocation,
-                                                           isAppStoreBuild: AppDelegate.isAppStoreBuild) else {
+                                                           isSandboxed: NSApp.isSandboxed) else {
                     completion(nil, nil)
                     return
                 }
@@ -211,8 +211,8 @@ extension FileDownloadManager: WebKitDownloadTaskDelegate {
         }
     }
 
-    private func verifyAccessToDestinationFolder(_ folderUrl: URL, destinationRequested: Bool, isAppStoreBuild: Bool) -> Bool {
-        if destinationRequested && isAppStoreBuild { return true }
+    private func verifyAccessToDestinationFolder(_ folderUrl: URL, destinationRequested: Bool, isSandboxed: Bool) -> Bool {
+        if destinationRequested && isSandboxed { return true }
 
         let folderPath = folderUrl.relativePath
         let c = open(folderPath, O_RDONLY)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204077668428787/f
CC: @ayoy 

**Description**:
This PR fixes the issue of `open(folderPath, O_RDONLY)` which always returned an error when trying to access a directory outside of the App Sandbox, even if it happened after the user has selected the directory in NSSavePanel.

**Steps to test this PR**:
1. Execute testing steps from https://github.com/duckduckgo/macos-browser/pull/970

3. On top of that, change your Downloads preferences to "Always ask where to save files"
4. Try to download a file to Desktop on both App Store and non App Store builds

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
