### PR TITLE
Scroll to the end when tab added from website in overflow mode

### DIFF
--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -745,7 +745,7 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
     }
 
     private func scrollCollectionViewToEnd() {
-        // Old frameworks are like old people. They need a special treatment
+        // Old frameworks... need a special treatment
         collectionView.scrollToEnd { _ in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                 self.collectionView.scrollToEnd()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204215579022561/f

**Description**: Solve the bug where when opening a link in a new tab in overflow mode does not trigger the tab collection view to scroll to the end

**Steps to test this PR**:
1. Open many tabs until the overflow mode kicks in (the left and right arrows appear in the bar with the tabs). On the last tab command click on a link (or right click and select open link in a new tab). Check that the new tab appears to to the right (without needing to scroll the view)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
