### PR TITLE
Autofill sorting fix for domains that are exact match to those in tlds.json

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8652,8 +8652,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = a5fef11678caeec906d9258d7263d4c7f67288c1;
+				kind = exactVersion;
+				version = 57.2.2;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "a5fef11678caeec906d9258d7263d4c7f67288c1"
+        "revision" : "4b49dbe4622e1959354a07fd6ff61c5dceba60c1",
+        "version" : "57.2.2"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204425262115661/f
Tech Design URL:
CC:

**Description**:
Fixes subdomains sorting issue where domains that are exact match to a domain contained in tlds.json were sorted under #, instead of by the first character of the domain name

**Steps to test this PR**:
Since the subdomains logic isn't live yet on macOS just confirm that there is no change to current behaviour.
1. Add Autofill Login for url `github.io`, leaving the title blank
2. Confirm it is grouped under `G`
3. Add Autofill Login for url `mysite.github.io`, leaving the title blank
4. Confirm it is grouped under `M`
5. Add Autofill Login for url `example.com`, leaving the title blank
6. Confirm it is grouped under `E`
7. Add Autofill Login for url `sub.example.com`, leaving the title blank
8. Confirm it is grouped under `S`

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
