### PR TITLE
Fix UserContentController cleared on Pinned Tab close

### DIFF
--- a/DuckDuckGo/PinnedTabs/Model/PinnedTabsManager.swift
+++ b/DuckDuckGo/PinnedTabs/Model/PinnedTabsManager.swift
@@ -16,9 +16,10 @@
 //  limitations under the License.
 //
 
-import Foundation
+import AppKit
 import Combine
 import Common
+import Foundation
 
 final class PinnedTabsManager {
 
@@ -91,7 +92,7 @@ final class PinnedTabsManager {
             .asVoid()
             .sink { [weak self] in
                 if NSApp.windows.filter({ $0 is MainWindow }).count == 1 {
-                    self?.tabCollection.tabs.forEach { $0.cleanUpBeforeClosing() }
+                    self?.tabCollection.tabs.forEach { $0.stopAllMediaAndLoading() }
                 }
             }
     }

--- a/DuckDuckGo/PinnedTabs/Model/PinnedTabsViewModel.swift
+++ b/DuckDuckGo/PinnedTabs/Model/PinnedTabsViewModel.swift
@@ -128,7 +128,6 @@ extension PinnedTabsViewModel {
 
     func isFireproof(_ tab: Tab) -> Bool {
         guard let host = tab.url?.host else {
-            os_log("PinnedTabsViewModel: Failed to get url of a tab", type: .error)
             return false
         }
         return fireproofDomains.isFireproof(fireproofDomain: host)

--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -444,10 +444,7 @@ protocol NewWindowPolicyDecisionMaker {
     @MainActor(unsafe)
     private func cleanUpBeforeClosing(onDeinit: Bool) {
         let job = { [webView, userContentController] in
-            webView.stopLoading()
-            webView.stopMediaCapture()
-            webView.stopAllMediaPlayback()
-            webView.fullscreenWindowController?.close()
+            webView.stopAllMediaAndLoading()
 
             userContentController?.cleanUpBeforeClosing()
             webView.assertObjectDeallocated(after: 4.0)
@@ -461,6 +458,10 @@ protocol NewWindowPolicyDecisionMaker {
             return
         }
         job()
+    }
+
+    func stopAllMediaAndLoading() {
+        webView.stopAllMediaAndLoading()
     }
 
 #if DEBUG
@@ -494,9 +495,7 @@ protocol NewWindowPolicyDecisionMaker {
     @Published private(set) var content: TabContent {
         didSet {
             if !content.displaysContentInWebView && oldValue.displaysContentInWebView {
-                webView.stopLoading()
-                webView.stopMediaCapture()
-                webView.stopAllMediaPlayback()
+                webView.stopAllMediaAndLoading()
             }
             handleFavicon()
             invalidateInteractionStateData()
@@ -576,8 +575,6 @@ protocol NewWindowPolicyDecisionMaker {
             if error == nil || error?.isFrameLoadInterrupted == true || error?.isNavigationCancelled == true {
                 return
             }
-            webView.stopLoading()
-            webView.stopMediaCapture()
             webView.stopAllMediaPlayback()
         }
     }
@@ -1125,7 +1122,7 @@ extension Tab: TabDataClearing {
     func prepareForDataClearing(caller: TabCleanupPreparer) {
         webViewCancellables.removeAll()
 
-        webView.stopLoading()
+        self.stopAllMediaAndLoading()
         (webView.configuration.userContentController as? UserContentController)?.cleanUpBeforeClosing()
 
         webView.navigationDelegate = caller

--- a/DuckDuckGo/Tab/View/WebView.swift
+++ b/DuckDuckGo/Tab/View/WebView.swift
@@ -28,6 +28,16 @@ final class WebView: WKWebView {
 
     weak var contextMenuDelegate: WebViewContextMenuDelegate?
 
+    func stopAllMediaAndLoading() {
+        stopLoading()
+        stopMediaCapture()
+        stopAllMediaPlayback()
+        fullscreenWindowController?.close()
+        if isInspectorShown {
+            closeDeveloperTools()
+        }
+    }
+
     deinit {
         self.configuration.userContentController.removeAllUserScripts()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1204943460154951/f

**Description**:
- Fixes removal of user scripts and content blocking rules from UserContentController on pinned tab close

**Steps to test this PR**:
1. Open a Pinned Tab (e.g. with youtube), start fullscreen video playback, open inspector
2. Close the window - ensure inspector and fullscreen video closed and media capture stopped
3. Reopen the window
4. Open console/Sources, ensure External Scripts/content blocking rules are still loaded (use nytimes.com for validation - the banner on the top should disappear when content blocking is applied)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
