### PR TITLE
Corrected prevention of user interaction during burning process

### DIFF
--- a/DuckDuckGo/Fire/Model/Fire.swift
+++ b/DuckDuckGo/Fire/Model/Fire.swift
@@ -97,7 +97,7 @@ final class Fire {
 
     let tabsCleaner = TabDataCleaner()
 
-    enum BurningData {
+    enum BurningData: Equatable {
         case specificDomains(_ domains: Set<String>)
         case all
     }

--- a/DuckDuckGo/Main/View/MainWindowController.swift
+++ b/DuckDuckGo/Main/View/MainWindowController.swift
@@ -51,7 +51,7 @@ final class MainWindowController: NSWindowController {
         setupWindow()
         setupToolbar()
         subscribeToTrafficLightsAlpha()
-        subscribeToIsFirePresentationInProgress()
+        subscribeToBurningData()
         subscribeToResolutionChange()
     }
 
@@ -118,14 +118,14 @@ final class MainWindowController: NSWindowController {
             .assign(to: \.constant, onWeaklyHeld: tabBarViewController.pinnedTabsViewLeadingConstraint)
     }
 
-    private var isFirePresentationInProgressCancellable: AnyCancellable?
-    private func subscribeToIsFirePresentationInProgress() {
-        isFirePresentationInProgressCancellable = fireViewModel.isFirePresentationInProgress
+    private var burningDataCancellable: AnyCancellable?
+    private func subscribeToBurningData() {
+        burningDataCancellable = fireViewModel.fire.$burningData
             .dropFirst()
             .removeDuplicates()
-            .sink(receiveValue: { [weak self] _ in
+            .sink(receiveValue: { [weak self] burningData in
                 guard let self else { return }
-                self.userInteraction(prevented: self.fireViewModel.fire.burningData != nil)
+                self.userInteraction(prevented: burningData != nil)
             })
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204469465991783/f

**Description**:
We prevent users from interaction with the app while data are being cleaned. This logic was slightly broken by latest changes and this PR fixes it

**Steps to test this PR**:
1. Burn a website using fire button
2. After burning finishes, make sure you can add tabs and navigate to websites

1. Burn a website listed on homepage activity feed
2. After burning finishes, make sure you can add tabs and navigate to websites

1. Open Burner Window, navigate to few sites and close it
2. After burning finishes, make sure you can add tabs and navigate to websites

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
