### PR TITLE
Revert "changes how the encryption key is saved (#1242)"

### DIFF
--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -69,8 +69,6 @@ public struct UserDefaultsWrapper<T> {
         case showAutocompleteSuggestions = "preferences.appearance.show-autocomplete-suggestions"
         case defaultPageZoom = "preferences.appearance.default-page-zoom"
 
-        case isEncryptionKeyResaved = "encryption.key.store.is.encryption.key.resaved"
-
         // ATB
         case installDate = "statistics.installdate.key"
         case atb = "statistics.atb.key"

--- a/IntegrationTests/EncryptionKeyStoreTests.swift
+++ b/IntegrationTests/EncryptionKeyStoreTests.swift
@@ -27,13 +27,11 @@ final class EncryptionKeyStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         removeTestKeys()
-        UserDefaultsWrapper<Any>.clearAll()
     }
 
     override func tearDown() {
         super.tearDown()
         removeTestKeys()
-        UserDefaultsWrapper<Any>.clearAll()
     }
 
     func testStoringKeys() {
@@ -68,21 +66,6 @@ final class EncryptionKeyStoreTests: XCTestCase {
         XCTAssertNotNil(secondReadKey)
         XCTAssertEqual(mockGenerator.numberOfKeysGenerated, 1)
         XCTAssertEqual(firstReadKey, secondReadKey)
-    }
-
-    func testThatReadingKeyWhenThereIsOneAndIsEncryptionKeyResavedIsTrueWillReturnTheSameKeyAndKey() {
-        // set IsEncryptionKeyResaved to true
-        var userDefaults = UserDefaultsWrapper<Bool>(key: .isEncryptionKeyResaved, defaultValue: false)
-        userDefaults.wrappedValue = true
-        // Save key in base 64
-        let originalKey = generator.randomKey()
-        let store = EncryptionKeyStore(generator: generator, account: account)
-        try? store.store(key: originalKey)
-        // Read key
-        let readKey = try? store.readKey()
-
-        // Check if it is the same key
-        XCTAssertEqual(originalKey, readKey)
     }
 
     private func removeTestKeys() {


### PR DESCRIPTION
This reverts commit 199cf19a0e24656c3e04226490f327eb1828fe25.

Task/Issue URL: https://app.asana.com/0/1177771139624306/1204466438263867/f
Tech Design URL:
CC:

## Description:

Rolls back the changes from https://github.com/duckduckgo/macos-browser/pull/1242

I'm creating this PR to make sure all is green, but I'll merge right away.  I'll be smoke testing the App anyways for 1.44.2.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
