### PR TITLE
BSK branch for autofill Optimization

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8657,8 +8657,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "daniel/autofill-hash-migration-updates";
-				kind = branch;
+				kind = exactVersion;
+				version = 57.6.3;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "daniel/autofill-hash-migration-updates",
-        "revision" : "62dd4032cb4f3c7aa0065d2eee9f5214c3cd4cc7"
+        "revision" : "4af75edf84c18453b010096c2a9796df1a3ae708",
+        "version" : "57.6.3"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204667757121868/f && https://app.asana.com/0/1204099484721401/1204677118392502/f

### Description
- Optimizes Autofill Hashing Migration
- Fixes an issue that caused Bitwarden logins not being shown in the autofill suggestion box

### Steps to test this PR:

#### Autofill migration
1. Close the debug browser
2.  Clean up debug browser data (`rm -rf ~/Library/Containers/com.duckduckgo.macos.browser.debug`)
3. Launch a pre 1.41.0 debug version (Like 1.39.0: https://github.com/duckduckgo/macos-browser/releases/tag/1.39.0)
4. Import 500 logins to Autofill
5. Close the browser
6. Check out BSK from the matching branch: https://github.com/duckduckgo/BrowserServicesKit/pull/372
7. Manually add your local BSK copy to the project (Drag and drop to project)
8. Apply the following patch to BSK (For testing only): [measure.patch](https://github.com/duckduckgo/macos-browser/files/11575397/measure.patch)
9. Set a breakpoint at DefaultDatabaseProvider, line 703 (Print statement)
10. Build and run
11. Open Autofill UI
12. Observe migration time is <1s

**M2 mac example**
<img width="617" alt="Screenshot 2023-05-26 at 2 54 54 PM" src="https://github.com/duckduckgo/macos-browser/assets/1156669/d22d9c48-4169-430e-be87-7d7a96ba2d78">


#### Bitwarden fix
1. Enable bitwarden in Autofill
2. Make sure you have a few credentials for the same domain (eg. netflix.com)
3. Visit the domain
4. Observe all credentials are showing in the Suggestion box

**Example**
<img width="347" alt="Screenshot 2023-05-26 at 2 49 22 PM" src="https://github.com/duckduckgo/macos-browser/assets/1156669/4ff9bb7e-2e92-461b-a09d-7ce28588da98">

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
