### PR TITLE
Open Bitwarden from the Password Overlay

### DIFF
--- a/DuckDuckGo/Autofill/ContentOverlayViewController.swift
+++ b/DuckDuckGo/Autofill/ContentOverlayViewController.swift
@@ -281,6 +281,11 @@ extension ContentOverlayViewController: SecureVaultManagerDelegate {
     }
 
     public func secureVaultManager(_: SecureVaultManager, didRequestPasswordManagerForDomain domain: String) {
-        autofillPreferencesModel.showAutofillPopover(.logins)
+        let mngr = PasswordManagerCoordinator.shared
+        if mngr.isEnabled {
+            mngr.bitwardenManagement.openBitwarden()
+        } else {
+            autofillPreferencesModel.showAutofillPopover(.logins)
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/0/1204099484721401/1204337437827879/f

**Description**:
Opens Bitwarden (if enabled) when selecting "Manage Logins..." from the password overlay.

![CleanShot 2023-04-13 at 15 58 27](https://user-images.githubusercontent.com/1156669/231794042-f00df161-dab3-451d-a462-5d173ab27fe5.jpg)


**Steps to test this PR**:
1. Set Bitwarden as your password manager
2. Go to fill.dev and add a couple logins
3. Click the "Manage Logins..." option from your autofill overlay and confirm Bitwarden opens
5. Disable Bitwarden integration in settings
6. Click the "Manage Logins..." option from your autofill overlay and confirm our internal pwd manager opens.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

