### PR TITLE
Fixes an issue with a completion callback not being called in PacketTunnelProvider.

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12090,7 +12090,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = e96218a38cbbc8413118678469cef81f64de69db;
+				revision = 980f6a5c8d19025203ae3d9ccdfa0e7497645553;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "e96218a38cbbc8413118678469cef81f64de69db"
+        "revision" : "980f6a5c8d19025203ae3d9ccdfa0e7497645553"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205410509758166/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/488
iOS PR: https://github.com/duckduckgo/iOS/pull/1971

## Description

Fixes an issue with a completion callback not being called in PacketTunnelProvider.

## Steps to test this PR

Just check that NetP works fine.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
