### PR TITLE
NetP Invite: Attempt to fix status view display

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/Invite/NetworkProtectionInvitePresenter.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/Invite/NetworkProtectionInvitePresenter.swift
@@ -57,11 +57,11 @@ final class NetworkProtectionInvitePresenter: NetworkProtectionInvitePresenting,
     }
 
     func didCompleteInviteFlow() {
-        Task {
-            await WindowControllersManager.shared.showNetworkProtectionStatus(retry: true)
-        }
         presentedViewController?.dismiss()
         presentedViewController = nil
+        Task {
+            await WindowControllersManager.shared.showNetworkProtectionStatus()
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1204742104005045/f
Tech Design URL:
CC:

**Description**:
At the end of the NetP Invite Code flow, the NetP status view should be shown to educate the user about where to look for it. Sometimes this doesn’t happen. However, the function used to present this view has a flag argument to retry it on failure. This was not being set to true previously, so this change does that in the hope of stabilising this view’s presentation.

**Steps to test this PR**:
1. Follow the NetP Invite Code flow: https://app.asana.com/0/0/1204371517085462/f
2. Enter a valid invite code: https://app.asana.com/0/1203135672790568/1204303483337129/f
3. Click “Get started”

**Expected**
Should consistently show the status view

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
