### PR TITLE
Upload dSYMs from release builds to S3 for Sentry

### DIFF
--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -255,7 +255,7 @@ jobs:
       run: |
         aws s3 cp \
           ${{ github.workspace }}/release/DuckDuckGo-${{ env.app-version }}-dSYM.zip \
-          s3://${{ env.DSYM_BUCKET_NAME }}/${{ env.DSYM_BUCKET_PREFIX }}
+          s3://${{ env.DSYM_BUCKET_NAME }}/${{ env.DSYM_BUCKET_PREFIX }}/
 
   create-dmg:
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1204873010712988/f

**Description**:
For notarized app's release workflows, upload dSYMs zip to a dedicated S3 bucket used by Sentry
to fetch debug symbols.
The workflow step runs only for "release" type builds from branches named `release/*` or `hotfix/*`.

**Steps to test this PR**:
Check out the workflow run I made from `release/dominik/gha-upload-dsym-to-s3` branch:
https://github.com/duckduckgo/macos-browser/actions/runs/5662293581/job/15341963173
* Verify that _Upload dSYMs to S3_ step was completed.
* The S3 path at the bottom uses my personal bucket name, that has since been updated to the
  proper Sentry bucket (together with AWS credentials). It's important that its format follows
  `s3://<bucket_name>/macos-browser/<dsym_zip>` pattern.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
