### PR TITLE
When checking if feature is enabled compare against the page URL instead of cookie banner's frame

### DIFF
--- a/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -217,7 +217,8 @@ extension AutoconsentUserScript {
             return
         }
 
-        guard config.isFeature(.autoconsent, enabledForDomain: url.host) else {
+        let topURLDomain = message.webView?.url?.host
+        guard config.isFeature(.autoconsent, enabledForDomain: topURLDomain) else {
             os_log("disabled for site: %s", log: .autoconsent, type: .info, String(describing: url.absoluteString))
             replyHandler([ "type": "ok" ], nil) // this is just to prevent a Promise rejection
             return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1205170203442767/f

Description:
When checking if feature is enabled compare against the page URL instead of cookie banner frame's.

Steps to test this PR:

1. Enable "Manage Cookie Pop-ups"
2. Open site that has set exemption at a given moment e.g. [news.sky.com](https://news.sky.com/) or [windowscentral.com](https://windowscentral.com/)
3. The cookie prompt should not be managed

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
