### PR TITLE
Makes main sync again

### DIFF
--- a/DuckDuckGo/Main/Main.swift
+++ b/DuckDuckGo/Main/Main.swift
@@ -37,23 +37,31 @@ final class AppMain {
         case startVPNFailed(_ error: Error)
     }
 
-    static func main() async throws {
+    static func main() {
 #if NETWORK_PROTECTION
         switch (CommandLine.arguments.first! as NSString).lastPathComponent {
         case "startVPN":
             swizzleMainBundle()
 
-            do {
-                try await NetworkProtectionTunnelController().start(enableLoginItems: false)
-                exit(0)
-            } catch {
-                throw LaunchError.startVPNFailed(error)
+            Task {
+                do {
+                    try await NetworkProtectionTunnelController().start(enableLoginItems: false)
+                    exit(0)
+                } catch {
+                    fatalError("Could not start the tunnel due to error: \(String(describing: error))")
+                }
             }
+
+            dispatchMain()
         case "stopVPN":
             swizzleMainBundle()
 
-            await NetworkProtectionTunnelController().stop()
-            exit(0)
+            Task {
+                await NetworkProtectionTunnelController().stop()
+                exit(0)
+            }
+
+            dispatchMain()
         default:
             break
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204862515245206/f

## Description:

Make our main method sync again.

Confirmation from Apple's Eskimo that making main `async` doesn't play well with the call to `NSApplicationMain` and that the proposed approach in this PR is good: https://app.asana.com/0/0/1204862515245206/1204870770333178/f

## Testing:

### Test App:

1. Launch the app.
2. Make sure it works well.

### Test NetP:

IMPORTANT: this test won't be possible in App Store builds since they don't include NetP.

Note: the system menu toggle is a bit buggy at the moment so it can fail, you can compare with `develop` to see if it behaves more or less the same.  I'm adding @samsymons as a reviewer for this specific case since we were discussing this yesterday.

1. Enable NetP by going into Settings > About > Tap 12 times in the version number and paste [an invite code](https://app.asana.com/0/1203137811378537/1204303483337129/f)
2. Start NetP once and stop it so the system menu comes up
3. Start NetP once from the system menu
4. Stop NetP once from the system menu

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
