### PR TITLE
Update autofill to 6.5.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8658,8 +8658,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 1b58d1a15b0f5b6e0f59a61116d9f68930abb773;
+				kind = exactVersion;
+				version = 57.4.3;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "1b58d1a15b0f5b6e0f59a61116d9f68930abb773"
+        "revision" : "3baef814ab04831b71b4bc6bf75720d1dbd3b176",
+        "version" : "57.4.3"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1204530982219497/f
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.0


## Description
Updates Autofill to version [6.5.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.0).

### Autofill 6.5.0 release notes
## What's Changed
* Improve debugging by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/293
* Reduce the calls on check position when there are many mutations by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/288
* Window release fetch tags before checkout by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/296
* Autofill compare generated test suites by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/283
* Update release scripts with latest Apple tooling by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/299
* Add temporary incontext_eligible pixel by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/304
* Fix double-click issue by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/306
* Fix a whole bunch of existing failing test cases by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/308

## New Contributors
* @greyivy made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/283

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.4.3...6.5.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).