### PR TITLE
Add support for invite codes flow

### DIFF
--- a/DuckDuckGo/DBP/DebugUI/DataBrokerProtectionDebugViewController.swift
+++ b/DuckDuckGo/DBP/DebugUI/DataBrokerProtectionDebugViewController.swift
@@ -28,6 +28,7 @@ final class DataBrokerProtectionDebugViewController: NSViewController {
     var fakeBrokerSwitch: NSSwitch!
 
     private let fakeBrokerFlag: FakeBrokerFlag = FakeBrokerUserDefaults()
+    private let reedemUseCase: DataBrokerProtectionRedeemUseCase
 
     private var isSchedulerRunning = false
     private var scheduler: DataBrokerProtectionScheduler?
@@ -42,6 +43,15 @@ final class DataBrokerProtectionDebugViewController: NSViewController {
     lazy var profileQueryViewController: DataBrokerProfileQueryViewController = {
         DataBrokerProfileQueryViewController(dataManager: dataManager)
     }()
+
+    init(reedemUseCase: DataBrokerProtectionRedeemUseCase) {
+        self.reedemUseCase = reedemUseCase
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -169,7 +179,9 @@ final class DataBrokerProtectionDebugViewController: NSViewController {
                                                   contentScopeProperties: prefs,
                                                   dataManager: dataManager,
                                                   notificationCenter: NotificationCenter.default,
-                                                  errorHandler: DataBrokerProtectionErrorHandling())
+                                                  errorHandler: DataBrokerProtectionErrorHandling(),
+                                                  redeemUseCase: reedemUseCase
+        )
     }
 }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationRunner.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationRunner.swift
