### PR TITLE
Allow adding favorites when a bookmark already exists

### DIFF
--- a/DuckDuckGo/HomePage/View/AddEditFavoriteViewController.swift
+++ b/DuckDuckGo/HomePage/View/AddEditFavoriteViewController.swift
@@ -99,11 +99,7 @@ final class AddEditFavoriteViewController: NSViewController {
 
     private var isInputValid: Bool {
         guard let url = urlInputTextField.stringValue.url else { return false }
-        let isBookmarked = bookmarkManager.isUrlBookmarked(url: url)
-        let isInputValid = !titleInputTextField.stringValue.isEmpty &&
-            url.isValid &&
-        (!isBookmarked || url.absoluteString == originalBookmark?.url)
-        return isInputValid
+        return !titleInputTextField.stringValue.isEmpty && url.isValid
     }
 
     private func updateConfirmButton() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203568202955279/f
Tech Design URL: 
CC:

**Description**:

This PR simplifies the Add/Edit Favorite view controller logic. Before this PR, if you opened up this view controller and entered a URL for a bookmark that already existed, it wouldn't let you do anything. Now it will update that bookmark with the new title (if it has changed) and favourite it.

**Steps to test this PR**:
1. Save a bookmark (don't favourite it) and copy its URL to your clipboard
2. Go to the new tab page and click the Add Favorite button
3. Enter a title and the URL that you have copied
4. Save the favorite
5. Check that a favourite now appears on the new tab page, and when you go into the Manage Bookmarks view that there isn't a second copy with that URL
6. Click Add Favorite again, enter the same URL, and change the title
7. Check that the favourite is updated with the new title

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
