### PR TITLE
Improvement to email incontext behaviour when multiple windows are open

### DIFF
--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -144,6 +144,7 @@ final class BrowserTabViewController: NSViewController {
         if let previouslySelectedTab = self.previouslySelectedTab {
             tabCollectionViewModel.select(tab: previouslySelectedTab)
             if #available(macOS 11.0, *) {
+                os_log(.debug, "Tab  %{private}s calling openAutofillAfterClosingEmailProtectionTab()", previouslySelectedTab.webView.url?.absoluteString ?? "with no url")
                 previouslySelectedTab.webView.evaluateJavaScript("window.openAutofillAfterClosingEmailProtectionTab()", in: nil, in: WKContentWorld.defaultClient)
             }
             self.previouslySelectedTab = nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198964220583541/1205223894381359/f
Tech Design URL:
CC:

**Description**:
Fixes issues around InContext signup triggering notification listeners in multiple windows causing unexpected behaviours when signing up / in 

**Steps to test this PR**:
1. Make sure you are signed out of Email Protection and if necessary "Reset Email Protection InContext Signup Prompt" in the Debug menu
2. Open multiple windows with one or more tabs open in each window
3. In one window visit https://fill.dev/form/registration-email
4. Tap the grey dax icon and follow the sign-up flow. Confirm the sign-up tab url loads correctly and is only opened in the current window
5. On completing sign-up, confirm you are taken back to your tab https://fill.dev/form/registration-email and that the autofill email tooltip is presented on the email field
6. Repeat steps 1-5 testing sign-in flow is also good

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
