### PR TITLE
Fix FutureExtensionTests

### DIFF
--- a/UnitTests/Common/Extensions/FutureExtensionTests.swift
+++ b/UnitTests/Common/Extensions/FutureExtensionTests.swift
@@ -157,11 +157,11 @@ final class FutureExtensionTests: XCTestCase {
 
     func testFulfilledPromiseOnGlobalQueueHasValue() {
         let e = expectation(description: "background job done")
+        let eFulfilled = expectation(description: "fulfilled")
         DispatchQueue.global().async {
             let promise = Future<String, Never>.promise()
             var value: String?
 
-            let eFulfilled = self.expectation(description: "fulfilled")
             let c = promise.future.sink {
                 XCTAssertEqual($0, "test")
                 value = $0
@@ -175,16 +175,16 @@ final class FutureExtensionTests: XCTestCase {
 
             e.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        wait(for: [e], timeout: 1)
     }
 
     func testPromiseOnGlobalQueueFulfilledAsyncHasValue() {
         let e = expectation(description: "background job done")
+        let eFulfilled = expectation(description: "fulfilled")
         DispatchQueue.global().async {
             let promise = Future<String, Never>.promise()
             var value: String?
 
-            let eFulfilled = self.expectation(description: "fulfilled")
             let c = promise.future.sink {
                 XCTAssertEqual($0, "test")
                 value = $0
@@ -200,16 +200,16 @@ final class FutureExtensionTests: XCTestCase {
 
             e.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        wait(for: [e], timeout: 1)
     }
 
     func testPromiseOnGlobalQueueFulfilledInBackgroundHasValue() {
         let e = expectation(description: "background job done")
+        let eFulfilled = expectation(description: "fulfilled")
         DispatchQueue.global().async {
             let promise = Future<String, Never>.promise()
             var value: String?
 
-            let eFulfilled = self.expectation(description: "fulfilled")
             let c = promise.future.sink {
                 XCTAssertEqual($0, "test")
                 value = $0
@@ -225,7 +225,7 @@ final class FutureExtensionTests: XCTestCase {
 
             e.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        wait(for: [e], timeout: 1)
     }
 
     // - main queue async -
@@ -269,11 +269,11 @@ final class FutureExtensionTests: XCTestCase {
 
     func testFulfilledPromiseAsyncHasValue() {
         let e = expectation(description: "async job done")
+        let eFulfilled = expectation(description: "fulfilled")
         DispatchQueue.main.async {
             let promise = Future<String, Never>.promise()
             var value: String?
 
-            let eFulfilled = self.expectation(description: "fulfilled")
             let c = promise.future.sink {
                 XCTAssertEqual($0, "test")
                 value = $0
@@ -287,16 +287,16 @@ final class FutureExtensionTests: XCTestCase {
 
             e.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        wait(for: [e], timeout: 1)
     }
 
     func testPromiseAsyncFulfilledAsyncHasValue() {
         let e = expectation(description: "async job done")
+        let eFulfilled = expectation(description: "fulfilled")
         RunLoop.main.perform {
             let promise = Future<String, Never>.promise()
             var value: String?
 
-            let eFulfilled = self.expectation(description: "fulfilled")
             let c = promise.future.sink {
                 XCTAssertEqual($0, "test")
                 value = $0
@@ -312,16 +312,16 @@ final class FutureExtensionTests: XCTestCase {
 
             e.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        wait(for: [e], timeout: 1)
     }
 
     func testPromiseAsyncFulfilledInBackgroundHasValue() {
         let e = expectation(description: "async job done")
+        let eFulfilled = expectation(description: "fulfilled")
         DispatchQueue.main.async {
             let promise = Future<String, Never>.promise()
             var value: String?
 
-            let eFulfilled = self.expectation(description: "fulfilled")
             let c = promise.future.sink {
                 XCTAssertEqual($0, "test")
                 value = $0
@@ -337,7 +337,7 @@ final class FutureExtensionTests: XCTestCase {
 
             e.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        wait(for: [e], timeout: 1)
     }
 
     // MARK: - Publishers.First.get()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205205535714739/f

**Description**:
Avoid waiting for some expectations twice in a single unit test.

**Steps to test this PR**:
Verify that FutureExtensionTests pass.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
