### PR TITLE
Add Debug menu option back in for resetting the Email Protection InContext prompt

### DIFF
--- a/DuckDuckGo/Menus/MainMenu.storyboard
+++ b/DuckDuckGo/Menus/MainMenu.storyboard
@@ -762,6 +762,12 @@ CQ
                                                             <action selector="resetMakeDuckDuckGoYoursUserSettings:" target="Ady-hI-5gd" id="maa-qG-0Bx"/>
                                                         </connections>
                                                     </menuItem>
+                                                    <menuItem title="Reset Email Protection InContext Signup Prompt" id="cQF-Np-0vk">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="resetEmailProtectionInContextPrompt:" target="Ady-hI-5gd" id="bRN-Eo-xL1"/>
+                                                        </connections>
+                                                    </menuItem>
                                                 </items>
                                             </menu>
                                         </menuItem>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1205102591611427/f
Tech Design URL:
CC:

**Description**:
Adds debug menu option back in 

**Steps to test this PR**:
1. Sign out of Email Protection (if signed in) and Reset the Email Protection InContext Signup Prompt (Debug menu > Reset Data)
2. Go to https://fill.dev/form/registration-email and tap the grey Dax icon and select the "Hide your email and block trackers" option from the tooltip
3. This loads a new tab. Go back to the tab you were on and the Dax icon should be gone
4. Reset the Email Protection InContext Signup Prompt again refresh the web page
5. Grey dax icon should be back! 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
