### PR TITLE
Dedicated temp directory for Tests

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1494,6 +1494,18 @@
 		B604085C274B8FBA00680351 /* UnprotectedDomains.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B604085A274B8CA300680351 /* UnprotectedDomains.xcdatamodeld */; };
 		B6085D062743905F00A9C456 /* CoreDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6085D052743905F00A9C456 /* CoreDataStore.swift */; };
 		B6085D092743AAB600A9C456 /* FireproofDomains.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B6085D072743993C00A9C456 /* FireproofDomains.xcdatamodeld */; };
+		B60C6F7E29B1B41D007BFAA8 /* TestRunHelperInitializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F7D29B1B41D007BFAA8 /* TestRunHelperInitializer.m */; };
+		B60C6F7F29B1B41D007BFAA8 /* TestRunHelperInitializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F7D29B1B41D007BFAA8 /* TestRunHelperInitializer.m */; };
+		B60C6F8129B1B4AD007BFAA8 /* TestRunHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F8029B1B4AD007BFAA8 /* TestRunHelper.swift */; };
+		B60C6F8229B1B4AD007BFAA8 /* TestRunHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F8029B1B4AD007BFAA8 /* TestRunHelper.swift */; };
+		B60C6F8429B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F8329B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift */; };
+		B60C6F8529B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F8329B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift */; };
+		B60C6F8629B1CAB0007BFAA8 /* TestRunHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F8029B1B4AD007BFAA8 /* TestRunHelper.swift */; };
+		B60C6F8729B1CAB2007BFAA8 /* TestRunHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F8029B1B4AD007BFAA8 /* TestRunHelper.swift */; };
+		B60C6F8829B1CAB6007BFAA8 /* TestRunHelperInitializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F7D29B1B41D007BFAA8 /* TestRunHelperInitializer.m */; };
+		B60C6F8929B1CAB7007BFAA8 /* TestRunHelperInitializer.m in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F7D29B1B41D007BFAA8 /* TestRunHelperInitializer.m */; };
+		B60C6F8A29B1CABF007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F8329B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift */; };
+		B60C6F8B29B1CAC0007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60C6F8329B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift */; };
 		B6106BA026A7BE0B0013B453 /* PermissionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6106B9F26A7BE0B0013B453 /* PermissionManagerTests.swift */; };
 		B6106BA726A7BECC0013B453 /* PermissionAuthorizationQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6106BA526A7BEC80013B453 /* PermissionAuthorizationQuery.swift */; };
 		B6106BAB26A7BF1D0013B453 /* PermissionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6106BAA26A7BF1D0013B453 /* PermissionType.swift */; };
@@ -2467,6 +2479,9 @@
 		B604085B274B8CA400680351 /* Permissions.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Permissions.xcdatamodel; sourceTree = "<group>"; };
 		B6085D052743905F00A9C456 /* CoreDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStore.swift; sourceTree = "<group>"; };
 		B6085D082743993D00A9C456 /* Permissions.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Permissions.xcdatamodel; sourceTree = "<group>"; };
+		B60C6F7D29B1B41D007BFAA8 /* TestRunHelperInitializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestRunHelperInitializer.m; sourceTree = "<group>"; };
+		B60C6F8029B1B4AD007BFAA8 /* TestRunHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRunHelper.swift; sourceTree = "<group>"; };
+		B60C6F8329B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerTempDirReplacement.swift; sourceTree = "<group>"; };
 		B6106B9D26A565DA0013B453 /* BundleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
 		B6106B9F26A7BE0B0013B453 /* PermissionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManagerTests.swift; sourceTree = "<group>"; };
 		B6106BA526A7BEC80013B453 /* PermissionAuthorizationQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAuthorizationQuery.swift; sourceTree = "<group>"; };
@@ -4047,6 +4062,7 @@
 				4B723E1726B000DC00E14D75 /* TemporaryFileCreator.swift */,
 				4BBF09222830812900EE1418 /* FileSystemDSL.swift */,
 				4BBF0924283083EC00EE1418 /* FileSystemDSLTests.swift */,
+				B60C6F8329B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift */,
 				4B9292C42667104B00AD2C21 /* CoreDataTestUtilities.swift */,
 				B683097A274DCFE3004B46BB /* Database */,
 				AAEC74B92642E66600C2EFBC /* Extensions */,
