### PR TITLE
fix sandboxed downloads quarantine attributes

### DIFF
--- a/DuckDuckGo/FileDownload/Model/FileDownloadManager.swift
+++ b/DuckDuckGo/FileDownload/Model/FileDownloadManager.swift
@@ -245,15 +245,8 @@ extension FileDownloadManager: WebKitDownloadTaskDelegate {
     func fileDownloadTask(_ task: WebKitDownloadTask, didFinishWith result: Result<URL, FileDownloadError>) {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        defer {
-            self.downloads.remove(task)
-            self.downloadTaskDelegates[task] = nil
-        }
-
-        if case .success(let url) = result {
-            try? url.setQuarantineAttributes(sourceURL: task.originalRequest?.url,
-                                             referrerURL: task.originalRequest?.mainDocumentURL)
-        }
+        self.downloads.remove(task)
+        self.downloadTaskDelegates[task] = nil
     }
 
 }

--- a/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
+++ b/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
@@ -44,6 +44,8 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
         var destinationURL: URL?
         /// Temporary  (.duckload)  file URL; set to nil when download completes
         var tempURL: URL?
+        /// Item-replacement directory for the item when .duckload file could not be created
+        var itemReplacementDirectory: URL?
     }
 
     @Published private(set) var location: FileLocation {
@@ -126,10 +128,9 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
                   let completionHandler = self.decideDestinationCompletionHandler
             else { throw URLError(.cancelled) }
 
-            let downloadURL = try self.downloadURL(for: localURL)
-            self.location = .init(destinationURL: localURL, tempURL: downloadURL)
+            self.location = try self.downloadLocation(for: localURL)
 
-            completionHandler(downloadURL)
+            completionHandler(location.tempURL)
 
         } catch {
             self.download.cancel()
@@ -138,9 +139,11 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
         }
     }
 
-    private func downloadURL(for localURL: URL) throws -> URL {
+    private func downloadLocation(for localURL: URL) throws -> FileLocation {
         var downloadURL = self.location.tempURL ?? localURL.appendingPathExtension(Self.downloadExtension)
+        let downloadFilename = downloadURL.lastPathComponent
         let ext = localURL.pathExtension + (localURL.pathExtension.isEmpty ? "" : ".") + Self.downloadExtension
+        var itemReplacementDirectory: URL?
 
         // create temp file and move to Downloads folder with .duckload extension increasing index if needed
         let fm = FileManager.default
@@ -149,7 +152,14 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
             guard fm.createFile(atPath: tempURL.path, contents: nil, attributes: nil) else {
                 throw CocoaError(.fileWriteNoPermission)
             }
-            downloadURL = try fm.moveItem(at: tempURL, to: downloadURL, incrementingIndexIfExists: true, pathExtension: ext)
+            do {
+                downloadURL = try fm.moveItem(at: tempURL, to: downloadURL, incrementingIndexIfExists: true, pathExtension: ext)
+            } catch CocoaError.fileWriteNoPermission {
+                // [Sandbox] we have no access to whole directory, only to the localURL
+                // ask system for a temp directory on destination volume so we can adjust file quarantine attributes inside of it
+                itemReplacementDirectory = try fm.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: localURL, create: true)
+                downloadURL = try fm.moveItem(at: tempURL, to: itemReplacementDirectory!.appendingPathComponent(downloadFilename), incrementingIndexIfExists: true)
+            }
         } catch CocoaError.fileWriteNoPermission {
             try? fm.removeItem(at: tempURL)
             downloadURL = localURL
@@ -162,7 +172,7 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
         // remove temp item and let WebKit download the file
         try? fm.removeItem(at: downloadURL)
 
-        return downloadURL
+        return .init(destinationURL: localURL, tempURL: downloadURL, itemReplacementDirectory: itemReplacementDirectory)
     }
 
     func cancel() {
@@ -209,6 +219,9 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
         if resumeData == nil,
            let tempURL = location.tempURL {
             try? FileManager.default.removeItem(at: tempURL)
+            if let itemReplacementDirectory = location.itemReplacementDirectory {
+                try? FileManager.default.removeItem(at: itemReplacementDirectory)
+            }
         }
         self.finish(with: .failure(.failedToCompleteDownloadTask(underlyingError: error,
                                                                  resumeData: resumeData,
@@ -290,6 +303,8 @@ extension WebKitDownloadTask: WebKitDownloadDelegate {}
             self.finish(with: .failure(.failedToMoveFileToDownloads))
             return
         }
+        // set quarantine attributes
+        try? (location.tempURL ?? destinationURL).setQuarantineAttributes(sourceURL: originalRequest?.url, referrerURL: originalRequest?.mainDocumentURL)
 
         if let tempURL = location.tempURL, tempURL != destinationURL {
             do {
@@ -297,6 +312,9 @@ extension WebKitDownloadTask: WebKitDownloadDelegate {}
             } catch {
                 destinationURL = tempURL
             }
+        }
+        if let itemReplacementDirectory = location.itemReplacementDirectory {
+            try? FileManager.default.removeItem(at: itemReplacementDirectory)
         }
 
         self.finish(with: .success(destinationURL))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204230165373734/f

**Description**:
- fix quarantine attributes for custom-folder downloads in Sandboxed mode

**Steps to test this PR**:
0. Use App Store build; Turn on "Always ask for download location" setting
1. Download an app (e.g. from hexfiend.com), choose save to Desktop, validate the app can be opened
2. Insert USB drive, validate temp file is created on the same drive (WebKitDownloadTask.swift:175 tempURL: downloadURL), validate the downloaded app can be opened

