### PR TITLE
iOS InContext Email Protection promotion config update

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10203,7 +10203,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = ed6a0d0841eccfe6f2b5215075dcc8044ab973d7;
+				revision = a852f62d61f45d21ba83bbef8de9618559604a52;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "ed6a0d0841eccfe6f2b5215075dcc8044ab973d7"
+        "revision" : "a852f62d61f45d21ba83bbef8de9618559604a52"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1204936655327681
Tech Design URL:
CC:

**Description**:
BSK change for iOS config for InContext Email Protection promotion `installedDays`

**Steps to test this PR**:
1. Smoke test Email Protection and confirm grey dax icon is still present when signed out of Email Protection (you may need to reset the Email InContext prompt via the `Debug` menu)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
