### PR TITLE
Move the exti event to first engagement

### DIFF
--- a/DuckDuckGo/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/DuckDuckGo/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -61,7 +61,7 @@ final class OnboardingViewModel: ObservableObject {
 
     init(delegate: OnboardingDelegate? = nil, statisticsLoader: StatisticsLoader? = (NSApp.isRunningUnitTests ? nil : StatisticsLoader.shared)) {
         self.delegate = delegate
-        self.statisticsLoader = (NSApp.isRunningUnitTests ? nil : StatisticsLoader.shared)
+        self.statisticsLoader = statisticsLoader
         self.state = onboardingFinished ? .startBrowsing : .startFlow
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204713935614786/f

**Description**: will assign atb cohort and send exti event when the users clicks the "Get Started" button at the start of the onboarding

**Steps to test this PR**:
1. ./clean-app.sh debug  
2. On MainWindowController.swift on line 67 change false to true to enable the onboarding
3. run the app and check that the exti event is sent with an atb value when clicking Get started (line 122 of StatisticsLoader.swift)
4. try a search and check the exti does not event occur but the search retention does (line 155 of StatisticsLoader.swift)

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
