### PR TITLE
Use automatic codesigning for NetP system extension debug builds

### DIFF
--- a/Configuration/Extensions/NetworkProtection/NetworkProtectionSystemExtension.xcconfig
+++ b/Configuration/Extensions/NetworkProtection/NetworkProtectionSystemExtension.xcconfig
@@ -20,6 +20,7 @@ CODE_SIGN_ENTITLEMENTS[config=CI][sdk=macosx*] =
 CODE_SIGN_ENTITLEMENTS[config=Debug][sdk=macosx*] = NetworkProtectionSystemExtension/NetworkProtectionSystemExtension_Debug.entitlements
 CODE_SIGN_ENTITLEMENTS[config=Release][sdk=macosx*] = NetworkProtectionSystemExtension/NetworkProtectionSystemExtension_Release.entitlements
 CODE_SIGN_ENTITLEMENTS[config=Review][sdk=macosx*] = NetworkProtectionSystemExtension/NetworkProtectionSystemExtension_Release.entitlements
+CODE_SIGN_STYLE[config=Debug][sdk=*] = Automatic
 
 CODE_SIGN_IDENTITY[sdk=macosx*] = Developer ID Application
 CODE_SIGN_IDENTITY[config=CI][sdk=macosx*] =
@@ -48,7 +49,6 @@ PRODUCT_NAME[config=Release][sdk=*] = $(SYSEX_BUNDLE_ID_BASE)
 PRODUCT_NAME[config=Review][sdk=*] = $(SYSEX_BUNDLE_ID_BASE)
 
 PROVISIONING_PROFILE_SPECIFIER[config=CI][sdk=macosx*] =
-PROVISIONING_PROFILE_SPECIFIER[config=Debug][sdk=macosx*] = macOS NetP System Extension - Debug
 PROVISIONING_PROFILE_SPECIFIER[config=Release][sdk=macosx*] = macOS NetP System Extension - Release
 PROVISIONING_PROFILE_SPECIFIER[config=Review][sdk=macosx*] = macOS NetP System Extension - Review
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1204717274008369/f
Tech Design URL:
CC: @brindy 

**Description**:

This PR updates the NetP system extension to follow in the footsteps of all other debug targets and use automatic codesigning. This lets us set up the app in development more easily, and only need to worry about profiles and certs for release builds.

**Steps to test this PR**:
1. Test that the app builds

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
