### PR TITLE
Avoid removing Favicons from saved logins

### DIFF
--- a/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
+++ b/DuckDuckGo/Favicons/Model/FaviconImageCache.swift
@@ -107,24 +107,28 @@ final class FaviconImageCache {
 
     func burnExcept(fireproofDomains: FireproofDomains,
                     bookmarkManager: BookmarkManager,
+                    savedLogins: Set<String>,
                     completion: @escaping () -> Void) {
         removeFavicons(filter: { favicon in
             guard let host = favicon.documentUrl.host else {
                 return false
             }
             return !(fireproofDomains.isFireproof(fireproofDomain: host) ||
-                     bookmarkManager.isHostInBookmarks(host: host))
+                     bookmarkManager.isHostInBookmarks(host: host) ||
+                     savedLogins.contains(host)
+            )
         }, completionHandler: completion)
     }
 
     func burnDomains(_ domains: Set<String>,
-                     except bookmarkManager: BookmarkManager,
+                     exceptBookmarks bookmarkManager: BookmarkManager,
+                     exceptSavedLogins: Set<String>,
                      completion: @escaping () -> Void) {
         removeFavicons(filter: { favicon in
             guard let host = favicon.documentUrl.host else {
                 return false
             }
-            return domains.contains(host) && !bookmarkManager.isHostInBookmarks(host: host)
+            return domains.contains(host) && !bookmarkManager.isHostInBookmarks(host: host) && !exceptSavedLogins.contains(host)
         }, completionHandler: completion)
     }
 

--- a/DuckDuckGo/Favicons/Model/FaviconManager.swift
+++ b/DuckDuckGo/Favicons/Model/FaviconManager.swift
@@ -34,9 +34,9 @@ protocol FaviconManagement {
 
     func getCachedFavicon(for host: String, sizeCategory: Favicon.SizeCategory) -> Favicon?
 
-    func burnExcept(fireproofDomains: FireproofDomains, bookmarkManager: BookmarkManager, completion: @escaping () -> Void)
+    func burnExcept(fireproofDomains: FireproofDomains, bookmarkManager: BookmarkManager, savedLogins: Set<String>, completion: @escaping () -> Void)
 
-    func burnDomains(_ domains: Set<String>, except bookmarkManager: BookmarkManager, completion: @escaping () -> Void)
+    func burnDomains(_ domains: Set<String>, exceptBookmarks bookmarkManager: BookmarkManager, exceptSavedLogins: Set<String>, completion: @escaping () -> Void)
 
 }
 