@@ -4058,6 +4074,8 @@
 				B6B3E0952654DACD0040E0A2 /* UTTypeTests.swift */,
 				B693956626F352940015B914 /* TestsBridging.h */,
 				B6DA06E02913AEDB00225DE2 /* TestNavigationDelegate.swift */,
+				B60C6F8029B1B4AD007BFAA8 /* TestRunHelper.swift */,
+				B60C6F7D29B1B41D007BFAA8 /* TestRunHelperInitializer.m */,
 				B6CA482F298D04690067ECCE /* MockPrivacyConfiguration.swift */,
 			);
 			path = Common;
@@ -6851,6 +6869,7 @@
 				3706FE31293F661700E42796 /* TabCollectionViewModelDelegateMock.swift in Sources */,
 				3706FE32293F661700E42796 /* BookmarksHTMLReaderTests.swift in Sources */,
 				3706FE33293F661700E42796 /* FireTests.swift in Sources */,
+				B60C6F8229B1B4AD007BFAA8 /* TestRunHelper.swift in Sources */,
 				3706FE34293F661700E42796 /* PermissionStoreTests.swift in Sources */,
 				3706FE35293F661700E42796 /* ThirdPartyBrowserTests.swift in Sources */,
 				3706FE36293F661700E42796 /* FirefoxFaviconsReaderTests.swift in Sources */,
@@ -6903,6 +6922,7 @@
 				3706FE5E293F661700E42796 /* DataImportMocks.swift in Sources */,
 				3706FE5F293F661700E42796 /* CrashReportTests.swift in Sources */,
 				3706FE60293F661700E42796 /* ConfigurationDownloaderTests.swift in Sources */,
+				B60C6F7F29B1B41D007BFAA8 /* TestRunHelperInitializer.m in Sources */,
 				3706FE61293F661700E42796 /* PinnedTabsViewModelTests.swift in Sources */,
 				3706FE62293F661700E42796 /* PasswordManagementListSectionTests.swift in Sources */,
 				3706FE63293F661700E42796 /* RecentlyClosedCoordinatorMock.swift in Sources */,
@@ -6940,6 +6960,7 @@
 				3706FE7F293F661700E42796 /* FileDownloadManagerMock.swift in Sources */,
 				3706FE80293F661700E42796 /* DeallocationTests.swift in Sources */,
 				3706FE81293F661700E42796 /* PermissionModelTests.swift in Sources */,
+				B60C6F8529B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */,
 				3706FE82293F661700E42796 /* MockStatisticsStore.swift in Sources */,
 				B6AA64752995164700D99CD6 /* MockPrivacyConfiguration.swift in Sources */,
 				3706FE83293F661700E42796 /* AutofillPreferencesModelTests.swift in Sources */,
@@ -6961,9 +6982,12 @@
 				3707C72E294B5D4400682A9F /* ContentBlockerRulesManagerMock.swift in Sources */,
 				3707C72C294B5D3D00682A9F /* ContentBlockingMock.swift in Sources */,
 				3706FEA3293F662100E42796 /* CoreDataEncryptionTests.swift in Sources */,
+				B60C6F8929B1CAB7007BFAA8 /* TestRunHelperInitializer.m in Sources */,
+				B60C6F8B29B1CAC0007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */,
 				3706FEA4293F662100E42796 /* CoreDataTestUtilities.swift in Sources */,
 				B626A77229928C6A00053070 /* MockPrivacyConfiguration.swift in Sources */,
 				3706FEA5293F662100E42796 /* CoreDataEncryptionTesting.xcdatamodeld in Sources */,
+				B60C6F8729B1CAB2007BFAA8 /* TestRunHelper.swift in Sources */,
 				3706FEA6293F662100E42796 /* EncryptionKeyStoreTests.swift in Sources */,
 				B6F5656A299A414300A04298 /* WKWebViewMockingExtension.swift in Sources */,
 			);
@@ -6981,9 +7005,12 @@
 				B31055CE27A1BA44001AC618 /* AutoconsentBackgroundTests.swift in Sources */,
 				4B1AD91725FC46FB00261379 /* CoreDataEncryptionTests.swift in Sources */,
 				7BA4727D26F01BC400EAA165 /* CoreDataTestUtilities.swift in Sources */,
