### PR TITLE
Add a unique Bitwarden decryption failure pixel

### DIFF
--- a/DuckDuckGo/PasswordManager/Bitwarden/Model/BWManager.swift
+++ b/DuckDuckGo/PasswordManager/Bitwarden/Model/BWManager.swift
@@ -226,6 +226,10 @@ final class BWManager: BWManagement, ObservableObject {
         case "cannot-decrypt":
             logOrAssertionFailure("BWManagement: Bitwarden error - cannot decrypt")
             Pixel.fire(.debug(event: .bitwardenRespondedCannotDecrypt))
+
+            if Pixel.Event.Repetition(key: "bitwardenRespondedCannotDecryptUnique", update: false) != .repetitive {
+                Pixel.fire(.debug(event: .bitwardenRespondedCannotDecryptUnique()))
+            }
         case "locked":
             if case let .connected(vault) = status {
                 status = .connected(vault: vault.locked)

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -183,6 +183,7 @@ extension Pixel {
 
             case bitwardenNotResponding
             case bitwardenRespondedCannotDecrypt
+            case bitwardenRespondedCannotDecryptUnique(repetition: Repetition = .init(key: "bitwardenRespondedCannotDecryptUnique"))
             case bitwardenHandshakeFailed
             case bitwardenDecryptionOfSharedKeyFailed
             case bitwardenStoringOfTheSharedKeyFailed
@@ -431,6 +432,8 @@ extension Pixel.Event.Debug {
             return "bitwarden_not_responding"
         case .bitwardenRespondedCannotDecrypt:
             return "bitwarden_responded_cannot_decrypt"
+        case .bitwardenRespondedCannotDecryptUnique:
+            return "bitwarden_responded_cannot_decrypt_unique"
         case .bitwardenHandshakeFailed:
             return "bitwarden_handshake_failed"
         case .bitwardenDecryptionOfSharedKeyFailed:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204290052851108/f
Tech Design URL:
CC:

**Description**:

This PR adds a new `bitwarden_responded_cannot_decrypt_unique` pixel, which is sent at most once per day.

The original pixel is still sent, so that we can continue to monitor the total number of failures, but this option gives us a way to also track the real number of users affected by this issue.

**Steps to test this PR**:

To test this, we'll need to simulate a Bitwarden failure:

1. Turn on pixel logging in the Debug menu
2. Inside `handleCredentialRetrievalResponse`, add the following block below the guard statement:

```
handleError("cannot-decrypt")
completion([], BWError.credentialRetrievalFailed)
return
```

3. Disable the `logOrAssertionFailure` check on line 350
4. Connect Bitwarden, and visit a site
5. Check that a pixel appears the logs
6. Refresh the page, and check that a pixel does **not** appear in the logs

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
