### PR TITLE
Fix potential render/selection/scroll issue in Autofill List

### DIFF
--- a/DuckDuckGo/SecureVault/Model/PasswordManagementItemListModel.swift
+++ b/DuckDuckGo/SecureVault/Model/PasswordManagementItemListModel.swift
@@ -241,8 +241,11 @@ final class PasswordManagementItemListModel: ObservableObject {
         didSet {
             updateFilteredData()
             calculateEmptyState()
+            itemCount = items.count
         }
     }
+
+    @Published private(set) var itemCount: Int = 0
 
     @Published var sortDescriptor = SecureVaultSorting.default {
         didSet {

--- a/DuckDuckGo/SecureVault/View/PasswordManagementItemList.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementItemList.swift
@@ -36,6 +36,7 @@ struct PasswordManagementItemListView: View {
     }
 
     @EnvironmentObject var model: PasswordManagementItemListModel
+    @State var autoSelected = false
 
     var body: some View {
 
@@ -53,11 +54,16 @@ struct PasswordManagementItemListView: View {
                 ScrollView {
                     ScrollViewReader { proxy in
                         PasswordManagementItemListStackView()
-                            .onAppear {
-                                // Scrolling to the selected item doesn't work consistently without a very slight delay.
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                    if let selectionID = model.selected?.id {
-                                        proxy.scrollTo(selectionID, anchor: .center)
+                            // Selection/scroll wont work until list is fully rendered
+                            // so give it a few milis based on element count before auto-selecting
+                            .onChange(of: model.selected?.id) { itemId in
+                                if !autoSelected {
+                                    let delay = TimeInterval(model.itemCount) * 0.0001
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                                        if let selectionID = itemId {
+                                            proxy.scrollTo(selectionID, anchor: .center)
+                                            autoSelected = true
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204099484721401/1204318806095433/f

**Description**:
In some cases, opening the Autofill popover causes the scroll to be janky or locked (see [this video](https://app.asana.com/app/asana/-/get_asset?asset_id=1204297462481575)).  

This issue has been around for a long time.  We've tried fixing without luck [here](https://app.asana.com/0/1177771139624306/1202037446274716/f) without luck. 

It's still unclear why this is happening, but it may be related to the lazy stack rendering..

A. The view takes too long to render when you have several hundreds of login items, causing the selection/scroll to have issues.
B. The model not returning the list of items before we trigger the selection, which happens onAppear.

I've implemented a few changes and moved the selection to .`onChange`, adding a dynamic delay based on the list of items in the user's vault, so the list has more time to render with bigger datasets.

Still, not an ideal solution until Apple implements a proper .onLayout method for SwiftUI views.

**Steps to test this PR**:
- Visit a website for which you have a password saved
- Open Autofill Via the shortcut.
- Observe that the relevant login item is selected

**Recommended:**. The more items you have in your vault, the better.  I've tested this with 700+ items. 

**Demo:**
![Screen Recording 2023-04-14 at 4 23 46 PM](https://user-images.githubusercontent.com/1156669/232072001-5baa25c9-385c-4ca9-a056-63b4004ed7cc.gif)

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
