### PR TITLE
Update BSK with autofill 8.1.1

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10203,7 +10203,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 74c639ac8a55b2d52e20314e3d536ac74d2c9520;
+				revision = 1513c0ac0e02dda184f295657b480872caf94561;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "b01e0010c7c0618f7329184c11c85a3c64a4307f",
-        "version" : "73.0.0"
+        "revision" : "1513c0ac0e02dda184f295657b480872caf94561"
       }
     },
     {
@@ -32,8 +31,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b1160df954eea20cd4cdf9356afc369751981b16",
-        "version" : "8.0.0"
+        "revision" : "56f1a4e8879888d05331c5749f49a7b6aa9c6a1d",
+        "version" : "8.1.1"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205223917466051/1205223917466051
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.1
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/450

## Description
Updates Autofill to version [8.1.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.1).

### Autofill 8.1.1 release notes
## What's Changed
* Add shared creds by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/361


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.1.0...8.1.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).