### PR TITLE
open favorite from keyboard in the current tab

### DIFF
--- a/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -124,8 +124,6 @@ extension WindowControllersManager {
             WindowsManager.openNewWindow(with: url, isBurner: false)
         } else if mainWindowController?.mainViewController.view.window?.isPopUpWindow ?? false {
             show(url: url, newTab: true)
-        } else if NSApplication.shared.isCommandPressed {
-            mainWindowController?.mainViewController.tabCollectionViewModel.appendNewTab(with: .url(url), selected: false)
         } else if selectedTab?.isPinned ?? false { // When selecting a bookmark with a pinned tab active, always open the URL in a new tab
             show(url: url, newTab: true)
         } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204216091208991/f

**Description**: The behaviour when opening favorite from the new tab and with keyboard shortcut differs. The former open the website in the same tab the latter opens it in a new tab. This will change the keyboard shortcut behaviour to opening the favorite in the current tab.

**Steps to test this PR**:
1. Go to the new tab page click on a favorite and check it is open in the same tab
2. from a tab press command +  option + (number of favorite) and check it is open in the same tab
3. From main menu bookmarks check that bookmarks are opened in the same tab
4. Open the bookmark manager from the main menu check that double clicking on a bookmark opens it in a new tab.

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
