### PR TITLE
remove logic to keep previous search mode

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -260,23 +260,7 @@ final class AddressBarTextField: NSTextField {
             return
         }
 
-        var url = providedUrl
-
-        // keep current search mode
-        if url.isDuckDuckGoSearch,
-           let oldURL = selectedTabViewModel.tab.content.url,
-            oldURL.isDuckDuckGoSearch {
-            if let ia = oldURL.getParameter(named: URL.DuckDuckGoParameters.ia.rawValue) {
-                url = url.removingParameters(named: [URL.DuckDuckGoParameters.ia.rawValue])
-                    .appendingParameter(name: URL.DuckDuckGoParameters.ia.rawValue, value: ia)
-            }
-            if let iax = oldURL.getParameter(named: URL.DuckDuckGoParameters.iax.rawValue) {
-                url = url.removingParameters(named: [URL.DuckDuckGoParameters.iax.rawValue])
-                    .appendingParameter(name: URL.DuckDuckGoParameters.iax.rawValue, value: iax)
-            }
-        }
-
-        selectedTabViewModel.tab.setUrl(url, userEntered: userEnteredValue)
+        selectedTabViewModel.tab.setUrl(providedUrl, userEntered: userEnteredValue)
 
         self.window?.makeFirstResponder(nil)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1202319845644422/f

**Description**: at the moment when we do a search we keep the previous search mode for example images. This behaviour differs from other platform and we want to remove it.

**Steps to test this PR**:
1. Search for example “cats"
2. Move to the image vertical
3. Search for example “dogs"
4. Check that when you press enter you are presented the general web results and not the images results.

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
