### PR TITLE
Require Duck Player scheme URL to be passed from YouTube Overlay User Script

### DIFF
--- a/DuckDuckGo/YoutubePlayer/YoutubeOverlayUserScript.swift
+++ b/DuckDuckGo/YoutubePlayer/YoutubeOverlayUserScript.swift
@@ -86,9 +86,10 @@ final class YoutubeOverlayUserScript: NSObject, Subfeature {
         guard let dict = params as? [String: Any],
               let href = dict["href"] as? String,
               let url = href.url,
+              url.isDuckPlayerScheme,
               let webView = message.messageWebView
         else {
-            assertionFailure("YoutubeOverlayUserScript: expected URL")
+            assertionFailure("YoutubeOverlayUserScript: expected duck:// URL")
             return nil
         }
         self.delegate?.youtubeOverlayUserScriptDidRequestDuckPlayer(with: url, in: webView)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205318681239304/f

**Description**:
Validate the message and return early if the passed URL is different than `duck://...`.

**Steps to test this PR**:
Refer to the linked Asana task for testing steps. There is a test build attached that you could use.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
