### PR TITLE
Close the window when cmd+w is pressed on a pinned tab and there are no regular tabs

### DIFF
--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -390,9 +390,10 @@ extension MainViewController {
         // when close is triggered by a keyboard shortcut,
         // instead of closing a pinned tab we select the first regular tab
         // (this is in line with Safari behavior)
+        // If there are no regular tabs, we close the window.
         if isHandlingKeyDownEvent, tabCollectionViewModel.selectionIndex?.isPinnedTab == true {
             if tabCollectionViewModel.tabCollection.tabs.isEmpty {
-                tabCollectionViewModel.append(tab: Tab(content: .homePage, isBurner: false), selected: true)
+                view.window?.performClose(sender)
             } else {
                 tabCollectionViewModel.select(at: .unpinned(0))
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204556813221233/1205135257377149/f

**Description**:
If there are only pinned tabs open, cmd+w would close the window.
If there are unpinned tabs and a pinned tab is selected, cmd+w selects the first unpinned tab
(as it was always the case).

**Steps to test this PR**:
1. Have one pinned tab and one unpinned tab
2. Select unpinned tab
3. Press cmd+w – verify that the unpinned tab was closed and pinned tab is selected
4. Press cmd+w – verify that the window is closed
5. Have one pinned tab and one unpinned tab again
6. Select pinned tab
7. Press cmd+w – verify that the unpinned tab was selected.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
