### PR TITLE
resolve export bookmarks warning

### DIFF
--- a/DuckDuckGo/Menus/MainMenu.storyboard
+++ b/DuckDuckGo/Menus/MainMenu.storyboard
@@ -7,11 +7,7 @@
         <!--Application-->
         <scene sceneID="JPo-4y-FX3">
             <objects>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                    <connections>
-                        <outlet property="exportBookmarksMenuItem" destination="3K6-pB-Kea" id="0aB-uI-R6L"/>
-                    </connections>
-                </customObject>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <customObject id="WIK-gq-Ncg" customClass="CopyHandler" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target"/>
                 <customObject id="YLy-65-1bz" customClass="NSFontManager"/>

--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -490,7 +490,7 @@ final class BookmarksSubMenu: NSMenu {
         addItem(withTitle: UserText.importBookmarks, action: #selector(MoreOptionsMenu.openBookmarkImportInterface(_:)), keyEquivalent: "")
             .targetting(target)
 
-        let exportBookmarItem = NSMenuItem(title: UserText.exportBookmarks, action: #selector(MoreOptionsMenu.openBookmarkExportInterface(_:)), keyEquivalent: "")
+        let exportBookmarItem = NSMenuItem(title: UserText.exportBookmarks, action: #selector(MoreOptionsMenu.openBookmarkExportInterface(_:)), keyEquivalent: "").targetting(target)
         exportBookmarItem.isEnabled = bookmarkManager.list?.totalBookmarks != 0
         addItem(exportBookmarItem)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1204810513366684/f

**Description**: Resolve new console warning printed to the console right after the start of the app.
"Failed to connect (exportBookmarksMenuItem) outlet…". Also fix clicking on export bookmarks from the moew options menu

**Steps to test this PR**:
1. Run the app and check the warning does not appear in the console
2. Go on more option menu -> Bookmarks -> Export Bookmarks check that the export dialog is hown

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
