### PR TITLE
Initialize Sync Service before restoring app state

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -183,6 +183,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
             // MARK: perform first time launch logic here
         }
 
+        startupSync()
+
         stateRestorationManager.applicationDidFinishLaunching()
 
         BWManager.shared.initCommunication()
@@ -210,8 +212,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
 #if NETWORK_PROTECTION
         startupNetworkProtection()
 #endif
-
-        startupSync()
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1204915179738569/f

**Description**:
This change makes Sync Service available at the time of restoring app state, and when
the active tab showed Sync Settings, it would now display the screen properly instead
of showing blank screen (or failing assertion in debug builds).

**Steps to test this PR**:
1. Authenticate as internal user
2. Go to Settings
3. Enable state restoration
4. Go to Sync Settings
5. Quit the app
6. Reopen the app
7. Verify that assertion failure hasn't been thrown and that Sync Settings are shown.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
