### PR TITLE
Don't use SPM cache in release workflows

### DIFF
--- a/.github/workflows/build_appstore.yml
+++ b/.github/workflows/build_appstore.yml
@@ -80,24 +80,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Set cache key hash
-      run: |
-        has_only_tags=$(jq '[ .pins[].state | has("version") ] | all' DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved)
-        if [[ "$has_only_tags" == "true" ]]; then
-          echo "cache_key_hash=${{ hashFiles('DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}" >> $GITHUB_ENV
-        else
-          echo "Package.resolved contains dependencies specified by branch or commit, skipping cache."
-        fi
-
-    - name: Cache SPM
-      if: env.cache_key_hash
-      uses: actions/cache@v3
-      with:
-        path: DerivedData/SourcePackages
-        key: ${{ runner.os }}-spm-${{ env.cache_key_hash }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
-
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_$(<.xcode-version).app/Contents/Developer
 

--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -179,24 +179,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Set cache key hash
-      run: |
-        has_only_tags=$(jq '[ .pins[].state | has("version") ] | all' DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved)
-        if [[ "$has_only_tags" == "true" ]]; then
-          echo "cache_key_hash=${{ hashFiles('DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}" >> $GITHUB_ENV
-        else
-          echo "Package.resolved contains dependencies specified by branch or commit, skipping cache."
-        fi
-
-    - name: Cache SPM
-      if: env.cache_key_hash
-      uses: actions/cache@v3
-      with:
-        path: DerivedData/SourcePackages
-        key: ${{ runner.os }}-spm-${{ env.cache_key_hash }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
-
     - name: Install xcbeautify
       continue-on-error: true
       run: brew install xcbeautify


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1205220954178133/f

**Description**:
Skip using SPM cache in release workflows to avoid workflow failures.

**Steps to test this PR**:
1. See [this DMG workflow](https://github.com/duckduckgo/macos-browser/actions/runs/5787326607/job/15684008317), verify that SPM cache step is not invoked.
2. See [this App Store workflow](https://github.com/duckduckgo/macos-browser/actions/runs/5787325244/job/15684003269) workflow from this branch, verify that SPM cache step is not invoked.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
