### PR TITLE
Show "Set as Default" card on every open if not already default

### DIFF
--- a/DuckDuckGo/HomePage/View/HomePageViewController.swift
+++ b/DuckDuckGo/HomePage/View/HomePageViewController.swift
@@ -58,6 +58,8 @@ final class HomePageViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        refreshModelsOnAppBecomingActive()
+
         favoritesModel = createFavoritesModel()
         defaultBrowserModel = createDefaultBrowserModel()
         recentlyVisitedModel = createRecentlyVisitedModel()
@@ -102,6 +104,14 @@ final class HomePageViewController: NSViewController {
         super.viewWillDisappear()
 
         historyCancellable = nil
+    }
+
+    func refreshModelsOnAppBecomingActive() {
+        NotificationCenter.default
+            .publisher(for: NSApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                self?.refreshModels()
+            }.store(in: &self.cancellables)
     }
 
     func refreshModels() {
@@ -158,7 +168,13 @@ final class HomePageViewController: NSViewController {
     }
 
     func refreshDefaultBrowserModel() {
-        defaultBrowserModel.isDefault = DefaultBrowserPreferences().isDefault
+        let prefs = DefaultBrowserPreferences()
+        if prefs.isDefault {
+            defaultBrowserDismissed = false
+        }
+
+        defaultBrowserModel.isDefault = prefs.isDefault
+        defaultBrowserModel.wasClosed = defaultBrowserDismissed
     }
 
     func subscribeToBookmarks() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204088905029480/f
Tech Design URL:
CC:

**Description**:
Reset the default browser prompt dismissed flag when detecting we're the default browser.

**Steps to test this PR**:
1. Use the clean app script to clean up your debug setup
2. Run the app, but don't become default browser
3. On the home page dismiss the prompt
4. check the value using `defaults read com.duckduckgo.macos.browser.debug | grep dismissed`, should be `"browser.default.dismissed" = 1;`
5. Use `about:welcome` to set the default browser
6. Check the value using `defaults read com.duckduckgo.macos.browser.debug | grep dismissed`, should be `"browser.default.dismissed" = 0;`
7. load a web page
8. Change the default browser to Safari
9. Open a new tab, the prompt should now re-appear
10. Dismiss the prompt
11. Open and close some tabs, the prompt should not appear
12. Use the above steps to ensure the prompt appears on the new tab page, even if it's already open

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
