### PR TITLE
Save/edit always the same profile

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/Mappers.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/Mappers.swift
@@ -27,8 +27,8 @@ struct MapperToDB {
         self.mechanism = mechanism
     }
 
-    func mapToDB(profile: DataBrokerProtectionProfile) throws -> ProfileDB {
-        .init(id: nil, birthYear: try withUnsafeBytes(of: profile.birthYear) { try mechanism(Data($0)) })
+    func mapToDB(id: Int64? = nil, profile: DataBrokerProtectionProfile) throws -> ProfileDB {
+        .init(id: id, birthYear: try withUnsafeBytes(of: profile.birthYear) { try mechanism(Data($0)) })
     }
 
     func mapToDB(_ name: DataBrokerProtectionProfile.Name, relatedTo profileId: Int64) throws -> NameDB {


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1203581873609357/1205344732841496/f

## Description

The database schema supports multiple profiles, and because of that, when saving a new profile, we insert new rows in the database. This is causing some issues with testing.

When a new profile is saved, we replace the current one and **delete all the current scan operations**. For example, if we save John Smith and there are scan operations, and then we want to test with Ben Douglas, all the scan operations of John Smith will be deleted to ensure we are always scanning for the latest profile.

If opt-outs are in progress, we continue with those.

## Steps to test

1. Save a profile and start a scan
2. Modify that profile and save it
3. Start a new scan
4. Check that scans are being done for the latest profile