### PR TITLE
Drops login title if equal to url when importing

### DIFF
--- a/DuckDuckGo/DataImport/Logins/SecureVault/SecureVaultLoginImporter.swift
+++ b/DuckDuckGo/DataImport/Logins/SecureVault/SecureVaultLoginImporter.swift
@@ -35,7 +35,8 @@ final class SecureVaultLoginImporter: LoginImporter {
         var failed: [String] = []
 
         for login in logins {
-            let account = SecureVaultModels.WebsiteAccount(title: login.title, username: login.username, domain: login.url)
+            let title = login.url != login.title ? login.title : nil
+            let account = SecureVaultModels.WebsiteAccount(title: title, username: login.username, domain: login.url)
             let credentials = SecureVaultModels.WebsiteCredentials(account: account, password: login.password.data(using: .utf8)!)
             let importSummaryValue: String
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204318806095419/f

**Description**:
If the URL is an exact match for the title, drop it on import.

**Steps to test this PR**:
1. Import a few logins from 1Password via CSV where the title is the same as the URL (Example CSV attached)
2. Observe titles are not imported if there's a match with the URL

![Screen Recording 2023-04-11 at 4 47 32 PM](https://user-images.githubusercontent.com/1156669/231201809-d689077a-b756-4dbd-973c-e15366a6a203.gif)

[sample.csv](https://github.com/duckduckgo/macos-browser/files/11201806/sample.csv)


---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
