### PR TITLE
Fix reordering favorites in the last row when it's not fully populated

### DIFF
--- a/DuckDuckGo/HomePage/View/FavoritesView.swift
+++ b/DuckDuckGo/HomePage/View/FavoritesView.swift
@@ -175,7 +175,11 @@ struct FavoritesGrid: View {
     private func pointConstrainedToFavoritesView(_ point: CGPoint) -> CGPoint {
         let rowCount: Int = {
             if model.showAllFavorites {
-                return model.models.count / HomePage.favoritesPerRow
+                var count = model.models.count / HomePage.favoritesPerRow
+                if model.models.count % HomePage.favoritesPerRow > 0 {
+                    count += 1
+                }
+                return count
             }
             return HomePage.favoritesRowCountWhenCollapsed
         }()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205124491027651/f

**Description**:
Fix favorites row count calculation for the drag gesture to include
last favorites row also when it's not fully populated.

**Steps to test this PR**:
It's easiest to populate and manage favorites by importing favorites from e.g. Safari and then adjusting them in Bookmark Management view.
1. Add 5 or fewer favorites and verify that they can be reordered on the new tab page.
2. Add 6 favorites and verify the same.
3. Add 7-11 favorites and verify the same. Check reordering between rows.
4. Add 13 favorites and verify the same. Check reordering between rows.
5. Add >14 favorites and verify the same. Check reordering between rows.
6. Collapse favorites to only show 1 row and check reordering. Ensure that collapsed rows are not affected by reordering.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
