### PR TITLE
Restore recently closed tabs with their local history

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -917,6 +917,8 @@
 		373A1AB02842C4EA00586521 /* BookmarkHTMLImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373A1AAF2842C4EA00586521 /* BookmarkHTMLImporter.swift */; };
 		373A1AB228451ED400586521 /* BookmarksHTMLImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373A1AB128451ED400586521 /* BookmarksHTMLImporterTests.swift */; };
 		37479F152891BC8300302FE2 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37479F142891BC8300302FE2 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift */; };
+		374EF08329B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374EF08229B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift */; };
+		374EF08429B7575B003D2E87 /* RecentlyClosedCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374EF08229B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift */; };
 		37534C9E28104D9B002621E7 /* TabLazyLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37534C9D28104D9B002621E7 /* TabLazyLoaderTests.swift */; };
 		37534CA028113101002621E7 /* LazyLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37534C9F28113101002621E7 /* LazyLoadable.swift */; };
 		37534CA3281132CB002621E7 /* TabLazyLoaderDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37534CA2281132CB002621E7 /* TabLazyLoaderDataSource.swift */; };
@@ -1935,6 +1937,7 @@
 		373A1AB128451ED400586521 /* BookmarksHTMLImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksHTMLImporterTests.swift; sourceTree = "<group>"; };
 		373A26962964CF0B0043FC57 /* TestsTargetsBase.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TestsTargetsBase.xcconfig; sourceTree = "<group>"; };
 		37479F142891BC8300302FE2 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabCollectionViewModelTests+WithoutPinnedTabsManager.swift"; sourceTree = "<group>"; };
+		374EF08229B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyClosedCoordinatorTests.swift; sourceTree = "<group>"; };
 		37534C9D28104D9B002621E7 /* TabLazyLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLazyLoaderTests.swift; sourceTree = "<group>"; };
 		37534C9F28113101002621E7 /* LazyLoadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyLoadable.swift; sourceTree = "<group>"; };
 		37534CA2281132CB002621E7 /* TabLazyLoaderDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLazyLoaderDataSource.swift; sourceTree = "<group>"; };
@@ -4560,6 +4563,7 @@
 			isa = PBXGroup;
 			children = (
 				AA7E9175286DB05D00AB6B62 /* RecentlyClosedCoordinatorMock.swift */,
+				374EF08229B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift */,
 			);
 			path = RecentlyClosed;
 			sourceTree = "<group>";
@@ -6893,6 +6897,7 @@
 				3706FDE7293F661700E42796 /* RecentlyVisitedSiteModelTests.swift in Sources */,
 				3706FDE8293F661700E42796 /* TemporaryFileHandlerTests.swift in Sources */,
 				3706FDE9293F661700E42796 /* StateRestorationManagerTests.swift in Sources */,
+				374EF08429B7575B003D2E87 /* RecentlyClosedCoordinatorTests.swift in Sources */,
 				3706FDEA293F661700E42796 /* BookmarkNodeTests.swift in Sources */,
 				3706FDEB293F661700E42796 /* WebsiteDataStoreTests.swift in Sources */,
 				3706FDEC293F661700E42796 /* TabCollectionViewModelTests.swift in Sources */,
@@ -7894,6 +7899,7 @@
 				3783F92329432E1800BCA897 /* WebViewTests.swift in Sources */,
 				EA8AE76A279FBDB20078943E /* ClickToLoadTDSTests.swift in Sources */,
 				B63ED0DA26AE7AF400A9DAD1 /* PermissionManagerMock.swift in Sources */,
+				374EF08329B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift in Sources */,
 				AA9C362825518C44004B1BA3 /* WebsiteDataStoreMock.swift in Sources */,
 				3776582D27F71652009A6B35 /* WebsiteBreakageReportTests.swift in Sources */,
 				31E163BA293A56F400963C10 /* BrokenSiteReportingReferenceTests.swift in Sources */,

--- a/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedCoordinator.swift
+++ b/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedCoordinator.swift
@@ -205,26 +205,11 @@ final class RecentlyClosedCoordinator: RecentlyClosedCoordinating {
 
     func burnCache(domains: Set<String>? = nil) {
         if let domains = domains {
-            cache.removeAll { (cacheItem) in
-                switch cacheItem {
-                case let tab as RecentlyClosedTab:
-                    return tab.contentContainsDomains(domains)
-                case let window as RecentlyClosedWindow:
-                    window.tabs.removeAll(where: { tab in
-                        tab.contentContainsDomains(domains)
-                    })
-                    if window.tabs.isEmpty { return true }
-                default:
-                    assertionFailure("Unknown type")
-                }
-
-                return false
-            }
+            cache.burn(for: domains)
         } else {
             cache.removeAll()
         }
     }
-
 }
 
 private extension RecentlyClosedTab {
@@ -237,15 +222,6 @@ private extension RecentlyClosedTab {
                   originalTabCollection: originalTabCollection,
                   index: tabIndex)
     }
