### PR TITLE
fix bug  where pasting url into address bar clears its content

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -1054,8 +1054,7 @@ final class AddressBarTextEditor: NSTextView {
 
         // Fixes an issue when url-name instead of url is pasted
         if let urlString = NSPasteboard.general.string(forType: .URL) {
-            let stringOriginalContent = string.dropping(suffix: AddressBarTextField.Suffix.searchSuffix)
-            string = stringOriginalContent + urlString
+            super.pasteAsPlainText(urlString)
             delegate.handlePastedURL()
         } else {
             super.paste(sender)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204464586950568/f

**Description**:  Maintains search bar content when a URL is pasted

**Steps to test this PR**:
1. Copy a URL to your clipboard
2. Clear the contents of the address bar
3. Type "keyword site:" and then press cmd+V should do a filtered search on duck duck go
4. Copy link from Outlook (make sure to choose a link with name - for example 'View it on GitHub’)
5. Paste into the address bar and make sure the URL is pasted instead of the name ('View it on GitHub’)

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
