### PR TITLE
Update the phased rollout tester to avoid caching the config

### DIFF
--- a/DuckDuckGo/NetworkProtection/PhasedRolloutFeatureFlagTester.swift
+++ b/DuckDuckGo/NetworkProtection/PhasedRolloutFeatureFlagTester.swift
@@ -37,20 +37,20 @@ final class PhasedRolloutFeatureFlagTester {
         static let hasSentPixelKey = "network-protection.incremental-feature-flag-test.has-sent-pixel"
     }
 
-    private let privacyConfiguration: PrivacyConfiguration
+    private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let pixelSender: PhasedRolloutPixelSender
     private let userDefaults: UserDefaults
 
-    init(privacyConfiguration: PrivacyConfiguration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig,
+    init(privacyConfigurationManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager,
          pixelSender: PhasedRolloutPixelSender = DefaultPhasedRolloutPixelSender(),
          userDefaults: UserDefaults = .standard) {
-        self.privacyConfiguration = privacyConfiguration
+        self.privacyConfigurationManager = privacyConfigurationManager
         self.pixelSender = pixelSender
         self.userDefaults = userDefaults
     }
 
     func sendFeatureFlagEnabledPixelIfNecessary(completion: (() -> Void)? = nil) {
-        guard !hasSentPixelBefore(), privacyConfiguration.isSubfeatureEnabled(IncrementalRolloutTestSubfeature.rollout) else {
+        guard !hasSentPixelBefore(), privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(IncrementalRolloutTestSubfeature.rollout) else {
             completion?()
             return
         }

--- a/UnitTests/NetworkProtection/PhasedRolloutFeatureFlagTesterTests.swift
+++ b/UnitTests/NetworkProtection/PhasedRolloutFeatureFlagTesterTests.swift
@@ -66,11 +66,12 @@ final class PhasedRolloutFeatureFlagTesterTests: XCTestCase {
     }
 
     func testWhenAttemptingToSendPixel_AndRolloutSubfeatureIsDisabled_ThenPixelDoesNotSend() {
-        let mockPrivacyConfiguration = mockConfiguration(subfeatureEnabled: false)
+        let mockManager = MockPrivacyConfigurationManager()
+        mockManager.privacyConfig = mockConfiguration(subfeatureEnabled: false)
         let pixelSender = MockPixelSender(returnError: false)
         let userDefaults = UserDefaults(suiteName: Self.testSuiteName)!
 
-        let tester = PhasedRolloutFeatureFlagTester(privacyConfiguration: mockPrivacyConfiguration,
+        let tester = PhasedRolloutFeatureFlagTester(privacyConfigurationManager: mockManager,
                                                     pixelSender: pixelSender,
                                                     userDefaults: userDefaults)
 
@@ -85,11 +86,12 @@ final class PhasedRolloutFeatureFlagTesterTests: XCTestCase {
     }
 
     func testWhenAttemptingToSendPixel_AndRolloutSubfeatureIsEnabled_AndPixelHasNotBeenSentBefore_ThenPixelSends() {
-        let mockPrivacyConfiguration = mockConfiguration(subfeatureEnabled: true)
+        let mockManager = MockPrivacyConfigurationManager()
+        mockManager.privacyConfig = mockConfiguration(subfeatureEnabled: true)
         let pixelSender = MockPixelSender(returnError: false)
         let userDefaults = UserDefaults(suiteName: Self.testSuiteName)!
 
-        let tester = PhasedRolloutFeatureFlagTester(privacyConfiguration: mockPrivacyConfiguration,
+        let tester = PhasedRolloutFeatureFlagTester(privacyConfigurationManager: mockManager,
                                                     pixelSender: pixelSender,
                                                     userDefaults: userDefaults)
 
@@ -104,11 +106,12 @@ final class PhasedRolloutFeatureFlagTesterTests: XCTestCase {
     }
 
     func testWhenAttemptingToSendPixel_AndRolloutSubfeatureIsEnabled_AndPixelHasBeenSentBefore_ThenPixelDoesNotSend() {
-        let mockPrivacyConfiguration = mockConfiguration(subfeatureEnabled: true)
+        let mockManager = MockPrivacyConfigurationManager()
+        mockManager.privacyConfig = mockConfiguration(subfeatureEnabled: true)
         let pixelSender = MockPixelSender(returnError: false)
         let userDefaults = UserDefaults(suiteName: Self.testSuiteName)!
 
-        let tester = PhasedRolloutFeatureFlagTester(privacyConfiguration: mockPrivacyConfiguration,
+        let tester = PhasedRolloutFeatureFlagTester(privacyConfigurationManager: mockManager,
                                                     pixelSender: pixelSender,
                                                     userDefaults: userDefaults)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205320853523387/f
Tech Design URL:
CC: @SlayterDev 

**Description**:

This PR updates the privacy config feature flag tester to not cache the config so aggressively.

Because of the previous behaviour, this class wouldn't get privacy config updates until the next time the app launches.

**Steps to test this PR**:
1. Add a breakpoint into `PhasedRolloutFeatureFlagTester`'s`sendFeatureFlagEnabledPixelIfNecessary` function
2. Run the app
3. Check that the breakpoint is hit, and that the function is pulling a dynamic copy of the privacy config

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
