### PR TITLE
Add error handler for sending pixels

### DIFF
--- a/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -19,6 +19,8 @@
 import Foundation
 import DataBrokerProtection
 import AppKit
+import BrowserServicesKit
+import Common
 
 final class DBPHomeViewController: NSViewController {
 
@@ -28,5 +30,19 @@ final class DBPHomeViewController: NSViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+
+}
+
+public class DataBrokerProtectionErrorHandling: EventMapping<DataBrokerProtectionOperationError> {
+
+    public init() {
+        super.init { event, _, _, _ in
+            Pixel.fire(.debug(event: .dataBrokerProtectionError, error: event.error), withAdditionalParameters: event.params)
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<DataBrokerProtectionOperationError>.Mapping) {
+        fatalError("Use init()")
     }
 }

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -260,7 +260,9 @@ extension Pixel {
             case invalidPayload(Configuration)
 
             case burnerTabMisplaced
-
+#if DBP
+            case dataBrokerProtectionError
+#endif
         }
 
     }
@@ -583,6 +585,9 @@ extension Pixel.Event.Debug {
 
         case .burnerTabMisplaced: return "burner_tab_misplaced"
 
+#if DBP
+        case .dataBrokerProtectionError: return "data_broker_error"
+#endif
         }
     }
 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/CCF/DataBrokerProtectionErrors.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/CCF/DataBrokerProtectionErrors.swift
@@ -22,7 +22,7 @@ struct CCFError: Decodable {
     let error: String
 }
 
