### PR TITLE
Update minor version by default in code_freeze lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -237,7 +237,7 @@ platform :mac do
   private_lane :validate_new_version do |options|
     current_version = macos_current_version
     user_version = format_user_version(options[:version])
-    new_version = user_version.nil? ? macos_bump_patch_version(current_version) : user_version
+    new_version = user_version.nil? ? macos_bump_minor_version(current_version) : user_version
     unless UI.confirm(
       "Current version is #{current_version}.\nNew version is #{new_version}.\nDo you want to continue?"
     )
@@ -352,15 +352,15 @@ platform :mac do
     current_version
   end
 
-  # Updates version in the config file by bumping the patch (third) number
+  # Updates version in the config file by bumping the minor (second) number
   #
   # @param [String] current version
   # @return [String] updated version
   #
-  def macos_bump_patch_version(current_version)
+  def macos_bump_minor_version(current_version)
     current_version_array = current_version.split('.')
-    new_patch_number = current_version_array[2].to_i + 1
-    "#{current_version_array[0]}.#{current_version_array[1]}.#{new_patch_number}"
+    new_minor_number = current_version_array[1].to_i + 1
+    "#{current_version_array[0]}.#{new_minor_number}.0"
   end
 
   # Formats the version provided by the user to be Major.Minor.Patch


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1205076166880574/f
CC: @loremattei 

**Description**:
When running code_freeze fastlane lane without specifying the version, bump minor version.

**Steps to test this PR**:
1. Check out this branch (`dominik/code-freeze-version-bump`)
2. Edit line 8 of fastlane/Fastfile to say `DEFAULT_BRANCH = 'dominik/code-freeze-version-bump'`
3. Commit the change locally
4. Run `bundle exec fastlane code_freeze`
5. Verify that it proposes to bump the minor version component (e.g. 1.49.0 -> 1.50.0)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
