### PR TITLE
Adds entitlements for review and CI builds for some of our agents

### DIFF
--- a/Configuration/App/NetworkProtection/DuckDuckGoAgent.xcconfig
+++ b/Configuration/App/NetworkProtection/DuckDuckGoAgent.xcconfig
@@ -33,9 +33,8 @@ INFOPLIST_KEY_NSPrincipalClass = Application
 //CODE_SIGN_STYLE[config=Debug][sdk=*] = Manual
 //CODE_SIGN_STYLE[config=Release][sdk=*] = Manual
 
-// Left empty intentionally as we currently only support debug and release builds
-CODE_SIGN_ENTITLEMENTS[config=Review][sdk=macosx*] =
-CODE_SIGN_ENTITLEMENTS[config=CI][sdk=macosx*] =
+CODE_SIGN_ENTITLEMENTS[config=Review][sdk=macosx*] = DuckDuckGoAgent/DuckDuckGoAgent.entitlements
+CODE_SIGN_ENTITLEMENTS[config=CI][sdk=macosx*] = DuckDuckGoAgent/DuckDuckGoAgent.entitlements
 CODE_SIGN_ENTITLEMENTS[config=Debug][sdk=macosx*] = DuckDuckGoAgent/DuckDuckGoAgent.entitlements
 CODE_SIGN_ENTITLEMENTS[config=Release][sdk=macosx*] = DuckDuckGoAgent/DuckDuckGoAgent.entitlements
 

--- a/Configuration/App/NetworkProtection/DuckDuckGoNotifications.xcconfig
+++ b/Configuration/App/NetworkProtection/DuckDuckGoNotifications.xcconfig
@@ -29,9 +29,8 @@ GENERATE_INFOPLIST_FILE = YES
 INFOPLIST_KEY_LSUIElement = YES
 INFOPLIST_KEY_NSPrincipalClass = Application
 
-// Left empty intentionally as we currently only support debug and release builds
-CODE_SIGN_ENTITLEMENTS[config=Review][sdk=macosx*] =
-CODE_SIGN_ENTITLEMENTS[config=CI][sdk=macosx*] =
+CODE_SIGN_ENTITLEMENTS[config=Review][sdk=macosx*] = DuckDuckGoNotifications/DuckDuckGoNotifications.entitlements
+CODE_SIGN_ENTITLEMENTS[config=CI][sdk=macosx*] = DuckDuckGoNotifications/DuckDuckGoNotifications.entitlements
 CODE_SIGN_ENTITLEMENTS[config=Debug][sdk=macosx*] = DuckDuckGoNotifications/DuckDuckGoNotifications.entitlements
 CODE_SIGN_ENTITLEMENTS[config=Release][sdk=macosx*] = DuckDuckGoNotifications/DuckDuckGoNotifications.entitlements
 

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,7 +129,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
       "state" : {
         "revision" : "4684440d03304e7638a2c8086895367e90987463",
         "version" : "1.2.1"


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/0/1205247616211793/f
Tech Design URL:
CC:

## Stack PR

- Feature branch: `diego/feature-network-protection-onboarding`
    - https://github.com/duckduckgo/macos-browser/pull/1465 (this PR)
    - https://github.com/duckduckgo/macos-browser/pull/1466
    - https://github.com/duckduckgo/macos-browser/pull/1474

## Description

Just adds entitlements to two agent Apps in REVIEW and CI configurations, since we'll use `UserDefaults` for sharing data between them.

This was disabled initially for NetP as we weren't supporting builds other than DEBUG and RELEASE.

## Scope

This PR simply adds entitlements to some of our Agent apps in some build configurations.  There should be no changes to functionality other than those targets having the entitlements configured for them.

## Testing

Checking that our CI is green should be enough to validate this PR.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