-enum DataBrokerProtectionError: Error, Equatable {
+public enum DataBrokerProtectionError: Error, Equatable {
     case malformedURL
     case noActionFound
     case actionFailed(actionID: String, message: String)
@@ -33,7 +33,7 @@ enum DataBrokerProtectionError: Error, Equatable {
     case unrecoverableError
     case noOptOutStep
     case captchaServiceError(CaptchaServiceError)
-    case emailError(EmailService.EmailError?)
+    case emailError(EmailError?)
 
     static func parse(params: Any) -> DataBrokerProtectionError {
         let errorDataResult = try? JSONSerialization.data(withJSONObject: params)
@@ -48,5 +48,34 @@ enum DataBrokerProtectionError: Error, Equatable {
         }
 
         return .parsingErrorObjectFailed
+    }
+}
+
+extension DataBrokerProtectionError {
+    var name: String {
+        switch self {
+        case .malformedURL:
+            return "malformedURL"
+        case .noActionFound:
+            return "noActionFound"
+        case .actionFailed:
+            return "actionFailed"
+        case .parsingErrorObjectFailed:
+            return "parsingErrorObjectFailed"
+        case .unknownMethodName:
+            return "unknownMethodName"
+        case .userScriptMessageBrokerNotSet:
+            return "userScriptMessageBrokerNotSet"
+        case .unknown(let name):
+            return name
+        case .unrecoverableError:
+            return "unrecoverableError"
+        case .noOptOutStep:
+            return "noOptOutStep"
+        case .captchaServiceError:
+            return "captchaServiceError"
+        case .emailError:
+            return "emailError"
+        }
     }
 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperation.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperation.swift
@@ -20,9 +20,11 @@ import Foundation
 import WebKit
 import BrowserServicesKit
 import UserScript
+import Common
 
 protocol DataBrokerOperation: CCFCommunicationDelegate {
     associatedtype ReturnValue
+
     var privacyConfig: PrivacyConfigurationManaging { get }
     var prefs: ContentScopeProperties { get }
     var query: BrokerProfileQueryData { get }
@@ -67,7 +69,7 @@ extension DataBrokerOperation {
             do {
                 query.profileQuery = try await getProfileWithEmail()
             } catch {
-                onError(error: .emailError(error as? EmailService.EmailError))
+                onError(error: .emailError(error as? EmailError))
                 return
             }
         }
@@ -84,10 +86,10 @@ extension DataBrokerOperation {
                 try? await webViewHandler?.load(url: url)
             } else {
                 assertionFailure("Trying to run email confirmation without an email.")
-                throw EmailService.EmailError.cantFindEmail
+                throw EmailError.cantFindEmail
             }
         } catch {
-            onError(error: .emailError(error as? EmailService.EmailError))
+            onError(error: .emailError(error as? EmailError))
         }
     }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionOperationError.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionOperationError.swift
@@ -1,0 +1,36 @@
+//
+//  DataBrokerProtectionOperationError.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct DataBrokerProtectionOperationError {
+    public let error: DataBrokerProtectionError
+    public let dataBrokerName: String
+
+    public var params: [String: String] {
+        if case let .actionFailed(actionID, message) = error {
+            return ["dataBroker": dataBrokerName,
+                    "name": error.name,
+                    "actionID": actionID,
+                    "message": message]
+        } else {
+            return ["dataBroker": dataBrokerName,
+                    "name": error.name]
+        }
+    }
+}

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
@@ -18,29 +18,33 @@
 
 import Foundation
 import Common
+import BrowserServicesKit
 
 public final class DataBrokerProtectionScheduler {
     private let activity: NSBackgroundActivityScheduler
+    private let errorHandler: EventMapping<DataBrokerProtectionOperationError>
     private let schedulerIdentifier = "com.duckduckgo.macos.browser.databroker-protection-scheduler"
 
     lazy var dataBrokerProcessor: DataBrokerProtectionProcessor = {
 
         DataBrokerProtectionProcessor(database: DataBrokerProtectionDataBase(),
                                       config: DataBrokerProtectionSchedulerConfig(),
-                                      operationRunnerProvider: DataBrokerOperationRunnerProvider())
+                                      operationRunnerProvider: DataBrokerOperationRunnerProvider(),
+                                      errorHandler: errorHandler)
     }()
 
-    public init() {
-          activity = NSBackgroundActivityScheduler(identifier: schedulerIdentifier)
-          activity.repeats = true
+    public init(errorHandler: EventMapping<DataBrokerProtectionOperationError>) {
+        self.errorHandler = errorHandler
 
-          // TODO: Arbitrary numbers for now
-          // Scheduling an activity to fire between 15 and 45 minutes from now
-          activity.interval = 30 * 60
-          activity.tolerance = 15 * 60
+        activity = NSBackgroundActivityScheduler(identifier: schedulerIdentifier)
+        activity.repeats = true
+        // TODO: Arbitrary numbers for now
+        // Scheduling an activity to fire between 15 and 45 minutes from now
+        activity.interval = 30 * 60
+        activity.tolerance = 15 * 60
 
-          activity.qualityOfService = QualityOfService.utility
-      }
+        activity.qualityOfService = QualityOfService.utility
+    }
 
     public func start() {
         os_log("Starting scheduler...", log: .dataBrokerProtection)
@@ -60,4 +64,5 @@ public final class DataBrokerProtectionScheduler {
         os_log("Scanning all brokers...", log: .dataBrokerProtection)
         self.dataBrokerProcessor.runScanOnAllDataBrokers()
     }
+
 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/CaptchaService.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/CaptchaService.swift
@@ -22,7 +22,7 @@ import Common
 typealias CaptchaTransactionId = String
 typealias CaptchaResolveData = String
 
-enum CaptchaServiceError: Error {
+public enum CaptchaServiceError: Error {
     case cantGenerateCaptchaServiceURL
     case nilTransactionIdWhenSubmittingCaptcha
     case criticalFailureWhenSubmittingCaptcha

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/EmailService.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/EmailService.swift
@@ -19,16 +19,15 @@
 import Foundation
 import Common
 
+public enum EmailError: Error, Equatable {
+    case cantGenerateURL
+    case cantFindEmail
+    case invalidEmailLink
+    case linkExtractionTimedOut
+    case cantDecodeEmailLink
+}
+
 struct EmailService {
-
-    enum EmailError: Error, Equatable {
-        case cantGenerateURL
-        case cantFindEmail
-        case invalidEmailLink
-        case linkExtractionTimedOut
-        case cantDecodeEmailLink
-    }
-
     private struct Constants {
         static let baseUrl = "https://dbp.duckduckgo.com/dbp/em/v0"
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1204946671793052/f

**Description**:
Add error handler for sending pixels

**Steps to test this PR**:
1. Force an error inside the scheduler using a function like this:

```swift
    public func testDataBrokerProtectionScanOperation(prefs: ContentScopeProperties,
                                                      manager: PrivacyConfigurationManaging) {

        let getCaptchaInfoAction = GetCaptchaInfoAction(selector: ".g-recapddtcha") // forcing error
        let solveCaptchaAction = SolveCaptchaAction(selector: ".g-recaptcha")
        let step = Step(type: .scan, actions: [getCaptchaInfoAction, solveCaptchaAction])
        let profileData = ProfileQuery(firstName: "Ben", lastName: "Smith", city: "Miami", state: "FL", age: 40)
        let dataBrokerData = DataBroker(name: "verecor", steps: [step], schedulingConfig: DataBrokerScheduleConfig(emailConfirmation: 10, retryError: 10, confirmOptOutScan: 10, maintenanceScan: 10))
        let query = BrokerProfileQueryData(id: UUID(), profileQuery: profileData, dataBroker: dataBrokerData)
        let dbp = ScanOperation(privacyConfig: manager, prefs: prefs, query: query)

        Task {
            do {
                let _ = try await dbp.run()
            } catch {
             // fire the error
                if let error = error as? DataBrokerProtectionError {
                     errorHandler.fire(.init(error: error, dataBrokerName: "whatever"))
               }
            }
        }
    }
}
```

and check if the pixel is being fired