+				B60C6F8829B1CAB6007BFAA8 /* TestRunHelperInitializer.m in Sources */,
+				B60C6F8A29B1CABF007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */,
 				4B1AD92125FC474E00261379 /* CoreDataEncryptionTesting.xcdatamodeld in Sources */,
 				B626A77329928C6B00053070 /* MockPrivacyConfiguration.swift in Sources */,
 				B6BDD9F62940B5B500F68088 /* ContentBlockingMock.swift in Sources */,
+				B60C6F8629B1CAB0007BFAA8 /* TestRunHelper.swift in Sources */,
 				4B1AD8D525FC38DD00261379 /* EncryptionKeyStoreTests.swift in Sources */,
 				B6F56568299A414300A04298 /* WKWebViewMockingExtension.swift in Sources */,
 			);
@@ -7664,6 +7691,7 @@
 				37CD54BB27F25A4000F1F7B9 /* DownloadsPreferencesTests.swift in Sources */,
 				4B02199C25E063DE00ED7DEA /* FireproofDomainsTests.swift in Sources */,
 				AA0F3DB7261A566C0077F2D9 /* SuggestionLoadingMock.swift in Sources */,
+				B60C6F8129B1B4AD007BFAA8 /* TestRunHelper.swift in Sources */,
 				4B9292BE2667103100AD2C21 /* PasteboardFolderTests.swift in Sources */,
 				4B9292C52667104B00AD2C21 /* CoreDataTestUtilities.swift in Sources */,
 				4B723E1926B000DC00E14D75 /* TemporaryFileCreator.swift in Sources */,
@@ -7683,6 +7711,7 @@
 				B6106BB126A7D8720013B453 /* PermissionStoreTests.swift in Sources */,
 				4BF4951826C08395000547B8 /* ThirdPartyBrowserTests.swift in Sources */,
 				4B98D27C28D960DD003C2B6F /* FirefoxFaviconsReaderTests.swift in Sources */,
+				B60C6F7E29B1B41D007BFAA8 /* TestRunHelperInitializer.m in Sources */,
 				37479F152891BC8300302FE2 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift in Sources */,
 				AA63745424C9BF9A00AB2AC4 /* SuggestionContainerTests.swift in Sources */,
 				AAC9C01524CAFBCE00AD1325 /* TabTests.swift in Sources */,
@@ -7708,6 +7737,7 @@
 				4B9292C02667103100AD2C21 /* BookmarkManagedObjectTests.swift in Sources */,
 				373A1AB228451ED400586521 /* BookmarksHTMLImporterTests.swift in Sources */,
 				4B723E0626B0003E00E14D75 /* CSVParserTests.swift in Sources */,
+				B60C6F8429B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */,
 				85F487B5276A8F2E003CE668 /* OnboardingTests.swift in Sources */,
 				B626A7642992506A00053070 /* SerpHeadersNavigationResponderTests.swift in Sources */,
 				AA652CCE25DD9071009059CC /* BookmarkListTests.swift in Sources */,

