### PR TITLE
Disables a flaky test from App Store unit tests

### DIFF
--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo Privacy Browser App Store.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo Privacy Browser App Store.xcscheme
@@ -108,6 +108,9 @@
                <Test
                   Identifier = "StatisticsLoaderTests/testWhenRefreshRetentionAtbIsPerformedForNavigationThenAppRetentionAtbRequested()">
                </Test>
+               <Test
+                  Identifier = "WindowManagerStateRestorationTests/testWindowManagerStateRestoration()">
+               </Test>
             </SkippedTests>
          </TestableReference>
          <TestableReference


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1205249621847889/f
Tech Design URL:
CC:

## Description:

Disables a flaky test from App Store unit test runs ([that's already disabled from DeveloperID unit test runs](https://github.com/duckduckgo/macos-browser/pull/1429)).

You can see the failure here: https://github.com/duckduckgo/macos-browser/actions/runs/5821469075/job/15783975898?pr=1466

## Steps to test this PR:

Just check the CI is green.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
