### PR TITLE
Stop media playback, capture and content loading when hiding webView in a tab

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -511,7 +511,16 @@ protocol NewWindowPolicyDecisionMaker {
         }
     }
 
-    @PublishedAfter var error: WKError?
+    @PublishedAfter var error: WKError? {
+        didSet {
+            if error == nil || error?.isFrameLoadInterrupted == true || error?.isNavigationCancelled == true {
+                return
+            }
+            webView.stopLoading()
+            webView.stopMediaCapture()
+            webView.stopAllMediaPlayback()
+        }
+    }
     let permissions: PermissionModel
 
     @Published private(set) var isLoading: Bool = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204437728957048/f

**Description**:
When tab is about to display native content (home page, onboarding, settings or bookmarks)
stop any media capture or playback and also stop loading web content as needed.

**Steps to test this PR**:
1. Open a youtube video
2. Click cmd+shift+h to open home page in a current tab
3. Verify that the audio stopped playing
4. Repeat step 1
5. Open `about:preferences` in the same tab, verify that the audio stopped playing
6. Repeat step 1
7. Open `about:welcome` in the same tab, verify that the audio stopped playing

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