--- a/DuckDuckGo/Browser Tab/Services/WebsiteDataStore.swift
+++ b/DuckDuckGo/Browser Tab/Services/WebsiteDataStore.swift
@@ -66,7 +66,7 @@ internal class WebCacheManager {
         let fm = FileManager.default
         let cachesDir = fm.urls(for: .cachesDirectory, in: .userDomainMask).first!
             .appendingPathComponent(Bundle.main.bundleIdentifier!)
-        let tmpDir = fm.temporaryDirectory(appropriateFor: cachesDir).appendingPathComponent(UUID().uuidString)
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 
         do {
             try fm.createDirectory(at: tmpDir, withIntermediateDirectories: false, attributes: nil)
@@ -96,7 +96,7 @@ internal class WebCacheManager {
         libraryURL.appendPathComponent("WebKit/\(bundleID)/WebsiteData/DeviceIdHashSalts/1")
 
         let fm = FileManager.default
-        let tmpDir = fm.temporaryDirectory(appropriateFor: libraryURL).appendingPathComponent(UUID().uuidString)
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 
         do {
             try fm.createDirectory(at: tmpDir, withIntermediateDirectories: false, attributes: nil)

--- a/DuckDuckGo/Common/Extensions/FileManagerExtension.swift
+++ b/DuckDuckGo/Common/Extensions/FileManagerExtension.swift
@@ -82,35 +82,4 @@ extension FileManager {
         fatalError("Unexpected flow")
     }
 
-    func temporaryDirectory(appropriateFor url: URL?) -> URL {
-        do {
-            struct ThrowableError: Error {}
-            guard let url = url else { throw ThrowableError() }
-
-            // this creates a temp diretory on the same volume as a requested url
-            // "(A Document Being Saved By DuckDuckGo Privacy Browser N)" folder is created
-            // on every call even if `create: false` is passed
-            // and this starts to fail after reaching 1000 folders
-            // so we'll create a temp directory, then delete it and
-            // return its parent (actual temp dir)
-            var tempURL = try self.url(for: .itemReplacementDirectory,
-                                       in: .userDomainMask,
-                                       appropriateFor: url,
-                                       create: true)
-            try self.removeItem(at: tempURL)
-
-            tempURL = tempURL.deletingLastPathComponent()
-            var isDir: ObjCBool = false
-            guard self.fileExists(atPath: tempURL.path, isDirectory: &isDir),
-                  isDir.boolValue,
-                  try tempURL.resourceValues(forKeys: [.isWritableKey]).isWritable == true
-            else { throw ThrowableError() }
-
-            return tempURL
-
-        } catch {
-            return self.temporaryDirectory
-        }
-    }
-
 }

--- a/DuckDuckGo/File Download/Model/WebKitDownloadTask.swift
+++ b/DuckDuckGo/File Download/Model/WebKitDownloadTask.swift
@@ -147,7 +147,7 @@ final class WebKitDownloadTask: NSObject, ProgressReporting {
 
         // create temp file and move to Downloads folder with .duckload extension increasing index if needed
         let fm = FileManager.default
-        let tempURL = fm.temporaryDirectory(appropriateFor: localURL).appendingPathComponent(.uniqueFilename())
+        let tempURL = fm.temporaryDirectory.appendingPathComponent(.uniqueFilename())
         do {
             guard fm.createFile(atPath: tempURL.path, contents: nil, attributes: nil) else {
                 throw CocoaError(.fileWriteNoPermission)

--- a/Unit Tests/App Delegate/URLEventHandlerTests.swift
+++ b/Unit Tests/App Delegate/URLEventHandlerTests.swift
@@ -52,7 +52,7 @@ final class URLEventHandlerTests: XCTestCase {
     }
 
     func testWhenFilePassedOnLaunchThenFileOpenedAfterAppDidFinishLaunching() {
-        let filepath = FileManager.default.temporaryDirectory(appropriateFor: nil).appendingPathComponent("testres.html").path
+        let filepath = FileManager.default.temporaryDirectory.appendingPathComponent("testres.html").path
         FileManager.default.createFile(atPath: filepath, contents: nil, attributes: nil)
         var handlerCalled: XCTestExpectation!
         let listener = URLEventHandler { url in

--- a/Unit Tests/Common/Extensions/FileManagerExtensionTests.swift
+++ b/Unit Tests/Common/Extensions/FileManagerExtensionTests.swift
@@ -27,30 +27,6 @@ class FileManagerExtensionTests: XCTestCase {
     let testData = "test".data(using: .utf8)!
     let fm = FileManager.default
 
-    override func setUp() {
-        let tempDir = fm.temporaryDirectory
-        for file in (try? fm.contentsOfDirectory(atPath: tempDir.path)) ?? [] where file.hasPrefix(testFile) {
-            try? fm.removeItem(at: tempDir.appendingPathComponent(file))
-        }
-    }
-
-    func testFileManagerCanCreateMoreThan1000TempDirs() {
-        let tempURL = fm.temporaryDirectory(appropriateFor: nil)
-        for _ in 0...1001 {
-            let otherTempURL = fm.temporaryDirectory(appropriateFor: nil)
-            XCTAssertEqual(otherTempURL, tempURL)
-        }
-    }
-
-    func testFileManagerCanCreateMoreThan1000TempDirsAppropriateForURL() {
-        let bundleURL = Bundle(for: Self.self).bundleURL
-        let tempURL = fm.temporaryDirectory(appropriateFor: bundleURL)
-        for _ in 0...1001 {
-            let otherTempURL = fm.temporaryDirectory(appropriateFor: bundleURL)
-            XCTAssertEqual(otherTempURL, tempURL)
-        }
-    }
-
     func testWhenItemMovedToSameURLIncrementingIndexThenNoErrorIsThrown() {
         let srcURL = fm.temporaryDirectory.appendingPathComponent(testFile)
         try? testData.write(to: srcURL)

--- a/Unit Tests/Common/FileManagerTempDirReplacement.swift
+++ b/Unit Tests/Common/FileManagerTempDirReplacement.swift
@@ -1,0 +1,42 @@
+//
+//  FileManagerTempDirReplacement.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension FileManager {
+
+    static var swizzleTemporaryDirectoryOnce: Void = {
+        let temporaryDirectoryMethod = class_getInstanceMethod(FileManager.self, #selector(getter: FileManager.temporaryDirectory))!
+        let swizzledTemporaryDirectoryMethod = class_getInstanceMethod(FileManager.self, #selector(FileManager.swizzled_temporaryDirectory))!
+
+        method_exchangeImplementations(temporaryDirectoryMethod, swizzledTemporaryDirectoryMethod)
+    }()
+
+    @objc dynamic func swizzled_temporaryDirectory() -> URL {
+        let testsTempDir = self.swizzled_temporaryDirectory()
+            .appendingPathComponent(Bundle(for: TestRunHelper.self).bundleIdentifier!)
+        try? self.createDirectory(at: testsTempDir, withIntermediateDirectories: false)
+        return testsTempDir
+    }
+
+    func cleanupTemporaryDirectory() {
+        try? self.removeItem(at: self.temporaryDirectory)
+        _=self.temporaryDirectory
+    }
+
+}

--- a/Unit Tests/Common/TestRunHelper.swift
+++ b/Unit Tests/Common/TestRunHelper.swift
@@ -1,0 +1,67 @@
+//
+//  TestRunHelper.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+@objc(TestRunHelper)
+final class TestRunHelper: NSObject {
+    @objc(sharedInstance) static let shared = TestRunHelper()
+
+    override init() {
+        super.init()
+        XCTestObservationCenter.shared.addTestObserver(self)
+
+        // dedicate temporary directory for tests
+        _=FileManager.swizzleTemporaryDirectoryOnce
+
+        // add code to be run on Unit Tests startup here...
+
+    }
+
+}
+
+extension TestRunHelper: XCTestObservation {
+
+    func testBundleWillStart(_ testBundle: Bundle) {
+
+    }
+
+    func testBundleDidFinish(_ testBundle: Bundle) {
+
+    }
+
+    func testSuiteWillStart(_ testSuite: XCTestSuite) {
+
+    }
+
+    func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+
+    }
+
+    func testCaseWillStart(_ testCase: XCTestCase) {
+        // cleanup dedicated temporary directory before each test run
+        FileManager.default.cleanupTemporaryDirectory()
+    }
+
+    func testCaseDidFinish(_ testCase: XCTestCase) {
+        // cleanup dedicated temporary directory after each test run
+        FileManager.default.cleanupTemporaryDirectory()
+    }
+
+}

--- a/Unit Tests/Common/TestRunHelperInitializer.m
+++ b/Unit Tests/Common/TestRunHelperInitializer.m
@@ -1,0 +1,31 @@
+//
+//  TestRunHelperInitializer.m
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface TestRunHelperInitializer: NSObject
+@end
+
+@implementation TestRunHelperInitializer
+
+// instantiate on app loading
++ (void)load {
+    [NSClassFromString(@"TestRunHelper") sharedInstance];
+}
+
+@end

--- a/Unit Tests/File Download/FileDownloadManagerTests.swift
+++ b/Unit Tests/File Download/FileDownloadManagerTests.swift
@@ -368,8 +368,7 @@ private extension FileManager {
         self.urlsForIn = nil
     }
 
-    @objc
-    func swizzled_urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+    @objc dynamic func swizzled_urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
         Self.lock.lock()
         defer { Self.lock.unlock() }
         guard let urlsForIn = Self.urlsForIn else { return self.urls(for: directory, in: domainMask) }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200194497630846/1203880849762501/f

**Description**:
- TestRunHelper used to track the whole Test Suite lifecycle
- Swizzled FileManager.temporaryDirectory to dedicate a directory for test runs and clean it up before/after each test case run
- FileManager.temporaryDirectory(appropriateFor:) extension removed as non needed

**Steps to test this PR**:
1. Validate Unit Tests work
2. Validate Downloads to default directory works
3. Validate burning web cache works (clearFileCache, clearDeviceHashSalts)