-
-    func contentContainsDomains(_ domains: Set<String>) -> Bool {
-        if let host = tabContent.url?.host, domains.contains(host) {
-            return true
-        } else {
-            return false
-        }
-    }
-
 }
 
 private extension Tab {
@@ -253,5 +229,4 @@ private extension Tab {
     var isContentEmpty: Bool {
         content == .none || content == .homePage
     }
-
 }

--- a/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedTab.swift
+++ b/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedTab.swift
@@ -32,7 +32,7 @@ final class RecentlyClosedTab: RecentlyClosedCacheItem {
     let tabContent: Tab.TabContent
     let favicon: NSImage?
     let title: String?
-    let interactionData: Data?
+    var interactionData: Data?
 
     weak var originalTabCollection: TabCollection?
     let index: TabIndex

--- a/UnitTests/RecentlyClosed/RecentlyClosedCoordinatorTests.swift
+++ b/UnitTests/RecentlyClosed/RecentlyClosedCoordinatorTests.swift
@@ -1,0 +1,99 @@
+//
+//  RecentlyClosedCoordinatorTests.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Combine
+@testable import DuckDuckGo_Privacy_Browser
+
+final class RecentlyClosedCoordinatorTests: XCTestCase {
+
+    let tab1 = RecentlyClosedTab("https://site1.com")
+    let tab2 = RecentlyClosedTab("https://site2.com")
+    let tab3 = RecentlyClosedTab("https://site2.com")
+    let tab4 = RecentlyClosedTab("https://site3.com")
+
+    func testWhenDomainsAreBurnedThenCachedTabsOpenToThemAreRemoved() throws {
+        var cache: [RecentlyClosedCacheItem] = [
+            tab1,
+            tab2,
+            RecentlyClosedWindow([
+                tab3,
+                tab4
+            ])
+        ]
+
+        cache.burn(for: ["site1.com", "site3.com"])
+
+        XCTAssertEqual(cache.count, 2)
+        let tab = try XCTUnwrap(cache[0] as? RecentlyClosedTab)
+        XCTAssertEqual(tab.tabContent, .url("https://site2.com".url!))
+
+        let window = try XCTUnwrap(cache[1] as? RecentlyClosedWindow)
+        XCTAssertEqual(window.tabs.count, 1)
+        XCTAssertEqual(window.tabs[0].tabContent, .url("https://site2.com".url!))
+    }
+
+    func testWhenDomainsAreBurnedThenInteractionDataIsDeleted() throws {
+        var cache: [RecentlyClosedCacheItem] = [
+            tab1,
+            tab2,
+            RecentlyClosedWindow([
+                tab3,
+                tab4
+            ])
+        ]
+
+        cache.burn(for: ["unrelatedsite1.com", "unrelatedsite2.com"])
+
+        XCTAssertEqual(cache.count, 3)
+
+        let tab1 = try XCTUnwrap(cache[0] as? RecentlyClosedTab)
+        XCTAssertNil(tab1.interactionData)
+
+        let tab2 = try XCTUnwrap(cache[1] as? RecentlyClosedTab)
+        XCTAssertNil(tab2.interactionData)
+
+        let window = try XCTUnwrap(cache[2] as? RecentlyClosedWindow)
+        XCTAssertEqual(window.tabs.count, 2)
+        XCTAssertNil(window.tabs[0].interactionData)
+        XCTAssertNil(window.tabs[1].interactionData)
+    }
+}
+
+private extension RecentlyClosedTab {
+    convenience init(_ url: String) {
+        self.init(tabContent: .url(url.url!), favicon: nil, title: nil, interactionData: Data(), index: .unpinned(0))
+    }
+}
+
+private extension RecentlyClosedWindow {
+    convenience init(_ tabs: [RecentlyClosedTab]) {
+        self.init(tabs: tabs, droppingPoint: nil, contentSize: nil)
+    }
+}
+
+private final class WindowControllersManagerMock: WindowControllersManagerProtocol {
+
+    var pinnedTabsManager = PinnedTabsManager(tabCollection: .init())
+
+    var didRegisterWindowController = PassthroughSubject<(MainWindowController), Never>()
+    var didUnregisterWindowController = PassthroughSubject<(MainWindowController), Never>()
+
+    func register(_ windowController: MainWindowController) {}
+    func unregister(_ windowController: MainWindowController) {}
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1200567280161804/f

**Description**:
Store tab interaction data in RecentlyClosedTab, in order to preserve back-forward list
when reopening recently closed tabs/windows.

**Steps to test this PR**:
1. Open a new tab
2. Navigate to wikipedia.org
3. Navigate to cnn.com
4. Close the tab
5. Reopen it using Main Menu -> History -> Reopen Last Closed Tab
6. Verify that the cnn.com tab is restored, the back button is active and it takes you to wikipedia.org
7. Go back to cnn.com and close the tab
8. Burn only wikipedia.org domain
9. Reopen the tab using Main Menu -> History -> Reopen Last Closed Tab
10. Verify that the cnn.com tab is restored and the back button is inactive.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
