### PR TITLE
Remove 'Duck Player' from tab title

### DIFF
--- a/DuckDuckGo/YoutubePlayer/Resources/youtube_player_template.html
+++ b/DuckDuckGo/YoutubePlayer/Resources/youtube_player_template.html
@@ -448,7 +448,7 @@
                                 let validTitle = VideoPlayer.getValidVideoTitle(title);
 
                                 if (validTitle) {
-                                    document.title = 'Duck Player - ' + validTitle;
+                                    document.title = validTitle;
                                     hasGottenValidVideoTitle = true;
                                 }
                             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203831324563630/f

**Description**: Removes the words “Duck Player -“ from the tab title when using duck player.

**Steps to test this PR**:
1. Watch a video using Duck Player and check that the tab title shows only the name of the video.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
