### PR TITLE
Remove redundant sync service initialization

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -157,9 +157,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
 #endif
 
         appIconChanger = AppIconChanger(internalUserDecider: internalUserDecider)
-
-        syncDataProviders = SyncDataProviders(bookmarksDatabase: BookmarkDatabase.shared.db)
-        syncService = DDGSync(dataProvidersSource: syncDataProviders, log: OSLog.sync)
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204702183150940/f
CC: @diegoreymendez 

**Description**:
SyncService initialization is unnecessarily duplicated so we're removing the one that's redundant.

**Steps to test this PR**:
1. Run the app.
2. Enable sync (you need to be an internal user for that).
3. Enable sync logs via Debug menu.
4. Relaunch the app.
5. Verify that sync request is fired at app startup.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
