### PR TITLE
Remove Rogue "Passwords" button that appears when clicking the password field in the Save Creds popover

### DIFF
--- a/DuckDuckGo/SecureVault/View/PasswordManager.storyboard
+++ b/DuckDuckGo/SecureVault/View/PasswordManager.storyboard
@@ -540,7 +540,7 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <secureTextField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vTO-BL-OkT">
+                            <secureTextField verticalHuggingPriority="750" textCompletion="NO" contentType="oneTimeCode" translatesAutoresizingMaskIntoConstraints="NO" id="vTO-BL-OkT">
                                 <rect key="frame" x="20" y="94" width="278" height="22"/>
                                 <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="kgY-kh-qxi">
                                     <font key="font" metaFont="system"/>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202187365326727/f

**Description**:
When Autofill is enabled on macOS, the system automatically displays a "Passwords" button when the user clicks on an NSSecureTextField.  Clicking in the Password text for our Save Login popover, triggers this behavior.

<img width="1393" alt="Screenshot 2023-06-08 at 5 56 16 PM" src="https://github.com/duckduckgo/macos-browser/assets/1156669/fe7a7290-5727-4aa3-a28f-ba5b95d9887f">

---
As there are no APIs to disable OS autofill, we're setting the password field to behave as "One time code" instead of "Password", so the system does not display the button

**Steps to test this PR**:
1.  Enable Autofill on macOS. (Settings > Passwords > Password Options > Autofill Passwords)
2. Go [to fill.dev](https://fill.dev/form/registration-email) type a username and pass and hit send
3. When the  "Save Login?" popover appears, click on the "Password" text field
4. Observe no "Passwords" button is displayed in the bottom-left of the browser window (See screenshot of issue above)

----
---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
