### PR TITLE
Adjusts the NetP onboarding bg color

### DIFF
--- a/LocalPackages/NetworkProtectionUI/Sources/NetworkProtectionUI/Resources/Assets.xcassets/Colors/OnboardingStepBackgroundColor.colorset/Contents.json
+++ b/LocalPackages/NetworkProtectionUI/Sources/NetworkProtectionUI/Resources/Assets.xcassets/Colors/OnboardingStepBackgroundColor.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.010",
+          "alpha" : "0.030",
           "blue" : "0x00",
           "green" : "0x00",
           "red" : "0x00"
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.030",
+          "alpha" : "0.060",
           "blue" : "0xFF",
           "green" : "0xFF",
           "red" : "0xFF"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205330979601113/f

## Description

Changes the background color of the NetP onboarding to match figma.

## Testing

Just validate the changes don't break.  The design will be approved with a review build.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
