### PR TITLE
Adjust pixel reporting for file move errors

### DIFF
--- a/DuckDuckGo/Common/Extensions/FileManagerExtension.swift
+++ b/DuckDuckGo/Common/Extensions/FileManagerExtension.swift
@@ -25,10 +25,6 @@ extension FileManager {
         return try self.perform(self.moveItem, from: srcURL, to: destURL, incrementingIndexIfExists: flag, pathExtension: pathExtension)
     }
 
-    func copyItem(at srcURL: URL, to destURL: URL, incrementingIndexIfExists flag: Bool, pathExtension: String? = nil) throws -> URL {
-        return try self.perform(self.copyItem, from: srcURL, to: destURL, incrementingIndexIfExists: flag, pathExtension: pathExtension)
-    }
-
     private func perform(_ operation: (URL, URL) throws -> Void,
                          from srcURL: URL,
                          to destURL: URL,
@@ -74,9 +70,6 @@ extension FileManager {
                     os_log("Failed to move file to Downloads folder, attempt %d", type: .error, copy)
                     throw CocoaError(.fileWriteFileExists)
                 }
-            } catch {
-                Pixel.fire(.debug(event: .fileMoveToDownloadsFailed, error: error))
-                throw error
             }
         }
         fatalError("Unexpected flow")

--- a/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
+++ b/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
@@ -136,6 +136,8 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
             self.download.cancel()
             self.finish(with: .failure(.failedToCompleteDownloadTask(underlyingError: URLError(.cancelled), resumeData: nil, isRetryable: false)))
             self.decideDestinationCompletionHandler?(nil)
+
+            Pixel.fire(.debug(event: .fileGetDownloadLocationFailed, error: error))
         }
     }
 
@@ -310,6 +312,7 @@ extension WebKitDownloadTask: WebKitDownloadDelegate {}
             do {
                 destinationURL = try FileManager.default.moveItem(at: tempURL, to: destinationURL, incrementingIndexIfExists: true)
             } catch {
+                Pixel.fire(.debug(event: .fileMoveToDownloadsFailed, error: error))
                 destinationURL = tempURL
             }
         }

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -141,6 +141,7 @@ extension Pixel {
 
             case fileStoreWriteFailed
             case fileMoveToDownloadsFailed
+            case fileGetDownloadLocationFailed
 
             case suggestionsFetchFailed
             case appOpenURLFailed
@@ -346,6 +347,8 @@ extension Pixel.Event.Debug {
             return "fswf"
         case .fileMoveToDownloadsFailed:
             return "df"
+        case .fileGetDownloadLocationFailed:
+            return "dl"
 
         case .suggestionsFetchFailed:
             return "sgf"

--- a/UnitTests/Common/Extensions/FileManagerExtensionTests.swift
+++ b/UnitTests/Common/Extensions/FileManagerExtensionTests.swift
@@ -72,26 +72,6 @@ class FileManagerExtensionTests: XCTestCase {
         XCTAssertFalse(fm.fileExists(atPath: srcURL.path))
     }
 
-    func testWhenItemCopiedToSameURLIncrementingIndexThenNoErrorIsThrown() {
-        let srcURL = fm.temporaryDirectory.appendingPathComponent(testFile)
-        try? testData.write(to: srcURL)
-
-        let destURL = (try? fm.copyItem(at: srcURL, to: srcURL, incrementingIndexIfExists: true))!
-        XCTAssertEqual(srcURL.deletingLastPathComponent(), destURL.deletingLastPathComponent())
-        XCTAssertEqual(destURL.lastPathComponent, "\(testFile) 1")
-        XCTAssertTrue(fm.fileExists(atPath: destURL.path))
-        XCTAssertEqual(try? Data(contentsOf: destURL), testData)
-    }
-
-    func testWhenItemCopiedToSameURLNotIncrementingIndexThenErrorIsThrown() {
-        let srcURL = fm.temporaryDirectory.appendingPathComponent(testFile)
-        try? testData.write(to: srcURL)
-
-        XCTAssertThrowsError(try fm.copyItem(at: srcURL, to: srcURL, incrementingIndexIfExists: false), "should throw file exists") { (error) in
-            XCTAssertEqual((error as? CocoaError)?.code, CocoaError.fileWriteFileExists)
-        }
-    }
-
     func testWhenItemWithExtensionMoveDestExistsThenIndexIsIncrementedBeforeExtension() {
         let srcURL = fm.temporaryDirectory.appendingPathComponent(testFile)
         let existingURL = fm.temporaryDirectory.appendingPathComponent(testFile + testFile)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1204253762271259/f

**Description**:
- Moved Pixel sending from helper move function (throwing frequently by design) to actual usage places
- Separated Choose Location errors on download start Pixel from Move to Final Destination failure Pixel

**Steps to test this PR**:
1. Validate places sending the Pixels are now correctly set

