### PR TITLE
Silence Sparkle error pixel when the app is running directly from DMG

### DIFF
--- a/DuckDuckGo/AppDelegate/UpdateController.swift
+++ b/DuckDuckGo/AppDelegate/UpdateController.swift
@@ -91,7 +91,8 @@ extension UpdateController: SPUUpdaterDelegate {
     func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
         let errorCode = (error as NSError).code
         guard ![Int(Sparkle.SUError.noUpdateError.rawValue),
-                Int(Sparkle.SUError.installationCanceledError.rawValue)].contains(errorCode) else {
+                Int(Sparkle.SUError.installationCanceledError.rawValue),
+                Int(Sparkle.SUError.runningTranslocated.rawValue)].contains(errorCode) else {
             return
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1204253762271252/f
Tech Design URL:
CC:

**Description**:
Silencing Sparkle error pixel which isn't directly related to updates.

**Steps to test this PR**:
1. Make sure the silencing logic make sense
2. A deeper test is to make sure the pixel isn't fired when the app runs from DMG, but I think it isn't necessary

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
