### PR TITLE
don't show day 7 when day 0 has been dismissed

### DIFF
--- a/DuckDuckGo/HomePage/Model/HomePageContinueSetUpModel.swift
+++ b/DuckDuckGo/HomePage/Model/HomePageContinueSetUpModel.swift
@@ -320,6 +320,7 @@ extension HomePage.Models {
         private var shouldSurveyDay7BeVisible: Bool {
             let oneWeekAgo = Calendar.current.date(byAdding: .weekOfYear, value: -1, to: Date())!
             return isDay7SurveyEnabled &&
+            shouldShowSurveyDay0 &&
             shouldShowSurveyDay7 &&
             !userInteractedWithSurveyDay0 &&
             firstLaunchDate <= oneWeekAgo

--- a/UnitTests/HomePage/ContinueSetUpModelTests.swift
+++ b/UnitTests/HomePage/ContinueSetUpModelTests.swift
@@ -144,6 +144,19 @@ final class ContinueSetUpModelTests: XCTestCase {
         XCTAssertFalse(vm.visibleFeaturesMatrix.reduce([], +).contains(HomePage.Models.FeatureType.surveyDay7))
     }
 
+    @MainActor func testWhenInstallDateIsMoreThanAWeekAgoAndUserDismissedDay0SurveyDay7SurveyCardIsNotShown() {
+        let statisticStore = MockStatisticsStore()
+        vm.statisticsStore = statisticStore
+        vm.removeItem(for: .surveyDay0)
+        let aDayAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
+        userDefaults.set(aDayAgo, forKey: UserDefaultsWrapper<Date>.Key.firstLaunchDate.rawValue)
+        vm = HomePage.Models.ContinueSetUpModel.fixture()
+        vm.shouldShowAllFeatures = true
+
+        XCTAssertFalse(vm.visibleFeaturesMatrix.reduce([], +).contains(HomePage.Models.FeatureType.surveyDay0))
+        XCTAssertFalse(vm.visibleFeaturesMatrix.reduce([], +).contains(HomePage.Models.FeatureType.surveyDay7))
+    }
+
     @MainActor func testWhenInitializedNotForTheFirstTimeTheMatrixHasAllElementsInTheRightOrder() {
         var homePageIsFirstSession = UserDefaultsWrapper<Bool>(key: .homePageIsFirstSession, defaultValue: true)
         homePageIsFirstSession.wrappedValue = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204186595873227/1205248215850616/f

**Description**: Modify the card logic to not show the day7 survey when the day0 card has been dismissed

**Steps to test this PR**:
1 Reset card dismissal: Debug -> Reset Data -> Reset Make DuckDuckGo Yours User Settings
2 Change install day to today: Debug -> Reset Data -> Change Activation Date -> Today
3 Open a new new tab page and check the day 0 survey card appear with the correct copy and icon
4 Click on the card and check it takes you to the correct survey. In the url check the atb is passed at the end of the url.
5 Go back to the new tab page and check the card has disappeared.
6 Change install day to during the past week: Debug -> Reset Data -> Change Activation Date -> Less than a week ago
7 Open a new new tab page and check none of the survey card is present.
8 Change install day to during more than a week ago: Debug -> Reset Data -> Change Activation Date -> More than a week ago.
9 Open a new new tab page and check none of the survey card is present.
10 Repeat steps 1 to 3
11 Dismiss the day 0 card
12 repeat steps 6 to 8
13 check the day 7 card does not appear
14 Repeat steps 1 to 3
15 Repeat steps 6 to 8
16 check the day 7 card appears
17 Click on the card and check it takes you to the correct survey. In the url check the atb is passed at the end of the url.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
