### PR TITLE
fallback to distributed notiications when VPN helper tools fail from sysex

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
@@ -275,7 +275,7 @@ final class NavigationBarPopovers {
                 name: UserText.networkProtectionNavBarStatusViewShareFeedback,
                 action: {
                     let appLauncher = AppLauncher(appBundleURL: Bundle.main.bundleURL)
-                    await appLauncher.launchApp(withCommand: .shareFeedback)
+                    try? await appLauncher.launchApp(withCommand: .shareFeedback)
             })
         ]
 

--- a/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/AppExtensionAndNotificationTargets/NetworkProtectionUNNotificationsPresenter.swift
+++ b/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/AppExtensionAndNotificationTargets/NetworkProtectionUNNotificationsPresenter.swift
@@ -156,10 +156,10 @@ extension NetworkProtectionUNNotificationsPresenter: UNUserNotificationCenterDel
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
         switch UNNotificationAction.Identifier(rawValue: response.actionIdentifier) {
         case .reconnect:
-            await appLauncher.launchApp(withCommand: .startVPN)
+            try? await appLauncher.launchApp(withCommand: .startVPN)
 
         case .none:
-            await appLauncher.launchApp(withCommand: .showStatus)
+            try? await appLauncher.launchApp(withCommand: .showStatus)
         }
     }
 

--- a/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/PacketTunnelProvider.swift
+++ b/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/PacketTunnelProvider.swift
@@ -447,7 +447,11 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
                 // To be reconsidered for the Kill Switch
                 if isOnDemand {
                     Task {
-                        await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .stopVPN)
+                        do {
+                            try await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .stopVPN)
+                        } catch {
+                            self.distributedNotificationCenter.post(.stopVPN)
+                        }
                         completionHandler(error)
                     }
                     return
@@ -460,7 +464,11 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
                     // on-demand ON so that it won't interfere with the current connection.
                     completionHandler(error)
 
-                    await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .enableOnDemand)
+                    do {
+                        try await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .enableOnDemand)
+                    } catch {
+                        self.distributedNotificationCenter.post(.enableOnDemand)
+                    }
                     return
                 }
             }
@@ -551,7 +559,11 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
                     // stop requested by user from System Settings
                     // we can‘t prevent a respawn with on-demand rule ON
                     // request the main app to reconfigure with on-demand OFF
-                    await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .stopVPN)
+                    do {
+                        try await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .stopVPN)
+                    } catch {
+                        self.distributedNotificationCenter.post(.stopVPN)
+                    }
 
                 case .superceded:
                     self.notificationsPresenter.showSupercededNotification()
@@ -568,7 +580,11 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
     override func cancelTunnelWithError(_ error: Error?) {
         // ensure on-demand rule is taken down on connection retry failure
         Task {
-            await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .stopVPN)
+            do {
+                try await AppLauncher(appBundleURL: .mainAppBundleURL).launchApp(withCommand: .stopVPN)
+            } catch {
+                distributedNotificationCenter.post(.stopVPN)
+            }
 
             super.cancelTunnelWithError(error)
         }

--- a/LocalPackages/NetworkProtection/Sources/NetworkProtection/Controllers/AppLauncher.swift
+++ b/LocalPackages/NetworkProtection/Sources/NetworkProtection/Controllers/AppLauncher.swift
@@ -82,7 +82,7 @@ public final class AppLauncher {
         mainBundleURL = appBundleURL
     }
 
-    public func launchApp(withCommand command: Command) async {
+    public func launchApp(withCommand command: Command) async throws {
         let configuration = NSWorkspace.OpenConfiguration()
         configuration.allowsRunningApplicationSubstitution = false
 
@@ -107,6 +107,7 @@ public final class AppLauncher {
             }
         } catch {
             os_log("🔵 Open Application failed: %{public}@", log: .networkProtection, type: .error, error.localizedDescription)
+            throw error
         }
     }
 

