### PR TITLE
prevent devices from being fetch when sync not visible

### DIFF
--- a/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -155,17 +155,17 @@ final class SyncPreferences: ObservableObject, SyncUI.ManagementViewModel {
     }
 
     func refreshDevices() {
-        if syncService.account != nil {
-            Task { @MainActor in
-                do {
-                    let registeredDevices = try await syncService.fetchDevices()
-                    mapDevices(registeredDevices)
-                } catch {
-                    print("error", error.localizedDescription)
-                }
-            }
-        } else {
+        guard syncService.account != nil else {
             devices = []
+            return
+        }
+        Task { @MainActor in
+            do {
+                let registeredDevices = try await syncService.fetchDevices()
+                mapDevices(registeredDevices)
+            } catch {
+                print("error", error.localizedDescription)
+            }
         }
     }
 

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/ManagementView/SyncedDevicesView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/ManagementView/SyncedDevicesView.swift
@@ -22,6 +22,8 @@ struct SyncedDevicesView<ViewModel>: View where ViewModel: ManagementViewModel {
 
     @EnvironmentObject var model: ViewModel
 
+    @State var isVisible = false
+
     let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -29,7 +31,14 @@ struct SyncedDevicesView<ViewModel>: View where ViewModel: ManagementViewModel {
                           presentDeviceDetails: model.presentDeviceDetails,
                           presentRemoveDevice: model.presentRemoveDevice)
         .onReceive(timer) { _ in
+            guard isVisible else { return }
             model.refreshDevices()
+        }
+        .onAppear {
+            isVisible = true
+        }
+        .onDisappear {
+            isVisible = false
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204659411978394/f
Tech Design URL:
CC:

**Description**:

Prevent calls to fetch devices when not viewing sync preferences.

**Steps to test this PR**:
1. Monitor network traffic or add print statement in refreshDevices call
2. Open sync preferences
3. Enable sync if needed
4. Observe call to fetch devices
5. Move to another section in the preferences
6. Observe no calls to fetch devices
7. Return to sync preference
8. Observe calls to fetch devices
9. Close tab
10. Observe no calls to fetch devices

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
