### PR TITLE
exclude www.figma.com from FB CTL

### DIFF
--- a/DuckDuckGo/ContentBlocker/clickToLoad.js
+++ b/DuckDuckGo/ContentBlocker/clickToLoad.js
@@ -775,6 +775,11 @@
     }
 
     const hostname = getTopLevelURL().hostname
+    const fbExcludedDomains = fbConfig['Facebook'].excludedDomains.map(x => x.domain);
+    if (fbExcludedDomains.includes(hostname)) {
+        // console.warn('BAILING ON excludedDomains');
+        return;
+    }
     window.webkit.messageHandlers.initClickToLoad.postMessage(hostname).then((blocked) => {
         if (!blocked || hostname === '') {
             return

--- a/DuckDuckGo/ContentBlocker/clickToLoadConfig.json
+++ b/DuckDuckGo/ContentBlocker/clickToLoadConfig.json
@@ -9,8 +9,8 @@
         ],
         "excludedDomains": [
             {
-                "domain": "",
-                "reason": ""
+                "domain": "www.figma.com",
+                "reason": "breakage due to file browser fb-page element"
             }
         ],
         "surrogates": [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204924502400025/f
Tech Design URL:
CC:

**Description**:
Fix to mitigate FB CTL element naming confusion-related breakage on www.figma.com

**Steps to test this PR**:
1. Log into Figma
2. Navigate to File Browser view, it should load

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
