### PR TITLE
Merge extracted profile with profile query

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/ExtractedProfile.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/ExtractedProfile.swift
@@ -85,6 +85,7 @@ struct ExtractedProfile: Codable, Sendable {
     let age: String?
     var email: String?
     var removedDate: Date?
+    let fullName: String?
 
     enum CodingKeys: CodingKey {
         case name
@@ -100,6 +101,7 @@ struct ExtractedProfile: Codable, Sendable {
         case age
         case email
         case removedDate
+        case fullName
     }
 
     init(name: String? = nil,
@@ -128,6 +130,24 @@ struct ExtractedProfile: Codable, Sendable {
         self.age = age
         self.email = email
         self.removedDate = removedDate
+        self.fullName = name
+    }
+
+    func merge(with profile: ProfileQuery) -> ExtractedProfile {
+        ExtractedProfile(
+            name: self.name ?? profile.fullName,
+            alternativeNamesList: self.alternativeNamesList,
+            addressFull: self.addressFull,
+            addressCityState: self.addressCityState,
+            addressCityStateList: self.addressCityStateList,
+            phone: self.phone,
+            relativesList: self.relativesList,
+            profileUrl: self.profileUrl,
+            reportId: self.reportId,
+            age: self.age ?? String(profile.age),
+            email: self.email,
+            removedDate: self.removedDate
+        )
     }
 }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OptOutOperation.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OptOutOperation.swift
@@ -56,7 +56,7 @@ final class OptOutOperation: DataBrokerOperation {
              webViewHandler: WebViewHandler? = nil,
              actionsHandler: ActionsHandler? = nil) async throws {
         try await withCheckedThrowingContinuation { continuation in
-            self.extractedProfile = inputValue
+            self.extractedProfile = inputValue.merge(with: query.profileQuery)
             self.continuation = continuation
 
             Task {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/ExtractedProfileTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/ExtractedProfileTests.swift
@@ -1,0 +1,60 @@
+//
+//  ExtractedProfileTests.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Foundation
+@testable import DataBrokerProtection
+
+final class ExtractedProfileTests: XCTestCase {
+
+    func testWhenExtractedProfileDoesNotHaveAName_thenMergeAddsProfileQueryNameToIt() {
+        let profileQuery = ProfileQuery(firstName: "John", lastName: "Doe", city: "Los Angeles", state: "CA", age: 45)
+        let extractedProfile = ExtractedProfile()
+
+        let sut = extractedProfile.merge(with: profileQuery)
+
+        XCTAssertEqual(sut.name, "John Doe")
+    }
+
+    func testWhenExtractedProfileHasAName_thenMergeLeavesExtractedProfileName() {
+        let profileQuery = ProfileQuery(firstName: "John", lastName: "Doe", city: "Los Angeles", state: "CA", age: 45)
+        let extractedProfile = ExtractedProfile(name: "Ben Smith")
+
+        let sut = extractedProfile.merge(with: profileQuery)
+
+        XCTAssertEqual(sut.name, "Ben Smith")
+    }
+
+    func testWhenExtractedProfileDoesNotHaveAge_thenMergeAddsProfileQueryAgeToIt() {
+        let profileQuery = ProfileQuery(firstName: "John", lastName: "Doe", city: "Los Angeles", state: "CA", age: 45)
+        let extractedProfile = ExtractedProfile()
+
+        let sut = extractedProfile.merge(with: profileQuery)
+
+        XCTAssertEqual(sut.age, "45")
+    }
+
+    func testWhenExtractedProfileHasAge_thenMergeLeavesExtractedProfileAge() {
+        let profileQuery = ProfileQuery(firstName: "John", lastName: "Doe", city: "Los Angeles", state: "CA", age: 45)
+        let extractedProfile = ExtractedProfile(age: "52")
+
+        let sut = extractedProfile.merge(with: profileQuery)
+
+        XCTAssertEqual(sut.age, "52")
+    }
+}


### PR DESCRIPTION
## Task

https://app.asana.com/0/1203581873609357/1205137387171122/f

## Description

When doing opt-outs we are currently using all the extracted profile data provided by CCF.

If some field is not present in the extracted profile and is required by the opt-out process, we need to fall back to the profile that the user entered.

The solution adds a `merge` function inside the `ExtractedProfile` that receives a `ProfileQuery` as a parameter, there we check if the field is present on the `ExtractedProfile` if not, we default to the `ProfileQuery`.