### PR TITLE
Resolves a crasher with the dock menu

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -59,7 +59,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
     private(set) var stateRestorationManager: AppStateRestorationManager!
     private var grammarFeaturesManager = GrammarFeaturesManager()
     private let crashReporter = CrashReporter()
-    private(set) var internalUserDecider: InternalUserDecider!
+    private(set) var internalUserDecider: InternalUserDecider?
     private(set) var featureFlagger: FeatureFlagger!
     private var appIconChanger: AppIconChanger!
 
@@ -132,7 +132,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
         stateRestorationManager = AppStateRestorationManager(fileStore: fileStore)
 
         let internalUserDeciderStore = InternalUserDeciderStore(fileStore: fileStore)
-        internalUserDecider = DefaultInternalUserDecider(store: internalUserDeciderStore)
+        let internalUserDecider = DefaultInternalUserDecider(store: internalUserDeciderStore)
+        self.internalUserDecider = internalUserDecider
 
 #if DEBUG
         func mock<T>(_ className: String) -> T {
@@ -262,6 +263,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
     }
 
     func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        guard let internalUserDecider else {
+            return nil
+        }
+
         return ApplicationDockMenu(internalUserDecider: internalUserDecider)
     }
 

--- a/DuckDuckGo/Menus/MainMenu.swift
+++ b/DuckDuckGo/Menus/MainMenu.swift
@@ -382,7 +382,8 @@ final class MainMenu: NSMenu {
     @MainActor
     private func updateBurnerWindowMenuItem() {
         if let appDelegate = NSApplication.shared.delegate as? AppDelegate,
-           !appDelegate.internalUserDecider.isInternalUser {
+           let internalUserDecider = appDelegate.internalUserDecider,
+           !internalUserDecider.isInternalUser {
             newBurnerWindowMenuItem.isHidden = true
         }
     }

--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -241,9 +241,15 @@ final class NavigationBarViewController: NSViewController {
     // swiftlint:disable force_cast
     @IBAction func optionsButtonAction(_ sender: NSButton) {
 
+        guard let internalUserDecider = (NSApp.delegate as! AppDelegate).internalUserDecider else {
+            assertionFailure("\(className): internalUserDecider is nil")
+            os_log("%s: internalUserDecider is nil", type: .error, className)
+            return
+        }
+
         let menu = MoreOptionsMenu(tabCollectionViewModel: tabCollectionViewModel,
                                    passwordManagerCoordinator: PasswordManagerCoordinator.shared,
-                                   internalUserDecider: (NSApp.delegate as! AppDelegate).internalUserDecider)
+                                   internalUserDecider: internalUserDecider)
         menu.actionDelegate = self
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.height + 4), in: sender)
     }

--- a/DuckDuckGo/Preferences/Model/PreferencesSection.swift
+++ b/DuckDuckGo/Preferences/Model/PreferencesSection.swift
@@ -30,7 +30,7 @@ struct PreferencesSection: Hashable, Identifiable {
             if includingDuckPlayer {
                 panes.append(.duckPlayer)
             }
-            if (NSApp.delegate as? AppDelegate)?.internalUserDecider.isInternalUser == true {
+            if (NSApp.delegate as? AppDelegate)?.internalUserDecider?.isInternalUser == true {
                 panes.insert(.sync, at: 1)
             }
             return panes


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/0/1204700475866733/f

## Description:

Fixes a crash that can happen when the user right-clicks in the dock menu icon when the App shows an alert at startup before `internalUserDecider` is created.

<img width="1644" alt="Screenshot 2023-05-30 at 08 43 22" src="https://github.com/duckduckgo/macos-browser/assets/1836005/c28951ec-be09-48b9-a8c8-2c6e3bc7bab4">

## How to test:

### See the original issue:

1. Check out `develop`
2. Add the following code right at the beginning of `applicationWillFinishLaunching`:

```swift
NSAlert().runModal()
```

3. Run the app.  When the alert is shown you should see it crash right away due to the syncService being `nil`.
   - If for any reason it doesn't crash either:
      - Right click on the dock icon while the alert is shown; or
      - Click on the menu while the alert is shown.

### Test the fix:

1. Check out this branch and run the same test as before.  It should not crash.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
