### PR TITLE
Fix creating DMG from release workflow

### DIFF
--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -192,7 +192,7 @@ jobs:
 
     name: Create DMG
     needs: export-notarized-app
-    if: ${{ github.event.inputs.create-dmg == 'true' || inputs.create-dmg == 'true' }}
+    if: ${{ github.event.inputs.create-dmg == true || inputs.create-dmg == true }}
 
     # use macos-12 for creating DMGs as macos-13 beta runners can't run AppleScript: https://app.asana.com/0/0/1204523592790998/f
     runs-on: macos-12


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1204592740032629/f
CC: @samsymons 

**Description**:
This change fixes `create-dmg` job inputs check so that it can be run when build_notarized.yml is called by release.yml.

**Steps to test this PR**:
Check the following runs:
* release.yml where create-dmg is successfully created: https://github.com/duckduckgo/macos-browser/actions/runs/4973993659
* build_notarized.yml with create-dmg set to true: https://github.com/duckduckgo/macos-browser/actions/runs/4974127610
* build_notarized.yml with create-dmg set to false: https://github.com/duckduckgo/macos-browser/actions/runs/4974052303

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
