### PR TITLE
Restore tab history when reopening last closed window

### DIFF
--- a/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedCoordinator.swift
+++ b/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedCoordinator.swift
@@ -195,7 +195,14 @@ final class RecentlyClosedCoordinator: RecentlyClosedCoordinating {
     private func reopenWindow(_ recentlyClosedWindow: RecentlyClosedWindow) {
         let tabCollection = TabCollection()
         recentlyClosedWindow.tabs.forEach { recentlyClosedTab in
-            let tab = Tab(content: recentlyClosedTab.tabContent, title: recentlyClosedTab.title, favicon: recentlyClosedTab.favicon, shouldLoadInBackground: false, shouldLoadFromCache: true)
+            let tab = Tab(
+                content: recentlyClosedTab.tabContent,
+                title: recentlyClosedTab.title,
+                favicon: recentlyClosedTab.favicon,
+                interactionStateData: recentlyClosedTab.interactionData,
+                shouldLoadInBackground: false,
+                shouldLoadFromCache: true
+            )
             tabCollection.append(tab: tab)
         }
         WindowsManager.openNewWindow(with: tabCollection,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1200567280161804/f

**Description**:
Fix window reopening logic to make use of RecentlyClosedTab’s interaction data.

**Steps to test this PR**:
1. Open a new tab, navigate to a couple of websites to populate back-forward history
2. Repeat the same with another tab or two
3. Close the entire window (cmd+shift+w)
4. Go to Main Menu -> History -> Reopen Last Closed Window
5. Verify that in the opened window all tabs have their local history (you can navigate back or forward within tabs).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
