### PR TITLE
disable on-demand on retry failure or cancelTunnelWithError

### DIFF
--- a/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/PacketTunnelProvider.swift
+++ b/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/PacketTunnelProvider.swift
@@ -563,6 +563,15 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    override func cancelTunnelWithError(_ error: Error?) {
+        // ensure on-demand rule is taken down on connection retry failure
+        Task {
+            await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .stopVPN)
+
+            super.cancelTunnelWithError(error)
+        }
+    }
+
     /// Do not cancel, directly... call this method so that the adapter and tester are stopped too.
     private func stopTunnel(with stopError: Error) {
         connectionStatus = .disconnecting


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1204915390132702/f

**Description**:
Disables on-demand rule in cancelTunnelWithError/stopTunnel(with:)

**Steps to test this PR**:
1. Validate on-demand rule is disabled when stopTunnel(with:) is called

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
