### PR TITLE
Update BSK with autofill 6.4.3

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8600,8 +8600,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = cff2b1334b081ffaddabfebe0a5c69dee9efba0d;
+				kind = exactVersion;
+				version = 53.1.0;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "695b5b3ffe2be395c581474c856ab578d75a76a1",
-        "version" : "53.0.0"
+        "revision" : "9b7cd2b689f39cf34c5430fa00dabcca4d6cf6ee",
+        "version" : "53.1.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "26283ffcc7ed69a6853dfeca4514a2e552da2c96",
-        "version" : "6.4.1"
+        "revision" : "4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
+        "version" : "6.4.3"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.4.3
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/279

## Description
Updates Autofill to version [6.4.3](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.4.3).

## What's Changed

### Tests and Tooling

- Remove manual server setup in tests by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/289
- Add windows release automation by @szanto90balazs in https://github.com/duckduckgo/duckduckgo-autofill/pull/272
- Fix extension release flow by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/294
* Update Asana integration to include expected header by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/295

### Bugfixes

- Set tooltip initial offscreen position by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/291
- Only center tooltip on small screensizes by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/290


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.4.1...6.4.3

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).