### PR TITLE
Fixes a bug with us using the wrong utun for WireGuard

### DIFF
--- a/LocalPackages/NetworkProtection/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
+++ b/LocalPackages/NetworkProtection/Sources/NetworkProtection/WireGuardKit/WireGuardAdapter.swift
@@ -78,7 +78,11 @@ public class WireGuardAdapter {
                 _ = strcpy($0, "com.apple.net.utun_control")
             }
         }
-        for fd: Int32 in 0...1024 {
+
+        // We stride backwards since sometimes the OS creates more than one fd and from
+        // our testing the highest fd is always the one that we should use.
+        // Ref: https://app.asana.com/0/1203137811378537/1204887455080246/f
+        for fd: Int32 in stride(from: 1023, through: 1, by: -1) {
             var addr = sockaddr_ctl()
             var ret: Int32 = -1
             var len = socklen_t(MemoryLayout.size(ofValue: addr))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1204887455080246/f
Tech Design URL:
CC:

## Description

Fixes an issue that was causing NetP to lose connectivity.

## Testing:

1. Connect and disconnect many many times, sometimes faster sometimes slower and...
2. Test that your connection works.

Type: `ifconfig` to see how many utuns are created - this PR doesn't prevent many from being created, it just tries to ensure connectivity isn't lost due to them.  Make sure you reach a really high number like 50 utun interfaces or so.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
