### PR TITLE
fix bug where wrong address bar text is shown when opening DuckPlayer…

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -117,7 +117,7 @@ protocol NewWindowPolicyDecisionMaker {
         }
         var userEditableUrl: URL? {
             switch self {
-            case .url(let url, credential: _, userEntered: _):
+            case .url(let url, credential: _, userEntered: _) where !(url.isDuckPlayer || url.isDuckPlayerScheme):
                 return url
             default:
                 return nil

--- a/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -187,11 +187,7 @@ final class TabViewModel {
     }
 
     private var tabURL: URL? {
-        if tab.content.url?.isDuckPlayer ?? false || tab.content.url?.isDuckPlayerScheme ?? false {
-            return nil
-        } else {
-            return tab.content.url ?? tab.parentTab?.content.url
-        }
+        return tab.content.url
     }
 
     private var tabHostURL: URL? {


### PR DESCRIPTION
… from target=blank links

Task/Issue URL: https://app.asana.com/0/1177771139624306/1204301052974318/f

**Description**: fix bug where wrong address bar text is shown when opening DuckPlayer from target=blank links. Moves the check for DuckPlayer URLs in the Tab view model before when in case the url is nil the tab content url is associated to the parent tab content url. 

**Steps to test this PR**:
1. Create an HTML file with the follwing 
<html>
   <body>
      <a href="https://youtu.be/dQw4w9WgXcQ" target="_blank">YouTube</a>
   </body>
</html>
2. Drag and drop it in the browser click on the link and select to watch the video with DuckPlayer. 
3. Check that the address bar is empty
4. Go on youtube select a video and chose to play it with DuckPlayer
5. 3. Check that the address bar is empty

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
