### PR TITLE
Download location selector disabled for sandboxed build

### DIFF
--- a/DuckDuckGo/Preferences/View/PreferencesDownloadsView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesDownloadsView.swift
@@ -34,9 +34,11 @@ extension Preferences {
                     TextMenuItemHeader(text: UserText.downloadsLocation)
                     HStack {
                         NSPathControlView(url: model.selectedDownloadLocation)
+#if !APPSTORE
                         Button(UserText.downloadsChangeDirectory) {
                             model.presentDownloadDirectoryPanel()
                         }
+#endif
                     }
                     .disabled(model.alwaysRequestDownloadLocation)
                     ToggleMenuItem(title: UserText.downloadsAlwaysAsk, isOn: $model.alwaysRequestDownloadLocation)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204372566145905/f

**Description**:
Sandbox access right limitations don't allow us to have a different default download location than ~/Downloads. 

**Steps to test this PR**:
1. Run App Store build
2. Go to Settings -> Downloads
3. Verify the default location is ~/Downloads and there is no option to change it.
4. Make sure you can enable/disable "Always ask where to save files"

1. Repeat the test with "DuckDuckGo Privacy Browser" build (standard) and make sure user can change the default location for downloads

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
