### PR TITLE
Enable Add button when creating new bookmark and bookmark already exists

### DIFF
--- a/DuckDuckGo/Bookmarks/View/AddBookmarkModalViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/AddBookmarkModalViewController.swift
@@ -75,8 +75,7 @@ final class AddBookmarkModalViewController: NSViewController {
         if originalBookmark != nil {
             return !bookmarkTitleTextField.stringValue.isEmpty && url.isValid
         } else {
-            let isBookmarked = LocalBookmarkManager.shared.isUrlBookmarked(url: url)
-            let isInputValid = !bookmarkTitleTextField.stringValue.isEmpty && url.isValid && !isBookmarked
+            let isInputValid = !bookmarkTitleTextField.stringValue.isEmpty && url.isValid
 
             return isInputValid
         }


### PR DESCRIPTION
# Task/Issue URL

https://app.asana.com/0/1203949938596045/1203959599365992/f

## Description
When creating a bookmark manually from the bookmarks panel, if the bookmark was already added, the 'Add' button is disabled, and the user does not have any input on why it was being disabled.

When the bookmark gets added using the bookmark popover (pressing cmd+D, tapping the book address icon, or the 'Bookmark this page' from the Bookmarks menu item), we show the popover with the 'Bookmark added' and we let the user press 'Done' even if the bookmark was already added.

This change adds some consistency. In the future, it would be nice to change the popover menu to show 'Edit bookmark' instead of 'Bookmark added' when the bookmark was already added. Brave, for example, shows different popover titles when that happens.

## Steps to test this PR:
1. Go to the three-dot settings menu
2. Go to Bookmarks -> Open Bookmarks Panel
3. There tap the 'New bookmark' icon
4. A dialog with the 'New bookmark' title should appear with two fields: 'Title' and 'Address'
5. Try to add a bookmark with an address that already exists in your bookmarks list
6. The 'Add' button should be enabled and you should be able to tap it

## Screenshots
| Before | After |
| --- | --- |
|<video src="https://user-images.githubusercontent.com/7924732/222278044-831032bc-08ba-4ba5-8c97-df50a70d88b0.mov"/>|<video src="https://user-images.githubusercontent.com/7924732/222278132-b9bc1c48-a295-4150-b8cb-ec52dcfea733.mov"/>|