### PR TITLE
Update BSK with autofill 8.1.2

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10202,8 +10202,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 85ede20e9a2164dbf618622962d5497db48bd710;
+				kind = exactVersion;
+				version = 73.0.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "b01e0010c7c0618f7329184c11c85a3c64a4307f",
-        "version" : "73.0.0"
+        "revision" : "873bb1f0a774cf069c0ceba99be3f93515135baf",
+        "version" : "73.0.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b1160df954eea20cd4cdf9356afc369751981b16",
-        "version" : "8.0.0"
+        "revision" : "40bcd0d347b51d14e8114f191df2817d8dcb4284",
+        "version" : "8.1.2"
       }
     },
     {

--- a/LocalPackages/NetworkProtectionUI/Package.swift
+++ b/LocalPackages/NetworkProtectionUI/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "73.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "73.0.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205255555424025/1205255555424025
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.2
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/457

## Description
Updates Autofill to version [8.1.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.2).

### Autofill 8.1.2 release notes
## What's Changed
* Ema/fix script naming by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/364
* Minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/365
* Send a breakage report flag when autofill is "activated" on the page by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/363
* Fix extension bugs by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/366
* Add regression test by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/367

## New Contributors
* @muodov made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/363

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.1.1...8.1.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).