### PR TITLE
fix windows repositioned on sleep/display on-off

### DIFF
--- a/DuckDuckGo/Main/View/MainWindow.swift
+++ b/DuckDuckGo/Main/View/MainWindow.swift
@@ -51,8 +51,6 @@ final class MainWindow: NSWindow {
         hasShadow = true
         titleVisibility = .hidden
         titlebarAppearsTransparent = true
-        // the window will be draggable using custom drag areas defined by WindowDraggingView
-        isMovable = false
     }
 
     // MARK: - First Responder Notification


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199178362774117/1205305189179523/f

**Description**:
- fixes windows positioning on sleep/external display connection/disconnection

**Steps to test this PR**:
0. get an external display (use your good judgement, I recommend Apple Cinema 😉)
1. position windows on both displays in random order expanded/not expanded
2. put computer into sleep/turn it on - windows should keep their positions
3. disconnect external display -> windows should be fully displayed on the built-in display; reconnect external display -> windows should restore their positions
4. close the macbook lid -> windows should be fully displayed on the external display; open the lid - > windows should be repositioned back
5. Validate window is still draggable/expandable/minimizable using all the drag areas (title bar, semaphore, under the burn window, empty tabbar space, address bar) and not movable with other controls

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
