### PR TITLE
Update the check used to determine which user defaults wrapper is used

### DIFF
--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -134,7 +134,7 @@ public struct UserDefaultsWrapper<T> {
     }
 
     static var sharedDefaults: UserDefaults {
-#if DEBUG && !NETP_SYSTEM_EXTENSION
+#if DEBUG && !(NETP_SYSTEM_EXTENSION && NETWORK_EXTENSION) // Avoid looking up special user defaults when running inside the system extension
         if case .normal = NSApp.runType {
             return .standard
         } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1204964526109657/f
Tech Design URL:
CC: @ayoy 

**Description**:

This PR fixes a test failure introduced recently in PR #1259.

This PR was using `NETP_SYSTEM_EXTENSION` as its check, but this value is actually set on the Developer ID target also. So, to fix this, we need to check for `NETP_SYSTEM_EXTENSION` and also `NETWORK_EXTENSION`, to ensure we're only targeting the system extension itself.

**Steps to test this PR**:
1. Run tests and make sure they pass

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
