### PR TITLE
Use unencrypted password for deduplicated Credentials objects

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12059,8 +12059,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "dominik/credentials-deduplication-fix";
-				kind = branch;
+				kind = exactVersion;
+				version = 75.2.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "dominik/credentials-deduplication-fix",
-        "revision" : "2f3e29c667c21df9ec9602c3072c8974ccdeea9d"
+        "revision" : "61947c2a53c43bd388f84001981e106c93775add",
+        "version" : "75.2.1"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "75.2.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "75.2.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [

--- a/LocalPackages/NetworkProtectionUI/Package.swift
+++ b/LocalPackages/NetworkProtectionUI/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "75.2.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "75.2.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1205352938100234/f

**Description**:
Credentials deduplication code looks for an existing credentials entity in the Secure Vault,
then returns it to Sync code where its title is updated, and then the credentials entity is passed
back to Secure Vault to be stored. The storing function expects unencrypted password
(such as when passed from the UI) and does encryption before storing.

The issue here was that we were passing an already encrypted password (just retrieved
from Secure Vault) in which case the encryption function failed to encrypt the value, returning nil.

This patch fixes the problem on the Sync Data Provider end (to feed an unencrypted password
to Secure Vault for saving) and also adds an assertion failure to `AutofillSecureVault` when an encrypted
password is passed to `encryptPassword` method.

**Steps to test this PR**:
1. Check out 1.51.1 tag (Bookmarks-only Sync) from macOS browser repository.
2. Clean debug and debug-appstore apps data: `./clean-app.sh debug && ./clean-app.sh debug-appstore`.
3. Run the DMG app from Xcode (_DuckDuckGo Privacy Browser_ scheme) and add a login (you can also import some logins). **Set a non-empty value as password**.
4. Run the App Store App from Xcode (_DuckDuckGo Privacy Browser App Store_ scheme) and add the same exact login(s).
5. Enable Sync on the DMG app
6. Enable Sync on the App Store app by connecting to DMG app's account
7. Check out this branch (still in the macOS repository)
8. Run the DMG app – credentials will be synced
9. Run the App Store app – credentials will be synced and all credentials in the App Store app should have passwords.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
