### PR TITLE
Daniel/login title and url changes

### DIFF
--- a/DuckDuckGo/SecureVault/Model/PasswordManagementLoginModel.swift
+++ b/DuckDuckGo/SecureVault/Model/PasswordManagementLoginModel.swift
@@ -105,7 +105,7 @@ final class PasswordManagementLoginModel: ObservableObject, PasswordManagementIt
         }
 
         let noScheme = domain.dropping(prefix: "https://").dropping(prefix: "http://")
-        return URLComponents(string: "https://\(noSchemeOrWWW)")?.host ?? ""
+        return URLComponents(string: "https://\(noScheme)")?.host ?? ""
     }
 
     var lastUpdatedDate: String = ""


### PR DESCRIPTION
Task/Issue URL:
- https://app.asana.com/0/1204099484721401/1204318806095420
- https://app.asana.com/0/1204099484721401/1204318806095425/f

**Description**:
- Do not remove the www prefix when saving passwords
- Stop pre-populating the title with the domain if no custom title was provided


**Steps to test this PR**:

**WWW Preffix**
1. Visit a website that has the www in the url
2. Login and save the username/passwiord
3. Observe the saved login includes the www prefix

**Login Item title^
1. Visit a website with a login form (ie. fill.dev)
2. Login and save the username/password when prompted
3. Go to Autofill > Login in Settings
4. Observe the recently saved item uses the host name as title
5. Click Edit
6. Observe that the Login Title is emply and the domain as a placeholder text
7. Add a custom name and hit save
8. Observe the custom name is used



---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

