### PR TITLE
update shield icon only after navigation ended and tab is selected

### DIFF
--- a/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -309,10 +309,12 @@ final class TabViewModel {
     // MARK: - Privacy icon animation
 
     let trackersAnimationTriggerPublisher = PassthroughSubject<Void, Never>()
+    let privacyEntryPointIconUpdateTrigger = PassthroughSubject<Void, Never>()
 
     private var trackerAnimationTimer: Timer?
 
     private func sendAnimationTrigger() {
+        privacyEntryPointIconUpdateTrigger.send()
         if self.tab.privacyInfo?.trackerInfo.trackersBlocked.count ?? 0 > 0 {
             self.trackersAnimationTriggerPublisher.send()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204211620454133/f

**Description**: Sites that start off insecure then redirect to https cause the red badge to flash then go away. To fix this the icon is only updated at the end of the navigation and when tab is selected.

**Steps to test this PR**:
1. Open an https website (e.g. wikipedia) check no red dot is visible on the shield icon
2. Open an http website (e.g. neverssl.com) check a red dot is visible on the shield icon
3. swap between the tabs and check the icon shield is correct
4. enter ‘cabubble.co.uk’ and check it never shows a red dot in the shield (no flash)
5. Open neverssl.com and then load wikipedia from a new tab and check no red dot is shown
6. Try other combinations you might think of

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
