### PR TITLE
Prevents the NetP popover from going out of screen bounds

### DIFF
--- a/LocalPackages/NetworkProtectionUI/Sources/NetworkProtectionUI/NetworkProtectionPopover.swift
+++ b/LocalPackages/NetworkProtectionUI/Sources/NetworkProtectionUI/NetworkProtectionPopover.swift
@@ -73,6 +73,10 @@ public final class NetworkProtectionPopover: NSPopover {
 
         let controller = NSHostingController(rootView: view)
         contentViewController = controller
+
+        // It's important to set the frame at least once here.  If we don't the popover
+        // fails to get the right width and the popover can exceed the screen's limits.
+        controller.view.frame = CGRect(origin: .zero, size: controller.view.intrinsicContentSize)
     }
 
     // MARK: - Forcing Status Refresh


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/0/1205267171934828/f

## Description:

Adds back some code that was removed in https://github.com/duckduckgo/macos-browser/pull/1407, that prevents the Network Protection popover from going out of screen bounds.

## Steps to test this PR:

1. Move the window to the right hand side of the screen.
2. Show the Network Protection popover
3. Make sure the popover is shown within the screen bounds.

NOTE: moving the screen when the popover is already shown doesn't adjust it to stay within bounds, but this is true for our other popovers as well.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
