### PR TITLE
DBP: Add missing selector properties to CCF

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/ExtractedProfile.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/ExtractedProfile.swift
@@ -21,6 +21,9 @@ import Foundation
 struct ProfileSelector: Codable {
     let selector: String
     let findElements: Bool?
+    let afterText: String?
+    let beforeText: String?
+    let separator: String?
 }
 
 struct ExtractProfileSelectors: Codable, Sendable {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1205355460110330/f

**Description**:
Add missing properties to actionData

**Steps to test this PR**:
1. Check if the macOS app is correctly sending afterText, beforeText and separator to CCF

