### PR TITLE
Changes external application prompt behaviour

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -321,9 +321,7 @@ final class AddressBarButtonsViewController: NSViewController {
                 button = popupsButton
                 popover = popupBlockedPopoverCreatingIfNeeded()
             case .externalScheme:
-                guard !query.wasShownOnce else { return }
                 button = externalSchemeButton
-                popover.behavior = .transient
                 query.shouldShowAlwaysAllowCheckbox = true
                 query.shouldShowCancelInsteadOfDeny = true
             default:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205137373084365

**Description**: The external application prompt is transient (disappear if users clicks elsewhere) and it does not appear if the user re-click on the button that makes it appear. Users tends to dismiss it and then thing the website is broken. To solve this we decided to make the prompt non transient and make it appear at every click.

**Steps to test this PR**:
1. Clicking on "View in Mac App Store" on https://apps.apple.com/us/app/duckduckgo-privacy-for-safari/id1482920575?mt=12 should show the prompt.
2. Check clicking elsewhere on the page does not dismiss the prompt.
3. Dismiss the prompt and then click on   "View in Mac App Store” again and check the prompt is presented again.

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
