### PR TITLE
only allow error reloads on http(s) urls

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -724,7 +724,9 @@ protocol NewWindowPolicyDecisionMaker {
 
     func reload() {
         userInteractionDialog = nil
-        if let error = error, let failingUrl = error.failingUrl {
+
+        // In the case of an error only reload web URLs to prevent uxss attacks via redirecting to javascript://
+        if let error = error, let failingUrl = error.failingUrl, (failingUrl.isHttp || failingUrl.isHttps) {
             webView.load(URLRequest(url: failingUrl, cachePolicy: .reloadIgnoringLocalCacheData))
             return
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205314901927898/f
Tech Design URL:
CC:

**Description**:

Fixes a bug which allows a UXSS attack by redirecting to a JavaScript URL.

**Steps to test this PR**:
1. Visit https://websecurity.is/poc/uxss.html and click go.  Should show error page.  Click reload, Google will load.
2. Visit http://brindy.org.uk/redirect.php - should redirect to the error page.  Click reload, error page should remain visible.
3. Smoke test general navigation / browsing.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
