### PR TITLE
Move Make /Applications symlink build phase to later

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -6806,13 +6806,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AA585DA4248FD31500E9A3E2 /* Build configuration list for PBXNativeTarget "DuckDuckGo Privacy Browser" */;
 			buildPhases = (
-				B6F2C8722A7A4C7D000498CF /* Make /Applications symlink, remove app on Clean build */,
 				CBCCF59E299667B700C02DFE /* Assert Xcode version */,
 				3705272528992C8A000C06A2 /* Check Embedded Config URLs */,
 				AA585D7A248FD31100E9A3E2 /* Sources */,
 				AA8EDF2824925E940071C2E8 /* Swift Lint */,
 				AA585D7B248FD31100E9A3E2 /* Frameworks */,
 				AA585D7C248FD31100E9A3E2 /* Resources */,
+				B6F2C8722A7A4C7D000498CF /* Make /Applications symlink, remove app on Clean build */,
 				4B2D065D2A11D2AE00DE1F49 /* Embed Login Items */,
 				4B5F14F32A14823D0060320F /* Embed NetP Controller Apps */,
 				4B5F14F62A14825A0060320F /* Replace VPN Controllers with Symlinks */,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1205251729301936/f

**Description**:

From @afterxleep : 
Out of nowhere, I started seeing the following error when building the macOS app (Likely after a DerivedData cleanup).   File name changed every time.


While it happened, I tried the following, and nothing worked.

Reboot
Clean Build
Clear issues
Clean Derived Data
Reset Packages
Git Clean
Reclone Repository
Clean User Data
Remove Command line tools
Reinstall Xcode
Throw the laptop out the window

@Dominik mentioned that he had to disable the  <Make /Applications symlink, remove app on Clean build>, script in CI, so I did the same, and after cleaning everything up, builds started to work.

This script moves the built app from Derived Data to the Applications folder and then creates a symlink.   If, for any reason, this symlink is not created, the Copy Resources Phase above fails, causing the error.  (Files are not there anymore)

On top of that, if the symlink creation fails, the project ends up in an unrecoverable state, and the only solution is to wipe out DerivedData, Reset Package caches, and remove the script from the Build Phases.

**Steps to test this PR**:
1. Delete Applications/DEBUG/DuckDuckGo.app
2. Clear Derived Data
3. Go to System Settings -> VPN -> (Blue) DuckDuckGo, click the (i) button and delete the configuration
4. Build the app from Xcode
5. Enable NetP and allow the network extension to be installed.
6. Ensure it functions as expected.
—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
