### PR TITLE
Only show the Firefox primary password copy when required 

### DIFF
--- a/DuckDuckGo/DataImport/View/BrowserImportViewController.swift
+++ b/DuckDuckGo/DataImport/View/BrowserImportViewController.swift
@@ -21,6 +21,7 @@ import AppKit
 protocol BrowserImportViewControllerDelegate: AnyObject {
 
     func browserImportViewController(_ viewController: BrowserImportViewController, didChangeSelectedImportOptions options: [DataImport.DataType])
+    func browserImportViewControllerRequestedParentViewRefresh(_ viewController: BrowserImportViewController)
 
 }
 
@@ -118,6 +119,11 @@ final class BrowserImportViewController: NSViewController {
             bookmarksCheckbox.title = UserText.bookmarkImportBookmarks
             passwordsWarningLabel.isHidden = true
         }
+    }
+
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        delegate?.browserImportViewControllerRequestedParentViewRefresh(self)
     }
 
     @IBAction func selectedImportOptionsChanged(_ sender: NSButton) {

--- a/DuckDuckGo/DataImport/View/DataImportViewController.swift
+++ b/DuckDuckGo/DataImport/View/DataImportViewController.swift
@@ -28,7 +28,7 @@ final class DataImportViewController: NSViewController {
         static let identifier = "DataImportViewController"
     }
 
-    enum InteractionState {
+    enum InteractionState: Equatable {
         case unableToImport
         case permissionsRequired([DataImport.DataType])
         case ableToImport
@@ -37,7 +37,7 @@ final class DataImportViewController: NSViewController {
         case completedImport(DataImport.Summary)
     }
 
-    private struct ViewState {
+    private struct ViewState: Equatable {
         var selectedImportSource: DataImport.Source
         var interactionState: InteractionState
 
@@ -75,7 +75,6 @@ final class DataImportViewController: NSViewController {
 
     private var viewState: ViewState = .defaultState() {
         didSet {
-
             renderCurrentViewState()
 
             let bookmarkImporter = CoreDataBookmarkImporter(bookmarkManager: LocalBookmarkManager.shared)
@@ -193,11 +192,21 @@ final class DataImportViewController: NSViewController {
             switch (source, loginsSelected) {
             case (.safari, _), (_, false):
                 interactionState = .ableToImport
+            case (.firefox, _):
+                if FirefoxDataImporter.loginDatabaseRequiresPrimaryPassword(profileURL: selectedProfile?.profileURL) {
+                    interactionState = .moreInfoAvailable
+                } else {
+                    interactionState = .ableToImport
+                }
             case (_, true):
                 interactionState = .moreInfoAvailable
             }
 
-            self.viewState = ViewState(selectedImportSource: source, interactionState: interactionState)
+            let newState = ViewState(selectedImportSource: source, interactionState: interactionState)
+
+            if newState != self.viewState {
+                self.viewState = newState
+            }
         }
 
     }
@@ -485,6 +494,10 @@ extension DataImportViewController: BrowserImportViewControllerDelegate {
         } else {
             refreshViewState()
         }
+    }
+
+    func browserImportViewControllerRequestedParentViewRefresh(_ viewController: BrowserImportViewController) {
+        refreshViewState()
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203151038082812/f
Tech Design URL:
CC:

**Description**:

This PR updates the Firefox import flow to only show the Primary Password warning when the database actually needs it.

**Steps to test this PR**:
1. Make sure you have Firefox installed and have some logins
2. Don't set a primary password
3. Try to import passwords via our browser, and check that you don't get warned about a primary password
4. Turn on the primary password feature in Firefox
5. Try to import password via our browser again, check that you get the copy

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