--- a/LocalPackages/NetworkProtection/Sources/NetworkProtection/Controllers/AppLaunchingController.swift
+++ b/LocalPackages/NetworkProtection/Sources/NetworkProtection/Controllers/AppLaunchingController.swift
@@ -26,10 +26,10 @@ public final class AppLaunchingController: TunnelController {
     }
 
     public func start() async throws {
-        await appLauncher.launchApp(withCommand: .startVPN)
+        try await appLauncher.launchApp(withCommand: .startVPN)
     }
 
-    public func stop() async {
-        await appLauncher.launchApp(withCommand: .stopVPN)
+    public func stop() async throws {
+        try await appLauncher.launchApp(withCommand: .stopVPN)
     }
 }

--- a/LocalPackages/NetworkProtection/Sources/NetworkProtection/Controllers/TunnelController.swift
+++ b/LocalPackages/NetworkProtection/Sources/NetworkProtection/Controllers/TunnelController.swift
@@ -30,5 +30,5 @@ public protocol TunnelController {
 
     /// Stops the VPN connection used for Network Protection
     ///
-    func stop() async
+    func stop() async throws
 }

--- a/LocalPackages/NetworkProtection/Sources/NetworkProtection/Notifications/DistributedNotification.swift
+++ b/LocalPackages/NetworkProtection/Sources/NetworkProtection/Notifications/DistributedNotification.swift
@@ -70,6 +70,10 @@ public enum DistributedNotificationName: String {
     // New Status Observer
     case requestStatusUpdate = "com.duckduckgo.network-protection.NetworkProtectionNotification.requestStatusUpdate"
 
+    case stopVPN = "com.duckduckgo.network-protection.NetworkProtectionNotification.stopVPN"
+    case startVPN = "com.duckduckgo.network-protection.NetworkProtectionNotification.startVPN"
+    case enableOnDemand = "com.duckduckgo.network-protection.NetworkProtectionNotification.enableOnDemand"
+
     fileprivate var notificationName: Foundation.Notification.Name {
         NSNotification.Name(rawValue: rawValue)
     }

--- a/LocalPackages/NetworkProtectionUI/Sources/NetworkProtectionUI/NetworkProtectionStatusBarMenu.swift
+++ b/LocalPackages/NetworkProtectionUI/Sources/NetworkProtectionUI/NetworkProtectionStatusBarMenu.swift
@@ -67,10 +67,10 @@ public final class StatusBarMenu {
 
         let menuItems = [
             MenuItem(name: UserText.networkProtectionStatusMenuShareFeedback, action: {
-                await appLauncher.launchApp(withCommand: .shareFeedback)
+                try? await appLauncher.launchApp(withCommand: .shareFeedback)
             }),
             MenuItem(name: UserText.networkProtectionStatusMenuOpenDuckDuckGo, action: {
-                await appLauncher.launchApp(withCommand: .justOpen)
+                try? await appLauncher.launchApp(withCommand: .justOpen)
             })
         ]
 

--- a/LocalPackages/NetworkProtectionUI/Sources/NetworkProtectionUI/NetworkProtectionStatusViewModel.swift
+++ b/LocalPackages/NetworkProtectionUI/Sources/NetworkProtectionUI/NetworkProtectionStatusViewModel.swift
@@ -466,7 +466,10 @@ extension NetworkProtectionStatusView {
         ///
         private func stopNetworkProtection() {
             Task { @MainActor in
-                await tunnelController.stop()
+                do {
+                    try await tunnelController.stop()
+                    // to be done: put try await transition to stopped here
+                } catch {}
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1204933809928857/f
Tech Design URL:
CC:

**Description**:
- sysex will send distributed notification to agent on helper tool launch failure

**Steps to test this PR**:
1. Make AppLauncher throw an error in SystemExtension instead of actually launching a helper tool app, or corrupt tool URL resolver
2. Connect to VPN
3. Disconnect from System Settings, make sure agent disables on-demand rule
4. Connect from System Settings, make sure agent enables on-demand rule

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
