### PR TITLE
Fix of Sparkle updates

### DIFF
--- a/DuckDuckGo/AppDelegate/UpdateController.swift
+++ b/DuckDuckGo/AppDelegate/UpdateController.swift
@@ -49,13 +49,15 @@ final class UpdateController: NSObject {
 
     // MARK: - Private
 
-    lazy private var updater = SPUStandardUpdaterController(updaterDelegate: self, userDriverDelegate: self)
+    private var updater: SPUStandardUpdaterController!
     private let willRelaunchAppSubject = PassthroughSubject<Void, Never>()
 
     private var internalUserDecider: InternalUserDeciding
 
     private func configureUpdater() {
     // The default configuration of Sparkle updates is in Info.plist
+    updater = SPUStandardUpdaterController(updaterDelegate: self, userDriverDelegate: self)
+
 #if DEBUG
         updater.updater.automaticallyChecksForUpdates = false
         updater.updater.updateCheckInterval = 0


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204087931415697/f

**Description**:
The lazy modifier caused that updater wasn't allocated in few cases and the app wasn't monitoring for updates. The property is refactored to resolve the issue.

**Steps to test this PR**:
1. Comment out following lines in UpdateController.swift
```
//#if DEBUG
//        updater.updater.automaticallyChecksForUpdates = false
//        updater.updater.updateCheckInterval = 0
//#endif
```
2. Set the version and build number of the app to something less than the latest published release
3. Clean user defaults for debug build -> ./clean-app.sh debug
4. Run the app
5. Wait couple of seconds and verify the update dialog is automatically presented to you

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
