### PR TITLE
Fix shortcut for 'Clear All History' menu item

### DIFF
--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -559,7 +559,6 @@ struct UserText {
     static let autoconsentModalConfirmButton = NSLocalizedString("autoconsent.modal.cta.confirm", value: "Manage Cookie Pop-ups", comment: "Confirm button for modal asking the user to auto manage cookies")
     static let autoconsentModalDenyButton = NSLocalizedString("autoconsent.modal.cta.deny", value: "No Thanks", comment: "Deny button for modal asking the user to auto manage cookies")
 
-    static let clearAllHistoryMenuItem = NSLocalizedString("history.menu.clear.all.history", value: "Clear All History…", comment: "Menu item to clear all history")
     static let clearThisHistoryMenuItem = NSLocalizedString("history.menu.clear.this.history", value: "Clear This History…", comment: "Menu item to clear parts of history and data")
     static let recentlyVisitedMenuSection = NSLocalizedString("history.menu.recently.visited", value: "Recently Visited", comment: "Section header of the history menu")
     static let olderMenuItem = NSLocalizedString("history.menu.older", value: "Older…", comment: "Menu item representing older history")

--- a/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/DuckDuckGo/Menus/HistoryMenu.swift
@@ -34,6 +34,8 @@ final class HistoryMenu: NSMenu {
             reopenMenuItemKeyEquivalentManager.lastSessionMenuItem = reopenAllWindowsFromLastSessionMenuItem
         }
     }
+    @IBOutlet weak var clearAllHistoryMenuItem: NSMenuItem?
+    private let clearAllHistorySeparator = NSMenuItem.separator()
 
     private let historyCoordinator: HistoryCoordinating = HistoryCoordinator.shared
     private var recentlyClosedMenu: RecentlyClosedMenu?
@@ -48,7 +50,7 @@ final class HistoryMenu: NSMenu {
         clearOldVariableMenuItems()
         addRecentlyVisited()
         addHistoryGroupings()
-        addClearAllHistory()
+        addClearAllHistoryOnTheBottom()
     }
 
     private func clearOldVariableMenuItems() {
@@ -212,19 +214,17 @@ final class HistoryMenu: NSMenu {
 
     // MARK: - Clear All History
 
-    lazy var clearAllHistoryMenuItem: NSMenuItem = {
-        let menuItem = NSMenuItem(title: UserText.clearAllHistoryMenuItem,
-                                  action: #selector(AppDelegate.clearAllHistory(_:)),
-                                  keyEquivalent: "\u{08}")
-        menuItem.keyEquivalentModifierMask = NSEvent.ModifierFlags(rawValue: 1179648)
-        return menuItem
-    }()
+    private func addClearAllHistoryOnTheBottom() {
+        guard let clearAllHistoryMenuItem else {
+            return
+        }
 
-    private func addClearAllHistory() {
-        addItem(NSMenuItem.separator())
+        if clearAllHistorySeparator.menu != nil {
+            removeItem(clearAllHistorySeparator)
+        }
+        addItem(clearAllHistorySeparator)
         addItem(clearAllHistoryMenuItem)
     }
-
 }
 
 extension HistoryMenu {

--- a/DuckDuckGo/Menus/MainMenu.storyboard
+++ b/DuckDuckGo/Menus/MainMenu.storyboard
@@ -500,8 +500,18 @@
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="eoz-XM-HpQ"/>
+                                        <menuItem title="Clear All History…" enabled="NO" id="n9a-Bc-r7Z">
+                                            <string key="keyEquivalent" base64-UTF8="YES">
+CA
+</string>
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="clearAllHistory:" target="Ady-hI-5gd" id="5Q8-pp-l2m"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                     <connections>
+                                        <outlet property="clearAllHistoryMenuItem" destination="n9a-Bc-r7Z" id="L22-xU-BaT"/>
                                         <outlet property="recentlyClosedMenuItem" destination="pWT-lm-yTC" id="bhY-MN-oMZ"/>
                                         <outlet property="reopenAllWindowsFromLastSessionMenuItem" destination="C6V-uF-uX8" id="YoX-kD-0PA"/>
                                         <outlet property="reopenLastClosedMenuItem" destination="c3l-v1-kxk" id="1OS-ma-fzm"/>

--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -78,7 +78,7 @@ extension AppDelegate {
         WindowsManager.openNewWindow(with: Tab(content: .contentFromURL(url), shouldLoadInBackground: true))
     }
 
-    @objc func clearAllHistory(_ sender: NSMenuItem) {
+    @IBAction func clearAllHistory(_ sender: NSMenuItem) {
         guard let window = WindowsManager.openNewWindow(with: Tab(content: .homePage)),
               let windowController = window.windowController as? MainWindowController else {
             assertionFailure("No reference to main window controller")
@@ -396,7 +396,7 @@ extension MainViewController {
         adjustFirstResponder()
     }
 
-    @objc func clearAllHistory(_ sender: NSMenuItem) {
+    @IBAction func clearAllHistory(_ sender: NSMenuItem) {
         guard let window = view.window else {
             assertionFailure("No window")
             return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203229562402534/f

**Description**:
Add the menu item to the storyboard so that it’s instantiated with the rest of the main menu
and not on demand by HistoryMenu logic.

**Steps to test this PR**:
1. Run the app
2. Without entering main menu press cmd+shift+del; verify that it triggers the “Clear all history” action ("Clear all history and close all tabs?" dialog)
3. Enter History menu and select “Clear All History…”; verify that it works as expected
4. Verify that History menu looks good with no recent history (there is a separator before “Recently Visited” and “Clear All History…”)
5. Visit some websites; verify that "Clear All History…” remains on the bottom of the History menu, after a separator.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
