### PR TITLE
reactivate Find In Page if already visible

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/FindInPageTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/FindInPageTabExtension.swift
@@ -56,7 +56,11 @@ final class FindInPageTabExtension: TabExtension {
 
     @MainActor
     private func showFindInPage() async {
-        guard !model.isVisible else {
+        let alreadyVisible = model.isVisible
+        // makes Find In Page a first responder if re-requested
+        model.show()
+
+        guard !alreadyVisible else {
             // Find In Page is already active
             guard !model.text.isEmpty,
                   // would just find next for PDF
@@ -66,8 +70,6 @@ final class FindInPageTabExtension: TabExtension {
             await find(model.text, with: [.noIndexChange, .determineMatchIndex, .showOverlay])
             return
         }
-
-        model.show()
 
         await reset()
         guard !model.text.isEmpty else { return }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205256914332550/f

**Description**:
- gives Find In Page field a First Responder if already active on cmd+f

**Steps to test this PR**:
1. Open FInd In Page, search for something
2. click outside of it
3. Hit cmd+f - text should be selected and Find In Page re-activated

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
