### PR TITLE
Crash with nil syncService

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -276,9 +276,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
     // MARK: - Sync
 
     private func startupSync() {
-        guard let syncService else {
-            fatalError("Unexpectedly found syncService to be nil")
-        }
+        let syncDataProviders = SyncDataProviders(bookmarksDatabase: BookmarkDatabase.shared.db)
+        let syncService = DDGSync(dataProvidersSource: syncDataProviders, log: OSLog.sync)
 
         syncStateCancellable = syncService.authStatePublisher
             .prepend(syncService.authState)
@@ -294,6 +293,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
         // since the scheduler debounces calls to notifyAppLifecycleEvent().
         //
         syncService.scheduler.notifyAppLifecycleEvent()
+
+        self.syncDataProviders = syncDataProviders
+        self.syncService = syncService
     }
 
     // MARK: - Network Protection


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204702183150940/f

## Description:

When the app launches, if a modal alert is shown before `syncService` is initialized, the app can crash.

## How to test:

### See the crash:

1. Check out `develop`.
2. Add the following line of code here:

```swift
NSAlert().runModal()
```

3. Run the app, you'll likely see it crash.

### Verify the fix:

1. Repeat the test above in this branch.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
