### PR TITLE
Rename DMG release workflow and remove references to 'AppStore' from it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Make Release Build
+name: Make Notarized DMG Release
 
 on: 
   workflow_dispatch:
@@ -11,8 +11,8 @@ on:
         options:
         - review
         - release
-        - review-appstore
-        - release-appstore
+        - review-sandbox
+        - release-sandbox
       create-dmg:
         description: "Create DMG image"
         required: true

--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -15,7 +15,7 @@ print_usage_and_exit() {
 
 	cat <<- EOF
 	Usage:
-	  $ $(basename "$0") <review|release|review-appstore|release-appstore> [-a <asana_task_url>] [-d] [-s] [-v <version>]
+	  $ $(basename "$0") <review|release|review-sandbox|release-sandbox> [-a <asana_task_url>] [-d] [-s] [-v <version>]
 
 	Options:
 	 -a <asana_task_url>  Update Asana task after building the app (implies -d)
@@ -48,12 +48,12 @@ read_command_line_arguments() {
 			scheme="DuckDuckGo Privacy Browser"
 			configuration="Release"
 			;;
-		review-appstore)
+		review-sandbox)
 			app_name="DuckDuckGo App Store Review"
 			scheme="Product Review Release App Store"
 			configuration="Review"
 			;;
-		release-appstore)
+		release-sandbox)
 			app_name="DuckDuckGo"
 			scheme="DuckDuckGo Privacy Browser App Store"
 			configuration="Release"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1204311068911471/f

**Description**:
Updated the workflow name to “Make Notarized DMG Release” and replaced _*-appstore_
build types with _*-sandbox_. These updates are also applied to archive.sh script.

**Steps to test this PR**:
1. Verify naming changes
2. Run `./scripts/archive.sh review-sandbox` and verify that it works.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
