### PR TITLE
Only use LazyVStack on home page when on macos 12 or higher

### DIFF
--- a/DuckDuckGo/HomePage/View/RecentlyVisitedView.swift
+++ b/DuckDuckGo/HomePage/View/RecentlyVisitedView.swift
@@ -32,7 +32,7 @@ struct RecentlyVisited: View {
                 .padding(.bottom, 18)
 
             Group {
-                if #available(macOS 11, *) {
+                if #available(macOS 12, *) {
                     LazyVStack(spacing: 0) {
                         ForEach(model.recentSites, id: \.domain) {
                             RecentlyVisitedSite(site: $0)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204437506621674/f
Tech Design URL:
CC:

**Description**:

Speculative fix for a crash on macOS 11

**Steps to test this PR**:
1.  Use the new tab page, ideally with plenty of favorites and recently view sites

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
