### PR TITLE
Fixes the wiring on some outlets

### DIFF
--- a/DuckDuckGo/Menus/MainMenu.storyboard
+++ b/DuckDuckGo/Menus/MainMenu.storyboard
@@ -889,6 +889,10 @@ CQ
                                                                     </connections>
                                                                 </menuItem>
                                                             </items>
+                                                            <connections>
+                                                                <outlet property="simulateControllerFailureMenuItem" destination="xyA-ob-gEy" id="1VV-xV-wsB"/>
+                                                                <outlet property="simulateTunnelFailureMenuItem" destination="kVa-n8-UNx" id="3Ie-Ed-VtG"/>
+                                                            </connections>
                                                         </menu>
                                                     </menuItem>
                                                 </items>

--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionSimulateFailureMenu.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionSimulateFailureMenu.swift
@@ -31,8 +31,8 @@ final class NetworkProtectionSimulateFailureMenu: NSMenu {
 ///
 @objc
 final class NetworkProtectionSimulateFailureMenu: NSMenu {
-    @IBOutlet weak var simulateControllerFailureMenuItem: NSMenuItem?
-    @IBOutlet weak var simulateTunnelFailureMenuItem: NSMenuItem?
+    @IBOutlet weak var simulateControllerFailureMenuItem: NSMenuItem!
+    @IBOutlet weak var simulateTunnelFailureMenuItem: NSMenuItem!
 
     private var simulationOptions: NetworkProtectionSimulationOptions {
         NetworkProtectionTunnelController.simulationOptions
@@ -53,8 +53,8 @@ final class NetworkProtectionSimulateFailureMenu: NSMenu {
     }
 
     override func update() {
-        simulateControllerFailureMenuItem?.state = simulationOptions.isEnabled(.controllerFailure) ? .on : .off
-        simulateTunnelFailureMenuItem?.state = simulationOptions.isEnabled(.tunnelFailure) ? .on : .off
+        simulateControllerFailureMenuItem.state = simulationOptions.isEnabled(.controllerFailure) ? .on : .off
+        simulateTunnelFailureMenuItem.state = simulationOptions.isEnabled(.tunnelFailure) ? .on : .off
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205158222182990/f

## Description:

Wires two outlets that weren't wired and changed their declaration to crash when unwired by request of @mallexxx 

## Steps to test this PR:

1. Launch the app, make sure it won't crash
2. Test the Debug > Network Protection > Simulate Failure menu items.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
