### PR TITLE
Fix Xcode 15 compilation

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10234,8 +10234,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "sam/fix-macos-xcode-15-builds";
-				kind = branch;
+				kind = exactVersion;
+				version = 75.0.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "sam/fix-macos-xcode-15-builds",
-        "revision" : "707b682860f0f9094b77493b3e0aa272ace6473c"
+        "revision" : "070cd5292161a2ca84efb7a583acecb55e777517",
+        "version" : "75.0.1"
       }
     },
     {

--- a/LocalPackages/NetworkProtectionUI/Package.swift
+++ b/LocalPackages/NetworkProtectionUI/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "75.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "75.0.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1205173072817403/f
Tech Design URL:
CC:

**Description**:

This PR updates the version of WireGuard used by the app. This version of WireGuard was compiled with Go 1.21, which fixes issues with the new linker in Xcode 15.

**Steps to test this PR**:
1. Test that the app builds and runs in Xcode 14, and that NetP works
2. Test that the app builds and runs in the Xcode 15 beta, and that NetP works

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