@@ -185,21 +185,25 @@ final class FaviconManager: FaviconManagement {
 
     func burnExcept(fireproofDomains: FireproofDomains,
                     bookmarkManager: BookmarkManager,
+                    savedLogins: Set<String> = [],
                     completion: @escaping () -> Void) {
         self.referenceCache.burnExcept(fireproofDomains: fireproofDomains,
-                                       bookmarkManager: bookmarkManager) {
+                                       bookmarkManager: bookmarkManager,
+                                       savedLogins: savedLogins) {
             self.imageCache.burnExcept(fireproofDomains: fireproofDomains,
-                                       bookmarkManager: bookmarkManager) {
+                                       bookmarkManager: bookmarkManager,
+                                       savedLogins: savedLogins) {
                 completion()
             }
         }
     }
 
     func burnDomains(_ domains: Set<String>,
-                     except bookmarkManager: BookmarkManager,
+                     exceptBookmarks bookmarkManager: BookmarkManager,
+                     exceptSavedLogins: Set<String> = [],
                      completion: @escaping () -> Void) {
-        self.referenceCache.burnDomains(domains, except: bookmarkManager) {
-            self.imageCache.burnDomains(domains, except: bookmarkManager) {
+        self.referenceCache.burnDomains(domains, exceptBookmarks: bookmarkManager, exceptSavedLogins: exceptSavedLogins) {
+            self.imageCache.burnDomains(domains, exceptBookmarks: bookmarkManager, exceptSavedLogins: exceptSavedLogins) {
                 DispatchQueue.main.async {
                     completion()
                 }

--- a/DuckDuckGo/Favicons/Model/FaviconReferenceCache.swift
+++ b/DuckDuckGo/Favicons/Model/FaviconReferenceCache.swift
@@ -169,11 +169,13 @@ final class FaviconReferenceCache {
 
     func burnExcept(fireproofDomains: FireproofDomains,
                     bookmarkManager: BookmarkManager,
+                    savedLogins: Set<String>,
                     completion: @escaping () -> Void) {
 
         func isHostApproved(host: String) -> Bool {
             return fireproofDomains.isFireproof(fireproofDomain: host) ||
-                bookmarkManager.isHostInBookmarks(host: host)
+                bookmarkManager.isHostInBookmarks(host: host) ||
+                savedLogins.contains(host)
         }
 
         // Remove host references
@@ -192,19 +194,20 @@ final class FaviconReferenceCache {
     }
 
     func burnDomains(_ domains: Set<String>,
-                     except bookmarkManager: BookmarkManager,
+                     exceptBookmarks bookmarkManager: BookmarkManager,
+                     exceptSavedLogins: Set<String>,
                      completion: @escaping () -> Void) {
         // Remove host references
         removeHostReferences(filter: { hostReference in
             let host = hostReference.host
-            return domains.contains(host) && !bookmarkManager.isHostInBookmarks(host: host)
+            return domains.contains(host) && !bookmarkManager.isHostInBookmarks(host: host) && !exceptSavedLogins.contains(host)
         }) {
             // Remove URL references
             self.removeUrlReferences(filter: { urlReference in
                 guard let host = urlReference.documentUrl.host else {
                     return false
                 }
-                return domains.contains(host) && !bookmarkManager.isHostInBookmarks(host: host)
+                return domains.contains(host) && !bookmarkManager.isHostInBookmarks(host: host) && !exceptSavedLogins.contains(host)
             }, completionHandler: completion)
         }
     }

--- a/DuckDuckGo/Fire/Model/Fire.swift
+++ b/DuckDuckGo/Fire/Model/Fire.swift
@@ -94,13 +94,14 @@ final class Fire {
     let stateRestorationManager: AppStateRestorationManager?
     let recentlyClosedCoordinator: RecentlyClosedCoordinating?
     let pinnedTabsManager: PinnedTabsManager
-
     let tabsCleaner = TabDataCleaner()
+    let secureVaultFactory: SecureVaultFactory
 
     enum BurningData {
         case specificDomains(_ domains: Set<String>)
         case all
     }
+
     @Published private(set) var burningData: BurningData?
 
     init(cacheManager: WebCacheManager = WebCacheManager.shared,
@@ -112,7 +113,8 @@ final class Fire {
          autoconsentManagement: AutoconsentManagement? = nil,
          stateRestorationManager: AppStateRestorationManager? = nil,
          recentlyClosedCoordinator: RecentlyClosedCoordinating? = RecentlyClosedCoordinator.shared,
-         pinnedTabsManager: PinnedTabsManager = WindowControllersManager.shared.pinnedTabsManager
+         pinnedTabsManager: PinnedTabsManager = WindowControllersManager.shared.pinnedTabsManager,
+         secureVaultFactory: SecureVaultFactory = SecureVaultFactory.default
     ) {
         self.webCacheManager = cacheManager
         self.historyCoordinating = historyCoordinating
@@ -122,6 +124,7 @@ final class Fire {
         self.faviconManagement = faviconManagement
         self.recentlyClosedCoordinator = recentlyClosedCoordinator
         self.pinnedTabsManager = pinnedTabsManager
+        self.secureVaultFactory = secureVaultFactory
 
         if #available(macOS 11, *), autoconsentManagement == nil {
             self.autoconsentManagement = AutoconsentManagement.shared
@@ -343,15 +346,27 @@ final class Fire {
 
     // MARK: - Favicons
 
+    private func autofillDomains() -> Set<String> {
+        guard let vault = try? secureVaultFactory.makeVault(errorReporter: SecureVaultErrorReporter.shared),
+              let accounts = try? vault.accounts() else {
+            return []
+        }
+        return Set(accounts.map { $0.domain })
+    }
+
     private func burnFavicons(completion: @escaping () -> Void) {
+        let autofillDomains = autofillDomains()
         self.faviconManagement.burnExcept(fireproofDomains: FireproofDomains.shared,
                                           bookmarkManager: LocalBookmarkManager.shared,
+                                          savedLogins: autofillDomains,
                                           completion: completion)
     }
 
     private func burnFavicons(for domains: Set<String>, completion: @escaping () -> Void) {
+        let autofillDomains = autofillDomains()
         self.faviconManagement.burnDomains(domains,
-                                           except: LocalBookmarkManager.shared,
+                                           exceptBookmarks: LocalBookmarkManager.shared,
+                                           exceptSavedLogins: autofillDomains,
                                            completion: completion)
     }
 

--- a/UnitTests/Tab/Services/FaviconManagerMock.swift
+++ b/UnitTests/Tab/Services/FaviconManagerMock.swift
@@ -42,16 +42,11 @@ final class FaviconManagerMock: FaviconManagement {
         return nil
     }
 
-    func burnExcept(fireproofDomains: FireproofDomains,
-                    bookmarkManager: BookmarkManager,
-                    completion: @escaping () -> Void) {
+    func burnExcept(fireproofDomains: DuckDuckGo_Privacy_Browser.FireproofDomains, bookmarkManager: DuckDuckGo_Privacy_Browser.BookmarkManager, savedLogins: Set<String>, completion: @escaping () -> Void) {
         completion()
     }
 
-    func burnDomains(_ domains: Set<String>,
-                     except bookmarkManager: BookmarkManager,
-                     completion: @escaping () -> Void) {
+    func burnDomains(_ domains: Set<String>, exceptBookmarks bookmarkManager: DuckDuckGo_Privacy_Browser.BookmarkManager, exceptSavedLogins: Set<String>, completion: @escaping () -> Void) {
         completion()
     }
-
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204099484721401/1204318806095429/f

**Description**:
We currently prevent favicons from Bookmarks and Fireproofed websites from being deleted.  These changes also prevent the deletion of Favicons from **non-fireproofed websites for which the user has login credentials stored.**


**Steps to test this PR**:
1. Visit a few websites that have a favicon, log in, and add the credentials to the Autofill vault  **(⚠️ Do not select the 'fireproof website' option)**
3. Confirm website Favicons are visible in the Autofill Overlay
4. Clear Browsing History and data for "All Sites"
5. Confirm Autofill favicons are still present
6. Clear browsing data for "Current tab"
7. Confirm Autofill favicons are still present

**Demo:** 

![Screen Recording 2023-04-12 at 5 24 20 PM](https://user-images.githubusercontent.com/1156669/231508148-7a70e0fa-2a32-44d7-999b-cbd3d73af87a.gif)



---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
