### PR TITLE
Ignore bookmarks with missing UUIDs in sync

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9971,8 +9971,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "dominik/syncable-crash-fix";
-				kind = branch;
+				kind = exactVersion;
+				version = 62.0.2;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "dominik/syncable-crash-fix",
-        "revision" : "52a7633addd3cf267e2ef52a78a3779bc6674335"
+        "revision" : "7279299b3964b400b96acfdf5800ead396927ee9",
+        "version" : "62.0.2"
       }
     },
     {

--- a/LocalPackages/NetworkProtection/Package.swift
+++ b/LocalPackages/NetworkProtection/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // If you are updating the BSK dependency in the main app, this version will need to be updated to match.
         // There is work underway to move this package into BSK itself, after which this will not be required.
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "62.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "62.0.2"),
         .package(url: "https://github.com/duckduckgo/wireguard-apple", exact: "1.0.0")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204699272468090/f

**Description**:
When UUID is missing, throw an error in Syncable initializer. The error is silenced up the call chain
and the broken bookmark ends up not being included in sync.

**Steps to test this PR**:
See https://github.com/duckduckgo/BrowserServicesKit/pull/373 for details

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
