### PR TITLE
Show context menu for TabBarViewItem on ctrl+click

### DIFF
--- a/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -152,6 +152,15 @@ final class TabBarViewItem: NSCollectionViewItem {
         return super.draggingImageComponents
     }
 
+    override func mouseDown(with event: NSEvent) {
+        if let menu = view.menu, NSEvent.isContextClick(event) {
+            NSMenu.popUpContextMenu(menu, with: event, for: view)
+            return
+        }
+
+        super.mouseDown(with: event)
+    }
+
     @objc func duplicateAction(_ sender: NSButton) {
         delegate?.tabBarViewItemDuplicateAction(self)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204316268967746/f

**Description**:
Enable context menu for TabBarViewItem.

**Steps to test this PR**:
1. Open some tabs
2. ctrl+click on any of tab in the tab bar; verify that context menu is shown and its actions work properly
3. Verify that a single click without keyboard modifiers works as expected, i.e. you can drag the tab (or the window if it’s the only tab)
4. Verify that the same works for pinned tabs (it’s not part of this pull request, but just to confirm that the functionality is the same – note that pinned tabs have different context menu).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
