### PR TITLE
Cleanup old bookmarks data if these have been already migrated

### DIFF
--- a/DuckDuckGo/Bookmarks/Legacy/LegacyBookmarksStoreMigration.swift
+++ b/DuckDuckGo/Bookmarks/Legacy/LegacyBookmarksStoreMigration.swift
@@ -57,7 +57,7 @@ public class LegacyBookmarksStoreMigration {
             // There should be no data left as migration has been done already
             if !bookmarkRoots.isEmpty {
                 Pixel.fire(.debug(event: .bookmarksMigrationAlreadyPerformed))
-                
+
                 cleanupOldData(in: source)
             }
             return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1204104921329543
Tech Design URL:
CC:

**Description**:

It is possible that due to timing issue new data has been saved but old has not been removed. We should cleanup old data if we detect that.

**Steps to test this PR**:

Perform migration and kill the app before cleaning old store, or try downgrading the app and creating bookmarks in old DB before updating again.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
