### PR TITLE
Update BSK with autofill 6.6.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8658,8 +8658,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 57.4.4;
+				kind = revision;
+				revision = 12ccd36ea86b95d628c753d4d2d7a63491bc47b1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204572551106233/1204572551106233
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.6.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/347

## Description
Updates Autofill to version [6.6.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.6.0).

### Autofill 6.6.0 release notes
## What's Changed
* Ema/fix release again by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/311
* Update Dax logo by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/312
* New subdomain matching rules by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/297
* Update release workflow by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/313


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.5.1...6.6.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).