@@ -28,22 +28,40 @@ protocol WebOperationRunner {
 
 @MainActor
 final class DataBrokerOperationRunner: WebOperationRunner {
-    var privacyConfigManager: PrivacyConfigurationManaging
-    var contentScopeProperties: ContentScopeProperties
+    let privacyConfigManager: PrivacyConfigurationManaging
+    let contentScopeProperties: ContentScopeProperties
+    let emailService: EmailServiceProtocol
+    let captchaService: CaptchaServiceProtocol
 
     internal init(privacyConfigManager: PrivacyConfigurationManaging,
-                  contentScopeProperties: ContentScopeProperties) {
+                  contentScopeProperties: ContentScopeProperties,
+                  emailService: EmailServiceProtocol,
+                  captchaService: CaptchaServiceProtocol) {
         self.privacyConfigManager = privacyConfigManager
         self.contentScopeProperties = contentScopeProperties
+        self.emailService = emailService
+        self.captchaService = captchaService
     }
 
     func scan(_ profileQuery: BrokerProfileQueryData) async throws -> [ExtractedProfile] {
-        let scan = ScanOperation(privacyConfig: privacyConfigManager, prefs: contentScopeProperties, query: profileQuery)
+        let scan = ScanOperation(
+            privacyConfig: privacyConfigManager,
+            prefs: contentScopeProperties,
+            query: profileQuery,
+            emailService: emailService,
+            captchaService: captchaService
+        )
         return try await scan.run(inputValue: ())
     }
 
     func optOut(profileQuery: BrokerProfileQueryData, extractedProfile: ExtractedProfile) async throws {
-        let optOut = OptOutOperation(privacyConfig: privacyConfigManager, prefs: contentScopeProperties, query: profileQuery)
+        let optOut = OptOutOperation(
+            privacyConfig: privacyConfigManager,
+            prefs: contentScopeProperties,
+            query: profileQuery,
+            emailService: emailService,
+            captchaService: captchaService
+        )
         try await optOut.run(inputValue: extractedProfile)
     }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationRunnerProvider.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationRunnerProvider.swift
@@ -22,10 +22,15 @@ import BrowserServicesKit
 struct DataBrokerOperationRunnerProvider: OperationRunnerProvider {
     var privacyConfigManager: PrivacyConfigurationManaging
     var contentScopeProperties: ContentScopeProperties
+    var emailService: EmailServiceProtocol
+    var captchaService: CaptchaServiceProtocol
 
     @MainActor
     func getOperationRunner() -> WebOperationRunner {
         DataBrokerOperationRunner(privacyConfigManager: privacyConfigManager,
-                            contentScopeProperties: contentScopeProperties)
+                                  contentScopeProperties: contentScopeProperties,
+                                  emailService: emailService,
+                                  captchaService: captchaService
+        )
     }
 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
@@ -36,11 +36,15 @@ public final class DataBrokerProtectionScheduler {
     private let errorHandler: EventMapping<DataBrokerProtectionOperationError>
     private let schedulerIdentifier = "com.duckduckgo.macos.browser.databroker-protection-scheduler"
     private let notificationCenter: NotificationCenter
+    private let emailService: EmailServiceProtocol
+    private let captchaService: CaptchaServiceProtocol
 
     lazy var dataBrokerProcessor: DataBrokerProtectionProcessor = {
 
         let runnerProvider = DataBrokerOperationRunnerProvider(privacyConfigManager: privacyConfigManager,
-                                                               contentScopeProperties: contentScopeProperties)
+                                                               contentScopeProperties: contentScopeProperties,
+                                                               emailService: emailService,
+                                                               captchaService: captchaService)
 
         return DataBrokerProtectionProcessor(database: dataManager.database,
                                              config: DataBrokerProtectionSchedulerConfig(),
@@ -53,7 +57,9 @@ public final class DataBrokerProtectionScheduler {
                 contentScopeProperties: ContentScopeProperties,
                 dataManager: DataBrokerProtectionDataManager,
                 notificationCenter: NotificationCenter = NotificationCenter.default,
-                errorHandler: EventMapping<DataBrokerProtectionOperationError>) {
+                errorHandler: EventMapping<DataBrokerProtectionOperationError>,
+                redeemUseCase: DataBrokerProtectionRedeemUseCase
+    ) {
 
         activity = NSBackgroundActivityScheduler(identifier: schedulerIdentifier)
         activity.repeats = true
@@ -66,6 +72,9 @@ public final class DataBrokerProtectionScheduler {
         self.contentScopeProperties = contentScopeProperties
         self.errorHandler = errorHandler
         self.notificationCenter = notificationCenter
+
+        self.emailService = EmailService(redeemUseCase: redeemUseCase)
+        self.captchaService = CaptchaService(redeemUseCase: redeemUseCase)
     }
 
     public func start(debug: Bool = true) {

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/CaptchaService.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/CaptchaService.swift
@@ -122,9 +122,12 @@ struct CaptchaService: CaptchaServiceProtocol {
     }
 
     private let urlSession: URLSession
+    private let redeemUseCase: DataBrokerProtectionRedeemUseCase
 
-    init(urlSession: URLSession = URLSession.shared) {
+    init(urlSession: URLSession = URLSession.shared,
+         redeemUseCase: DataBrokerProtectionRedeemUseCase = RedeemUseCase()) {
         self.urlSession = urlSession
+        self.redeemUseCase = redeemUseCase
     }
 
     func submitCaptchaInformation(_ captchaInfo: GetCaptchaInfoResponse,
@@ -159,7 +162,8 @@ struct CaptchaService: CaptchaServiceProtocol {
         }
         os_log("Submitting captcha request ...", log: .service)
         var request = URLRequest(url: url)
-        request.setValue(HTTPUtils.authorizationHeader, forHTTPHeaderField: "Authorization")
+        let authHeader = try await redeemUseCase.getAuthHeader()
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         request.addValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
 
         let bodyObject: [String: Any] = [
@@ -214,7 +218,8 @@ struct CaptchaService: CaptchaServiceProtocol {
         }
 
         var request = URLRequest(url: url)
-        request.setValue(HTTPUtils.authorizationHeader, forHTTPHeaderField: "Authorization")
+        let authHeader = try await redeemUseCase.getAuthHeader()
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         request.addValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "GET"
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/EmailService.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/EmailService.swift
@@ -41,9 +41,12 @@ struct EmailService: EmailServiceProtocol {
     }
 
     public let urlSession: URLSession
+    private let redeemUseCase: DataBrokerProtectionRedeemUseCase
 
-    init(urlSession: URLSession = URLSession.shared) {
+    init(urlSession: URLSession = URLSession.shared,
+         redeemUseCase: DataBrokerProtectionRedeemUseCase = RedeemUseCase()) {
         self.urlSession = urlSession
+        self.redeemUseCase = redeemUseCase
     }
 
     func getEmail() async throws -> String {
@@ -52,7 +55,8 @@ struct EmailService: EmailServiceProtocol {
         }
 
         var request = URLRequest(url: url)
-        request.setValue(HTTPUtils.authorizationHeader, forHTTPHeaderField: "Authorization")
+        let authHeader = try await redeemUseCase.getAuthHeader()
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
 
         let (data, _) = try await urlSession.data(for: request)
 
@@ -100,7 +104,8 @@ struct EmailService: EmailServiceProtocol {
         }
 
         var request = URLRequest(url: url)
-        request.setValue(HTTPUtils.authorizationHeader, forHTTPHeaderField: "Authorization")
+        let authHeader = try await redeemUseCase.getAuthHeader()
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
 
         let (data, _) = try await urlSession.data(for: request)
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/HTTPUtils.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/HTTPUtils.swift
@@ -19,11 +19,8 @@
 import Foundation
 
 struct HTTPUtils {
-    private static let authToken = "" // Use DBP API Dev Access Token on Bitwarden
     private static let fakeBrokerUsername = ""
     private static let fakeBrokerPassword = ""
-
-    static let authorizationHeader = "bearer \(authToken)"
 
     static func fetchFakeBrokerCredentials() -> (username: String, password: String) {
         if fakeBrokerUsername.isEmpty || fakeBrokerPassword.isEmpty {

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/RedeemCodeServices.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/RedeemCodeServices.swift
@@ -1,0 +1,169 @@
+//
+//  ReedemCodeServices.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+
+public protocol DataBrokerProtectionRedeemUseCase {
+    /// Method to know if we should ask for an invite code when selecting the DataBrokerProtectionPackage
+    ///
+    /// - Returns: `true` if we need the user to enter an invite code
+    ///            `false` in othercase
+    func shouldAskForInviteCode() -> Bool
+
+    /// Tries to redeem an invite code. Throws in case there was an issue when trying to redeem the invite code.
+    ///
+    /// - Parameters:
+    ///   - inviteCode: An invite code used to reedem access to data broker protection
+    func redeem(inviteCode: String) async throws
+
+    /// Returns the auth header needed for the authenticated endpoints.
+    ///
+    /// In case there is no auth header present, tries to fetch a new access token with the saved invite code.
+    ///
+    /// - Returns: `String` a string that contains the bearer access token
+    func getAuthHeader() async throws -> String
+}
+
+public protocol AuthenticationRepository {
+    func getInviteCode() -> String?
+    func getAccessToken() -> String?
+
+    func save(accessToken: String)
+    func save(inviteCode: String)
+}
+
+public protocol DataBrokerProtectionAuthenticationService {
+    /// Reedems an invite code. This will return an access token that needs to be used to authenticate data broker protection requests.
+    ///
+    /// - Parameters:
+    ///   - inviteCode: An invite code used to reedem access to data broker protection
+    /// - Returns: `accessToken: String` a string that contains the access token needed for future authenticated requests
+    func redeem(inviteCode: String) async throws -> String
+}
+
+public final class RedeemUseCase: DataBrokerProtectionRedeemUseCase {
+    private let authenticationService: DataBrokerProtectionAuthenticationService
+    private let authenticationRepository: AuthenticationRepository
+
+    public init(authenticationService: DataBrokerProtectionAuthenticationService = AuthenticationService(),
+                authenticationRepository: AuthenticationRepository = UserDefaultsAuthenticationData()) {
+        self.authenticationService = authenticationService
+        self.authenticationRepository = authenticationRepository
+    }
+
+    public func shouldAskForInviteCode() -> Bool {
+        authenticationRepository.getAccessToken() == nil
+    }
+
+    public func redeem(inviteCode: String) async throws {
+        let accessToken = try await authenticationService.redeem(inviteCode: inviteCode)
+        authenticationRepository.save(accessToken: accessToken)
+    }
+
+    public func getAuthHeader() async throws -> String {
+        guard let inviteCode = authenticationRepository.getInviteCode() else {
+            throw AuthenticationError.noInviteCode
+        }
+
+        var accessToken = authenticationRepository.getAccessToken() ?? ""
+
+        if accessToken.isEmpty {
+            accessToken = try await authenticationService.redeem(inviteCode: inviteCode)
+            authenticationRepository.save(accessToken: accessToken)
+        }
+
+        return "bearer \(accessToken)"
+    }
+}
+
+// ⚠️ NOTE: This is just a temporary solution. We should not store the access token on User Defaults.
+// The access token will be saved in the secure database once we have that in place.
+public final class UserDefaultsAuthenticationData: AuthenticationRepository {
+    struct Keys {
+        static let accessTokenKey = "dbp:accessTokenKey"
+        static let inviteCodeKey = "dbp:inviteCodeKey"
+    }
+
+    // Initialize this constant with the DBP API Dev Access Token on Bitwarden if you do not want to use the redeem endpoint.
+    private let developmentToken: String? = nil
+
+    public init() {}
+
+    public func getInviteCode() -> String? {
+        UserDefaults.standard.string(forKey: Keys.inviteCodeKey)
+    }
+
+    public func getAccessToken() -> String? {
+        UserDefaults.standard.string(forKey: Keys.accessTokenKey) ?? developmentToken
+    }
+
+    public func save(accessToken: String) {
+        UserDefaults.standard.set(accessToken, forKey: Keys.accessTokenKey)
+    }
+
+    public func save(inviteCode: String) {
+        UserDefaults.standard.set(inviteCode, forKey: Keys.inviteCodeKey)
+    }
+}
+
+public enum AuthenticationError: Error, Equatable {
+    case noInviteCode
+    case cantGenerateURL
+    case issueRedeemingInviteCode(error: String)
+}
+
+struct RedeemResponse: Codable {
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case message
+    }
+
+    let accessToken: String?
+    let message: String?
+}
+
+public struct AuthenticationService: DataBrokerProtectionAuthenticationService {
+    private struct Constants {
+        static let redeemURL = "https://dbp.duckduckgo.com/dbp/redeem?"
+    }
+
+    private let urlSession: URLSession
+
+    public init(urlSession: URLSession = URLSession.shared) {
+        self.urlSession = urlSession
+    }
+
+    public func redeem(inviteCode: String) async throws -> String {
+        guard let url = URL(string: Constants.redeemURL + "code=\(inviteCode)") else {
+            throw AuthenticationError.cantGenerateURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        let (data, _) = try await urlSession.data(for: request)
+
+        let result = try JSONDecoder().decode(RedeemResponse.self, from: data)
+
+        if let accessToken = result.accessToken {
+            return accessToken
+        } else {
+            throw AuthenticationError.issueRedeemingInviteCode(error: result.message ?? "Unknown")
+        }
+    }
+}

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/AuthenticationServiceTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/AuthenticationServiceTests.swift
@@ -1,0 +1,111 @@
+//
+//  AuthenticationServiceTests.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Foundation
+@testable import DataBrokerProtection
+
+final class AuthenticationServiceTests: XCTestCase {
+
+    enum MockError: Error {
+        case someError
+    }
+
+    private var mockURLSession: URLSession {
+        let testConfiguration = URLSessionConfiguration.default
+        testConfiguration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: testConfiguration)
+    }
+
+    override func tearDown() async throws {
+        MockURLProtocol.requestHandlerQueue.removeAll()
+    }
+
+    func testWhenFailsOnNetworkingLayer_thenNoAuthenticationErrorIsThrown() async {
+        MockURLProtocol.requestHandlerQueue.append({ _ in throw MockError.someError })
+        let sut = AuthenticationService(urlSession: mockURLSession)
+
+        do {
+            _ = try await sut.redeem(inviteCode: "someInviteCode")
+            XCTFail("Expected an error to be thrown")
+        } catch {
+            if let error = error as? AuthenticationError {
+                XCTFail("Unexpected error thrown: \(error).")
+            }
+        }
+    }
+
+    func testWhenFailsToRedeemWithNoAccessTokenAndMessage_thenUnknownErrorIsThrown() async {
+        let emptyMessageResponseData = try? JSONEncoder().encode(RedeemResponse(accessToken: nil, message: nil))
+        let emptyMessageResponse: RequestHandler = { _ in (HTTPURLResponse.ok, emptyMessageResponseData) }
+        MockURLProtocol.requestHandlerQueue.append(emptyMessageResponse)
+        let sut = AuthenticationService(urlSession: mockURLSession)
+
+        do {
+            _ = try await sut.redeem(inviteCode: "someInviteCode")
+            XCTFail("Expected an error to be thrown")
+        } catch {
+            if let error = error as? AuthenticationError, case .issueRedeemingInviteCode(let error) = error {
+                if error != "Unknown" {
+                    XCTFail("Unexpected error thrown: \(error).")
+                }
+
+                return
+            }
+
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+    }
+
+    func testWhenFailsToRedeemWithMessage_thenIssueRedeemingInviteCodeIsThrown() async {
+        let message = "FAILURE CRITICAL: Error"
+        let failureCriticalResponseData = try? JSONEncoder().encode(RedeemResponse(accessToken: nil, message: message))
+        let failureCriticalResponse: RequestHandler = { _ in (HTTPURLResponse.ok, failureCriticalResponseData) }
+        MockURLProtocol.requestHandlerQueue.append(failureCriticalResponse)
+        let sut = AuthenticationService(urlSession: mockURLSession)
+
+        do {
+            _ = try await sut.redeem(inviteCode: "someInviteCode")
+            XCTFail("Expected an error to be thrown")
+        } catch {
+            if let error = error as? AuthenticationError, case .issueRedeemingInviteCode(let error) = error {
+                if error != message {
+                    XCTFail("Unexpected error thrown: \(error).")
+                }
+
+                return
+            }
+
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+    }
+
+    func testWhenAccessTokenIsRetrieved_thenAccessTokenIsReturned() async {
+        let emptyMessageResponseData = try? JSONEncoder().encode(RedeemResponse(accessToken: "accessToken", message: nil))
+        let emptyMessageResponse: RequestHandler = { _ in (HTTPURLResponse.ok, emptyMessageResponseData) }
+        MockURLProtocol.requestHandlerQueue.append(emptyMessageResponse)
+        let sut = AuthenticationService(urlSession: mockURLSession)
+
+        do {
+            let accessToken = try await sut.redeem(inviteCode: "someInviteCode")
+            XCTAssertEqual(accessToken, "accessToken")
+        } catch {
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+    }
+}

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/CaptchaServiceTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/CaptchaServiceTests.swift
@@ -39,7 +39,7 @@ final class CaptchaServiceTests: XCTestCase {
 
     func testWhenSessionThrowsOnSubmittingCaptchaInfo_thenTheCorrectErrorIsThrown() async {
         MockURLProtocol.requestHandlerQueue.append({ _ in throw MockError.someError })
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.submitCaptchaInformation(GetCaptchaInfoResponse.mock)
@@ -56,7 +56,7 @@ final class CaptchaServiceTests: XCTestCase {
     func testWhenFailureCriticalIsReturnedOnSubmittingCaptchaInfo_thenCriticalErrorWhenSubmittingCaptchaIsThrown() async {
         let response = CaptchaTransaction(message: .failureCritical, transactionId: nil)
         MockURLProtocol.requestHandlerQueue.append({ _ in (HTTPURLResponse.ok, try? self.jsonEncoder.encode(response)) })
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.submitCaptchaInformation(GetCaptchaInfoResponse.mock)
@@ -73,7 +73,7 @@ final class CaptchaServiceTests: XCTestCase {
     func testWhenInvalidRequestIsReturnedOnSubmittingCaptchaInfo_thenInvalidRequestWhenSubmittingCaptchaIsThrown() async {
         let response = CaptchaTransaction(message: .invalidRequest, transactionId: nil)
         MockURLProtocol.requestHandlerQueue.append({ _ in (HTTPURLResponse.ok, try? self.jsonEncoder.encode(response)) })
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.submitCaptchaInformation(GetCaptchaInfoResponse.mock)
@@ -94,7 +94,7 @@ final class CaptchaServiceTests: XCTestCase {
         MockURLProtocol.requestHandlerQueue.append(requestHandler)
         MockURLProtocol.requestHandlerQueue.append(requestHandler)
 
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.submitCaptchaInformation(GetCaptchaInfoResponse.mock, retries: 2)
@@ -113,7 +113,7 @@ final class CaptchaServiceTests: XCTestCase {
         let requestHandler: RequestHandler = { _ in (HTTPURLResponse.ok, try? self.jsonEncoder.encode(captchaResult)) }
         MockURLProtocol.requestHandlerQueue.append(requestHandler)
 
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.submitCaptchaToBeResolved(for: "123456")
@@ -132,7 +132,7 @@ final class CaptchaServiceTests: XCTestCase {
         let requestHandler: RequestHandler = { _ in (HTTPURLResponse.ok, try? self.jsonEncoder.encode(captchaResult)) }
         MockURLProtocol.requestHandlerQueue.append(requestHandler)
 
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.submitCaptchaToBeResolved(for: "123456")
@@ -151,7 +151,7 @@ final class CaptchaServiceTests: XCTestCase {
         let requestHandler: RequestHandler = { _ in (HTTPURLResponse.ok, try? self.jsonEncoder.encode(captchaResult)) }
         MockURLProtocol.requestHandlerQueue.append(requestHandler)
 
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.submitCaptchaToBeResolved(for: "123456")
@@ -172,7 +172,7 @@ final class CaptchaServiceTests: XCTestCase {
         MockURLProtocol.requestHandlerQueue.append(requestHandler)
         MockURLProtocol.requestHandlerQueue.append(requestHandler)
 
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.submitCaptchaToBeResolved(for: "123456", retries: 2, pollingInterval: 1)
@@ -191,7 +191,7 @@ final class CaptchaServiceTests: XCTestCase {
         let requestHandler: RequestHandler = { _ in (HTTPURLResponse.ok, try? self.jsonEncoder.encode(captchaResult)) }
         MockURLProtocol.requestHandlerQueue.append(requestHandler)
 
-        let sut = CaptchaService(urlSession: mockURLSession)
+        let sut = CaptchaService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             let data = try await sut.submitCaptchaToBeResolved(for: "123456", retries: 2, pollingInterval: 1)

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/EmailServiceTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/EmailServiceTests.swift
@@ -38,7 +38,7 @@ final class EmailServiceTests: XCTestCase {
 
     func testWhenSessionThrows_thenTheCorrectErrorIsThrown() async {
         MockURLProtocol.requestHandlerQueue.append({ _ in throw MockError.someError })
-        let sut = EmailService(urlSession: mockURLSession)
+        let sut = EmailService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.getEmail()
@@ -59,7 +59,7 @@ final class EmailServiceTests: XCTestCase {
         let responseData = try? JSONSerialization.data(withJSONObject: responseDictionary, options: .prettyPrinted)
         MockURLProtocol.requestHandlerQueue.append({ _ in (HTTPURLResponse.ok, responseData) })
 
-        let sut = EmailService(urlSession: mockURLSession)
+        let sut = EmailService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.getEmail()
@@ -78,7 +78,7 @@ final class EmailServiceTests: XCTestCase {
         let responseData = try? JSONSerialization.data(withJSONObject: responseDictionary, options: .prettyPrinted)
         MockURLProtocol.requestHandlerQueue.append({ _ in (HTTPURLResponse.ok, responseData) })
 
-        let sut = EmailService(urlSession: mockURLSession)
+        let sut = EmailService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             let email = try await sut.getEmail()
@@ -119,7 +119,7 @@ final class EmailServiceTests: XCTestCase {
         MockURLProtocol.requestHandlerQueue.append(notReadyResponse)
         MockURLProtocol.requestHandlerQueue.append(notReadyResponse)
 
-        let sut = EmailService(urlSession: mockURLSession)
+        let sut = EmailService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.getConfirmationLink(
@@ -147,7 +147,7 @@ final class EmailServiceTests: XCTestCase {
         MockURLProtocol.requestHandlerQueue.append(notReadyResponse)
         MockURLProtocol.requestHandlerQueue.append(successResponse)
 
-        let sut = EmailService(urlSession: mockURLSession)
+        let sut = EmailService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             let url = try await sut.getConfirmationLink(
@@ -166,7 +166,7 @@ final class EmailServiceTests: XCTestCase {
         let responseData = try? JSONSerialization.data(withJSONObject: responseDictionary, options: .prettyPrinted)
         MockURLProtocol.requestHandlerQueue.append({ _ in (HTTPURLResponse.ok, responseData) })
 
-        let sut = EmailService(urlSession: mockURLSession)
+        let sut = EmailService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.getConfirmationLink(
@@ -188,7 +188,7 @@ final class EmailServiceTests: XCTestCase {
         let responseData = try? JSONEncoder().encode(invalidLink)
         MockURLProtocol.requestHandlerQueue.append({ _ in (HTTPURLResponse.ok, responseData) })
 
-        let sut = EmailService(urlSession: mockURLSession)
+        let sut = EmailService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             _ = try await sut.getConfirmationLink(
@@ -210,7 +210,7 @@ final class EmailServiceTests: XCTestCase {
         let responseData = try? JSONEncoder().encode(validURL)
         MockURLProtocol.requestHandlerQueue.append({ _ in (HTTPURLResponse.ok, responseData) })
 
-        let sut = EmailService(urlSession: mockURLSession)
+        let sut = EmailService(urlSession: mockURLSession, redeemUseCase: MockRedeemUseCase())
 
         do {
             let url = try await sut.getConfirmationLink(

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -245,3 +245,77 @@ final class CaptchaServiceMock: CaptchaServiceProtocol {
         wasSubmitCaptchaToBeResolvedCalled = false
     }
 }
+
+final class MockRedeemUseCase: RedeemUseCaseProtocol {
+
+    func shouldAskForInviteCode() -> Bool {
+        false
+    }
+
+    func redeem(inviteCode: String) async throws {
+
+    }
+
+    func getAuthHeader() async throws -> String {
+        return "auth header"
+    }
+}
+
+final class MockAuthenticationService: AuthenticationServiceProtocol {
+
+    var wasRedeemCalled = false
+    var shouldThrow = false
+
+    func redeem(inviteCode: String) async throws -> String {
+        wasRedeemCalled = true
+        if shouldThrow {
+            throw AuthenticationError.issueRedeemingInviteCode(error: "mock")
+        }
+
+        return "accessToken"
+    }
+
+    func reset() {
+        wasRedeemCalled = false
+        shouldThrow = false
+    }
+}
+
+final class MockAuthenticationRepository: AuthenticationRepository {
+
+    var shouldSendNilInviteCode = false
+    var shouldSendNilAccessToken = false
+    var wasInviteCodeSaveCalled = false
+    var wasAccessTokenSaveCalled = false
+
+    func getInviteCode() -> String? {
+        if shouldSendNilInviteCode {
+            return nil
+        }
+
+        return "inviteCode"
+    }
+
+    func getAccessToken() -> String? {
+        if shouldSendNilAccessToken {
+            return nil
+        }
+
+        return "accessToken"
+    }
+
+    func save(inviteCode: String) {
+        wasInviteCodeSaveCalled = true
+    }
+
+    func save(accessToken: String) {
+        wasAccessTokenSaveCalled = true
+    }
+
+    func reset() {
+        shouldSendNilInviteCode = false
+        shouldSendNilAccessToken = false
+        wasInviteCodeSaveCalled = false
+        wasAccessTokenSaveCalled = false
+    }
+}

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/RedeemUseCaseTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/RedeemUseCaseTests.swift
@@ -1,0 +1,99 @@
+//
+//  RedeemUseCaseTests.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Foundation
+@testable import DataBrokerProtection
+
+final class RedeemUseCaseTests: XCTestCase {
+    let repository = MockAuthenticationRepository()
+    let service = MockAuthenticationService()
+
+    override func tearDown() async throws {
+        repository.reset()
+        service.reset()
+    }
+
+    func testWhenAccessTokenIsNil_thenShouldAskForInviteCodeReturnsTrue() {
+        repository.shouldSendNilAccessToken = true
+
+        let sut = RedeemUseCase(authenticationService: service, authenticationRepository: repository)
+
+        XCTAssertTrue(sut.shouldAskForInviteCode())
+    }
+
+    func testWhenAccessTokenIsNotNil_thenShouldAskForInviteCodeReturnsFalse() {
+        repository.shouldSendNilAccessToken = false
+
+        let sut = RedeemUseCase(authenticationService: service, authenticationRepository: repository)
+
+        XCTAssertFalse(sut.shouldAskForInviteCode())
+    }
+
+    func testWhenRedeemSucceds_thenTokenIsSaved() async {
+        service.shouldThrow = false
+        let sut = RedeemUseCase(authenticationService: service, authenticationRepository: repository)
+
+        try? await sut.redeem(inviteCode: "someInviteCode")
+
+        XCTAssertTrue(repository.wasAccessTokenSaveCalled)
+    }
+
+    func testWhenRedeemFails_thenTokenIsNotSaved() async {
+        service.shouldThrow = true
+        let sut = RedeemUseCase(authenticationService: service, authenticationRepository: repository)
+
+        try? await sut.redeem(inviteCode: "someInviteCode")
+
+        XCTAssertFalse(repository.wasAccessTokenSaveCalled)
+    }
+
+    func testWhenGetAuthHeaderHasNoInviteCode_thenThrowsNoInviteCodeError() async {
+        repository.shouldSendNilInviteCode = true
+        let sut = RedeemUseCase(authenticationService: service, authenticationRepository: repository)
+
+        let accessToken = try? await sut.getAuthHeader()
+
+        XCTAssertNil(accessToken)
+        XCTAssertFalse(service.wasRedeemCalled)
+        XCTAssertFalse(repository.wasAccessTokenSaveCalled)
+    }
+
+    func testWhenGetAuthHeadersHasEmptyAccessToken_thenWeRedeemAndSave() async {
+        repository.shouldSendNilInviteCode = false
+        repository.shouldSendNilAccessToken = true
+        let sut = RedeemUseCase(authenticationService: service, authenticationRepository: repository)
+
+        _ = try? await sut.getAuthHeader()
+
+        XCTAssertTrue(service.wasRedeemCalled)
+        XCTAssertTrue(repository.wasAccessTokenSaveCalled)
+    }
+
+    func testWhenGetAuthHeadersHasAccessToken_thenWeReturnHeaderWithoutRedeeming() async {
+        repository.shouldSendNilInviteCode = false
+        repository.shouldSendNilAccessToken = false
+        let sut = RedeemUseCase(authenticationService: service, authenticationRepository: repository)
+
+        let accessToken = try? await sut.getAuthHeader()
+
+        XCTAssertEqual(accessToken, "bearer accessToken")
+        XCTAssertFalse(service.wasRedeemCalled)
+        XCTAssertFalse(repository.wasAccessTokenSaveCalled)
+    }
+}


### PR DESCRIPTION
## Task

https://app.asana.com/0/1204006570077678/1205148229682452/f

## Description

We need to add support for the `/redeem` endpoint.

[API ](https://dub.duckduckgo.com/duckduckgo/dbp-api#post-dbpredeemcodeinvite_code)[/redeem](https://dub.duckduckgo.com/duckduckgo/dbp-api#post-dbpredeemcodeinvite_code)[ documentation](https://dub.duckduckgo.com/duckduckgo/dbp-api#post-dbpredeemcodeinvite_code)

**Acceptance criteria**
- Given I'm a user with a saved invited code when I'm hitting any endpoint that needs authorization and no access token was saved, then we should hit the /redeem endpoint, and if it is successful, save the auth token and use it as bearer token on the auth header.
- Given I'm a user with a saved invited code when I'm hitting any endpoint that needs authorization and no access token was saved, then we should hit the /redeem endpoint, and if it fails, then we should throw, and the flow should stop.
- Given that I'm a user with a saved invited code when I hit any endpoint that needs authorization and an access token is stored, then we should use that stored access token as the bearer token on the auth header.

In this first iteration, we will save the returned access token into UserDefaults . When we implement secure storage, we will save the access token there.