### PR TITLE
Disable log formatting in notarized build workflow when run with debug logging enabled

### DIFF
--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -180,6 +180,7 @@ jobs:
         submodules: recursive
 
     - name: Install xcbeautify
+      if: runner.debug != '1'
       continue-on-error: true
       run: brew install xcbeautify
 
@@ -198,7 +199,11 @@ jobs:
         export APPLE_API_KEY_PATH="$RUNNER_TEMP/apple_api_key.pem"
         echo -n "$APPLE_API_KEY_BASE64" | base64 --decode -o $APPLE_API_KEY_PATH
 
-        ./scripts/archive.sh ${{ env.release-type }}
+        if [[ "${{ runner.debug }}" == "1" ]]; then
+          ./scripts/archive.sh ${{ env.release-type }} -r
+        else
+          ./scripts/archive.sh ${{ env.release-type }}
+        fi
 
     - name: Set app name and version
       id: set-outputs

--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -15,12 +15,13 @@ print_usage_and_exit() {
 
 	cat <<- EOF
 	Usage:
-	  $ $(basename "$0") <review|release|review-sandbox|release-sandbox> [-a <asana_task_url>] [-d] [-s] [-v <version>]
+	  $ $(basename "$0") <review|release|review-sandbox|release-sandbox> [-a <asana_task_url>] [-d] [-s] [-r] [-v <version>]
 
 	Options:
 	 -a <asana_task_url>  Update Asana task after building the app (implies -d)
 	 -d                   Create a DMG image alongside the zipped app and dSYMs
 	 -h                   Print this message
+	 -r                   Show raw output (don't use xcpretty or xcbeautify)
 	 -s                   Skip xcodebuild output in logs
 	 -v <version>         Override app version with <version> (does not update Xcode project)
 
@@ -68,7 +69,7 @@ read_command_line_arguments() {
 
 	shift 1
 
-	while getopts 'a:dhsv:' OPTION; do
+	while getopts 'a:dhrsv:' OPTION; do
 		case "${OPTION}" in
 			a)
 				asana_task_url="${OPTARG}"
@@ -81,6 +82,9 @@ read_command_line_arguments() {
 				;;
 			h)
 				print_usage_and_exit
+				;;
+			r)
+				disable_log_formatting=1
 				;;
 			s)
 				# Use silent_output function to redirect all output to /dev/null
@@ -197,9 +201,9 @@ prepare_export_options_plist() {
 }
 
 setup_log_formatter() {
-	if [[ -n ${ACTIONS_STEP_DEBUG} ]]; then
+	if [[ ${disable_log_formatting} ]]; then
 		echo
-		echo "Debug logging enabled - not prettifying Xcode logs."
+		echo "Log formatting disabled - not prettifying Xcode logs."
 		echo
 		log_formatter='tee'
 	elif command -v xcbeautify &> /dev/null; then


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1205226517596953/f

**Description**:
Show raw logs when GitHub Actions debug logging is enabled when retrying a workflow.

**Steps to test this PR**:
Check the [workflow run with debug logging enabled](https://github.com/duckduckgo/macos-browser/actions/runs/5793822416/job/15706128477). Verify that "Install xcbeautify" didn't run and logs are raw.
Check the [regular workflow run](https://github.com/duckduckgo/macos-browser/actions/runs/5790536210/job/15693772000). Verify that logs are formatted.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
