### PR TITLE
Manual tab reloading using the Enter key is fixed

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -276,7 +276,7 @@ final class AddressBarTextField: NSTextField {
             }
         }
 
-        if selectedTabViewModel.tab.content == .url(url, userEntered: userEnteredValue) {
+        if let currentUrl = selectedTabViewModel.tab.content.url, currentUrl == url {
             selectedTabViewModel.reload()
         } else {
             selectedTabViewModel.tab.setUrl(url, userEntered: userEnteredValue)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204380596703094/f

**Description**:
PR fixes issue with tabs not refreshing after focusing address bar and hitting enter in some special cases

**Steps to test this PR**:
1. Open a bunch of tabs
2. Ensure 'save tab restore state' is enabled
3. Close the app
4. Open the app
5. In any tab, give the address bar focus
6. Hit enter
7. Make sure the tab reloaded

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
