### PR TITLE
Revert "update ddg browsing user agent (#1315)"

### DIFF
--- a/DuckDuckGo/UserAgent/Model/UserAgent.swift
+++ b/DuckDuckGo/UserAgent/Model/UserAgent.swift
@@ -61,8 +61,11 @@ enum UserAgent {
     static let webViewDefault = ""
 
     static let localUserAgentConfiguration: KeyValuePairs<RegEx, String> = [
-        // Use safari agent or else nginx gets a truncated user agent and ends it ends up blank
-        regex("https://duckduckgo\\.com/.*"): UserAgent.safari
+        // use safari when serving up PDFs from duckduckgo directly
+        regex("https://duckduckgo\\.com/[^?]*\\.pdf"): UserAgent.safari,
+
+        // use default WKWebView user agent for duckduckgo domain to remove CTA
+        regex("https://duckduckgo\\.com/.*"): UserAgent.webViewDefault
     ]
 
     static func duckDuckGoUserAgent(appVersion: String = AppVersion.shared.versionNumber,

--- a/UnitTests/UserAgent/Model/UserAgentTests.swift
+++ b/UnitTests/UserAgent/Model/UserAgentTests.swift
@@ -34,9 +34,9 @@ final class UserAgentTests: XCTestCase {
         XCTAssertEqual(UserAgent.safari, UserAgent.for(URL(string: "https://a.docs.google.com")!))
     }
 
-    func testWhenDomainIsDuckDuckGo_thenUserAgentIncludesSafariButNotChrome() {
-        XCTAssertTrue(UserAgent.for(URL.duckDuckGo).contains("Safari"))
-        XCTAssertFalse(UserAgent.for(URL.duckDuckGo).contains("Chrome"))
+    func testWhenDomainIsDuckDuckGo_ThenUserAgentDoesntIncludeChromeOrSafari() {
+        XCTAssert(!UserAgent.for(URL.duckDuckGo).contains("Safari"))
+        XCTAssert(!UserAgent.for(URL.duckDuckGo).contains("Chrome"))
     }
 
     func testWhenUserAgentIsDuckDuckGo_ThenUserAgentContainsExpectedParameters() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204978929821142/f

**Description**:
This reverts commit cfcc455b3d31bb13e17f4e8b8f24ba77de896af5.
This change brings back WebKit default UA for duckduckgo.com/* browsing requests
to make browser/extension CTAs disappear from duckduckgo.com and SERP.


**Steps to test this PR**:
1. Run the app from Xcode
2. Enable session restoration
3. Go to https://duckduckgo.com
4. Close the app
5. Relaunch the app, verify that you don't see CTAs (download macOS browser + set DDG as default search engine) on https://duckduckgo.com
6. Repeat the same with the App Store target.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
