### PR TITLE
Add broker updater mechanism

### DIFF
--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -43,6 +43,9 @@ let package = Package(
         ),
         .testTarget(
             name: "DataBrokerProtectionTests",
-            dependencies: ["DataBrokerProtection"])
+            dependencies: [
+                "DataBrokerProtection",
+                "BrowserServicesKit"
+            ])
     ]
 )

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDatabase.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDatabase.swift
@@ -50,31 +50,72 @@ final class DataBrokerProtectionDatabase: DataBrokerProtectionRepository {
     func save(_ profile: DataBrokerProtectionProfile) {
         do {
             let vault = try self.vault ?? DataBrokerProtectionSecureVaultFactory.makeVault(errorReporter: nil)
-            let brokers = try vault.fetchAllBrokers()
-            let profileId = try vault.save(profile: profile)
             let profileQueries = profile.profileQueries
+            let profileId: Int64 = 1 // At the moment, we only support one profile for DBP.
 
-            // On the error handling task we should handle the work when the list of brokers or profile queries are empty.
+            if try vault.fetchProfile(with: profileId) != nil {
+                // There is a profile created.
+                // 1. We update the profile in the database
+                // 2. The database layer takes care of deleting the scans related to the old profile.
+                // 3. We fetch the list of brokers
+                // 4. We save each profile query into the database
+                // 5. We initialize the scan operations (related to a profile query and a broker)
+                _ = try vault.save(profile: profile)
+                let brokerIDs = try vault.fetchAllBrokers().compactMap({ $0.id })
 
-            if brokers.isEmpty {
-                let brokerId = try vault.save(broker: DataBroker.initFromResource("verecor.com"))
-
-                for profileQuery in profileQueries {
-                    let profileQueryId = try vault.save(profileQuery: profileQuery, profileId: profileId)
-                    try vault.save(brokerId: brokerId, profileQueryId: profileQueryId, lastRunDate: nil, preferredRunDate: nil)
-                }
+                try intializeDatabaseForProfile(
+                    profileId: profileId,
+                    vault: vault,
+                    brokerIDs: brokerIDs,
+                    profileQueries: profileQueries
+                )
             } else {
-                for broker in brokers {
-                    guard let brokerId = broker.id else { continue } // What happens if a broker has a nil id? Should throw send a pixel or something?
+                // There is no profile in the database. We need to insert it.
+                // Here we do the following:
+                // 1. We save the profile into the database
+                // 2. We fetch all the broker JSON files from Resources
+                // 3. We convert those JSON files into DataBroker objects
+                // 4. We save the brokers into the database
+                // 5. We save each profile query into the database
+                // 6. We initialize the scan operations (related to a profile query and a broker)
+                _ = try vault.save(profile: profile)
 
-                    for profileQuery in profileQueries {
-                        let profileQueryId = try vault.save(profileQuery: profileQuery, profileId: profileId)
-                        try vault.save(brokerId: brokerId, profileQueryId: profileQueryId, lastRunDate: nil, preferredRunDate: nil)
+                if let brokers = FileResources().fetchBrokerFromResourceFiles() {
+                    var brokerIDs = [Int64]()
+
+                    for broker in brokers {
+                        let brokerId = try vault.save(broker: broker)
+                        brokerIDs.append(brokerId)
                     }
+
+                    try intializeDatabaseForProfile(
+                        profileId: profileId,
+                        vault: vault,
+                        brokerIDs: brokerIDs,
+                        profileQueries: profileQueries
+                    )
                 }
             }
         } catch {
             os_log("Database error: saveProfile, error: %{public}@", log: .error, error.localizedDescription)
+        }
+    }
+
+    private func intializeDatabaseForProfile(profileId: Int64,
+                                             vault: any (DataBrokerProtectionSecureVault),
+                                             brokerIDs: [Int64],
+                                             profileQueries: [ProfileQuery]) throws {
+        var profileQueryIDs = [Int64]()
+
+        for profileQuery in profileQueries {
+            let profileQueryId = try vault.save(profileQuery: profileQuery, profileId: profileId)
+            profileQueryIDs.append(profileQueryId)
+        }
+
+        for brokerId in brokerIDs {
+            for profileQueryId in profileQueryIDs {
+                try vault.save(brokerId: brokerId, profileQueryId: profileQueryId, lastRunDate: nil, preferredRunDate: nil)
+            }
         }
     }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/DataBroker.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/DataBroker.swift
@@ -82,10 +82,9 @@ struct DataBroker: Codable, Sendable {
         return optOutStep
     }
 
-    static func initFromResource(_ brokerName: String) -> DataBroker {
-        let jsonUrl = Bundle.module.url(forResource: brokerName, withExtension: "json")!
+    static func initFromResource(_ url: URL) -> DataBroker {
         // swiftlint:disable:next force_try
-        let data = try! Data(contentsOf: jsonUrl)
+        let data = try! Data(contentsOf: url)
         // swiftlint:disable:next force_try
         return try! JSONDecoder().decode(DataBroker.self, from: data)
     }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProtectionBrokerUpdater.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProtectionBrokerUpdater.swift
@@ -1,0 +1,195 @@
+//
+//  DataBrokerProtectionUpdater.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+
+protocol ResourcesRepository {
+    func fetchBrokerFromResourceFiles() -> [DataBroker]?
+}
+
+final class FileResources: ResourcesRepository {
+
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func fetchBrokerFromResourceFiles() -> [DataBroker]? {
+        guard let resourceURL = Bundle.module.resourceURL else {
+            return nil
+        }
+
+        do {
+            let fileURLs = try fileManager.contentsOfDirectory(
+                at: resourceURL,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+
+            let brokerJSONFiles = fileURLs.filter {
+                $0.isJSON && !$0.hasFakePrefix
+            }
+
+            return brokerJSONFiles.map(DataBroker.initFromResource(_:))
+        } catch {
+            os_log("Error fetching brokers JSON files from resources", log: .dataBrokerProtection)
+            return nil
+        }
+    }
+}
+
+protocol BrokerUpdaterRepository {
+
+    func saveLastRunDate(date: Date)
+    func getLastRunDate() -> Date?
+}
+
+final class BrokerUpdaterUserDefaults: BrokerUpdaterRepository {
+
+    struct Consts {
+        static let shouldCheckForUpdatesKey = "macos.browser.data-broker-protection.ShouldCheckForNewBrokers"
+    }
+
+    private let encoder = PropertyListEncoder()
+    private let decoder = PropertyListDecoder()
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func saveLastRunDate(date: Date) {
+        let encodedDate = try? encoder.encode(Date())
+        UserDefaults.standard.set(encodedDate, forKey: Consts.shouldCheckForUpdatesKey)
+    }
+
+    func getLastRunDate() -> Date? {
+        guard let lastRunDateData = UserDefaults.standard.data(forKey: Consts.shouldCheckForUpdatesKey) else { return nil }
+
+        if let lastRunDate = try? decoder.decode(Date.self, from: lastRunDateData) {
+            return lastRunDate
+        }
+
+        return nil
+    }
+}
+
+struct DataBrokerProtectionBrokerUpdater {
+
+    struct Consts {
+        static let updateWindow: Double = 24
+    }
+
+    private let repository: BrokerUpdaterRepository
+    private let resources: ResourcesRepository
+    private let vault: any DataBrokerProtectionSecureVault
+
+    init(repository: BrokerUpdaterRepository = BrokerUpdaterUserDefaults(),
+         resources: ResourcesRepository = FileResources(),
+         vault: any DataBrokerProtectionSecureVault) {
+        self.repository = repository
+        self.resources = resources
+        self.vault = vault
+    }
+
+    func checkForUpdatesInBrokerJSONFiles() {
+        if let lastRunDate = repository.getLastRunDate() {
+            if hasHoursPassed(hours: Consts.updateWindow, from: lastRunDate, to: Date()) {
+                updateBrokers()
+            }
+        } else {
+            // Last run date is nil. Probably it was not set yet, so we need to check for updates.
+            updateBrokers()
+        }
+    }
+
+    private func updateBrokers() {
+        repository.saveLastRunDate(date: Date())
+        guard let brokers = resources.fetchBrokerFromResourceFiles() else { return }
+
+        for broker in brokers {
+            do {
+                try update(broker)
+            } catch {
+                os_log("Error updating broker: %{public}@, with version: %{public}@", log: .dataBrokerProtection, broker.name, broker.version)
+            }
+        }
+    }
+
+    // Here we check if we need to update broker files
+    //
+    // 1. We check if the broker exists in the database
+    // 2. If does exist, we check the number version, if the version number is new, we update it
+    // 3. If it does not exist, we add it, and we create the scan operations related to it
+    private func update(_ broker: DataBroker) throws {
+        guard let savedBroker = try vault.fetchBroker(with: broker.name) else {
+            // The broker does not exist in the current storage. We need to add it.
+            try add(broker)
+            return
+        }
+
+        if shouldUpdate(incomingBrokerVersion: broker.version, storedVersion: savedBroker.version) {
+            guard let savedBrokerId = savedBroker.id else { return }
+
+            try vault.update(broker, with: savedBrokerId)
+        }
+    }
+
+    // 1. We save the broker into the database
+    // 2. We fetch the user profile and obtain the profile queries
+    // 3. We create the new scans operations for the profile queries and the new broker id
+    private func add(_ broker: DataBroker) throws {
+        let brokerId = try vault.save(broker: broker)
+
+        guard let profile = try vault.fetchProfile(with: 1) else {
+            return
+        }
+
+        let profileQueryIDs = profile.profileQueries.compactMap({ $0.id })
+
+        for profileQueryId in profileQueryIDs {
+            try vault.save(brokerId: brokerId, profileQueryId: profileQueryId, lastRunDate: nil, preferredRunDate: nil)
+        }
+    }
+
+    private func shouldUpdate(incomingBrokerVersion: String, storedVersion: String) -> Bool {
+        let result = incomingBrokerVersion.compare(storedVersion, options: .numeric)
+
+        return result == .orderedDescending
+    }
+
+    private func hasHoursPassed(hours: Double, from startDate: Date, to endDate: Date) -> Bool {
+        let timeInterval = endDate.timeIntervalSince(startDate)
+        let hoursPassed = timeInterval / 3600  // 3600 seconds in an hour
+
+        return hoursPassed >= hours
+    }
+}
+
+fileprivate extension URL {
+
+    var isJSON: Bool {
+        self.pathExtension.lowercased() == "json"
+    }
+
+    var hasFakePrefix: Bool {
+        self.lastPathComponent.lowercased().hasPrefix("fake")
+    }
+}

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
@@ -68,7 +68,15 @@ final class DataBrokerProtectionProcessor {
                                priorityDate: Date?,
                                completion: @escaping () -> Void) {
 
-        let brokersProfileData = database.fetchAllBrokerProfileQueryData(for: 1) // We assume one profile for now
+        // Before running new operatiosn we check if there is any updates to the broker files.
+        // This runs only once per 24 hours.
+        if let vault = try? DataBrokerProtectionSecureVaultFactory.makeVault(errorReporter: nil) {
+            let brokerUpdater = DataBrokerProtectionBrokerUpdater(vault: vault)
+            brokerUpdater.checkForUpdatesInBrokerJSONFiles()
+        }
+
+        let profileId: Int64 = 1 // We assume one profile for now
+        let brokersProfileData = database.fetchAllBrokerProfileQueryData(for: profileId)
         let dataBrokerOperationCollections = createDataBrokerOperationCollections(from: brokersProfileData,
                                                                                   operationType: operationType,
                                                                                   priorityDate: priorityDate)

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
@@ -30,7 +30,9 @@ protocol DataBrokerProtectionDatabaseProvider: SecureStorageDatabaseProvider {
     func fetchProfile(with id: Int64) throws -> FullProfileDB?
 
     func save(_ broker: BrokerDB) throws -> Int64
+    func update(_ broker: BrokerDB) throws
     func fetchBroker(with id: Int64) throws -> BrokerDB?
+    func fetchBroker(with name: String) throws -> BrokerDB?
     func fetchAllBrokers() throws -> [BrokerDB]
 
     func save(_ profileQuery: ProfileQueryDB) throws -> Int64
@@ -264,9 +266,23 @@ final class DefaultDataBrokerProtectionDatabaseProvider: GRDBSecureStorageDataba
         }
     }
 
+    func update(_ broker: BrokerDB) throws {
+        try db.write { db in
+            try broker.update(db)
+        }
+    }
+
     func fetchBroker(with id: Int64) throws -> BrokerDB? {
         try db.read { db in
             return try BrokerDB.fetchOne(db, key: id)
+        }
+    }
+
+    func fetchBroker(with name: String) throws -> BrokerDB? {
+        try db.read { db in
+            return try BrokerDB
+                .filter(Column(BrokerDB.Columns.name.name) == name)
+                .fetchOne(db)
         }
     }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionSecureVault.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionSecureVault.swift
@@ -39,7 +39,9 @@ protocol DataBrokerProtectionSecureVault: SecureVault {
     func fetchProfile(with id: Int64) throws -> DataBrokerProtectionProfile?
 
     func save(broker: DataBroker) throws -> Int64
+    func update(_ broker: DataBroker, with id: Int64) throws
     func fetchBroker(with id: Int64) throws -> DataBroker?
+    func fetchBroker(with name: String) throws -> DataBroker?
     func fetchAllBrokers() throws -> [DataBroker]
 
     func save(profileQuery: ProfileQuery, profileId: Int64) throws -> Int64
@@ -106,9 +108,27 @@ final class DefaultDataBrokerProtectionSecureVault<T: DataBrokerProtectionDataba
         }
     }
 
+    func update(_ broker: DataBroker, with id: Int64) throws {
+        try executeThrowingDatabaseOperation {
+            let mapper = MapperToDB(mechanism: l2Encrypt(data:))
+            return try self.providers.database.update(mapper.mapToDB(broker, id: id))
+        }
+    }
+
     func fetchBroker(with id: Int64) throws -> DataBroker? {
         try executeThrowingDatabaseOperation {
-            if let broker = try self.providers.database.fetchBroker(with: 1) {
+            if let broker = try self.providers.database.fetchBroker(with: id) {
+                let mapper = MapperToModel(mechanism: l2Decrypt(data:))
+                return try mapper.mapToModel(broker)
+            }
+
+            return nil
+        }
+    }
+
+    func fetchBroker(with name: String) throws -> DataBroker? {
+        try executeThrowingDatabaseOperation {
+            if let broker = try self.providers.database.fetchBroker(with: name) {
                 let mapper = MapperToModel(mechanism: l2Decrypt(data:))
                 return try mapper.mapToModel(broker)
             }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/Mappers.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/Mappers.swift
@@ -55,9 +55,9 @@ struct MapperToDB {
         .init(phoneNumber: try mechanism(phone.encoded), profileId: profileId)
     }
 
-    func mapToDB(_ broker: DataBroker) throws -> BrokerDB {
+    func mapToDB(_ broker: DataBroker, id: Int64? = nil) throws -> BrokerDB {
         let encodedBroker = try jsonEncoder.encode(broker)
-        return .init(id: nil, name: broker.name, json: encodedBroker, version: broker.version)
+        return .init(id: id, name: broker.name, json: encodedBroker, version: broker.version)
     }
 
     func mapToDB(_ profileQuery: ProfileQuery, relatedTo profileId: Int64) throws -> ProfileQueryDB {

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/ContainerView/ContainerViewModel.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/ContainerView/ContainerViewModel.swift
@@ -125,9 +125,9 @@ final class ContainerViewModel: ObservableObject {
                 let hasResults = brokerProfileData.contains { $0.hasMatches }
 
                 if hasResults {
-                    completion(.noResults)
-                } else {
                     completion(.results)
+                } else {
+                    completion(.noResults)
                 }
             }
         }

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionUpdaterTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionUpdaterTests.swift
@@ -1,0 +1,148 @@
+//
+//  DataBrokerProtectionUpdaterTests.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Foundation
+import SecureStorage
+@testable import DataBrokerProtection
+
+final class DataBrokerProtectionUpdaterTests: XCTestCase {
+
+    let repository = BrokerUpdaterRepositoryMock()
+    let resources = ResourcesRepositoryMock()
+    let vault: DataBrokerProtectionSecureVaultMock? = try? DataBrokerProtectionSecureVaultMock(providers:
+                                                        SecureStorageProviders(
+                                                            crypto: EmptySecureStorageCryptoProviderMock(),
+                                                            database: SecureStorageDatabaseProviderMock(),
+                                                            keystore: EmptySecureStorageKeyStoreProviderMock()))
+
+    override func tearDown() {
+        repository.reset()
+        resources.reset()
+        vault?.reset()
+    }
+
+    func testWhen24HoursDidntPassSinceLastRunDate_thenCheckingUpdatesIsSkipped() {
+        if let vault = self.vault {
+            let sut = DataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault)
+            repository.lastRunDate = substract(hours: 10, to: Date())
+
+            sut.checkForUpdatesInBrokerJSONFiles()
+
+            XCTAssertFalse(repository.wasSaveLastRunDateCalled)
+            XCTAssertFalse(resources.wasFetchBrokerFromResourcesFilesCalled)
+        } else {
+            XCTFail("Mock vault issue")
+        }
+    }
+
+    func testWhen24PassedSinceLastRunDate_thenWeTryToUpdateBrokers() {
+        if let vault = self.vault {
+            let sut = DataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault)
+            repository.lastRunDate = substract(hours: 25, to: Date())
+            resources.brokersList = [.init(id: 1, name: "Broker", steps: [Step](), version: "1.0.1", schedulingConfig: .mock)]
+
+            sut.checkForUpdatesInBrokerJSONFiles()
+
+            XCTAssertTrue(repository.wasSaveLastRunDateCalled)
+            XCTAssertTrue(resources.wasFetchBrokerFromResourcesFilesCalled)
+        } else {
+            XCTFail("Mock vault issue")
+        }
+    }
+
+    func testWhenLastRunDateIsNil_thenWeTryToUpdateBrokers() {
+        if let vault = self.vault {
+            let sut = DataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault)
+            repository.lastRunDate = nil
+            resources.brokersList = [.init(id: 1, name: "Broker", steps: [Step](), version: "1.0.1", schedulingConfig: .mock)]
+
+            sut.checkForUpdatesInBrokerJSONFiles()
+
+            XCTAssertTrue(repository.wasSaveLastRunDateCalled)
+            XCTAssertTrue(resources.wasFetchBrokerFromResourcesFilesCalled)
+        } else {
+            XCTFail("Mock vault issue")
+        }
+    }
+
+    func testWhenSavedBrokerIsOnAnOldVersion_thenWeUpdateIt() {
+        if let vault = self.vault {
+            let sut = DataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault)
+            repository.lastRunDate = nil
+            resources.brokersList = [.init(id: 1, name: "Broker", steps: [Step](), version: "1.0.1", schedulingConfig: .mock)]
+            vault.shouldReturnOldVersionBroker = true
+
+            sut.checkForUpdatesInBrokerJSONFiles()
+
+            XCTAssertTrue(repository.wasSaveLastRunDateCalled)
+            XCTAssertTrue(resources.wasFetchBrokerFromResourcesFilesCalled)
+            XCTAssertTrue(vault.wasBrokerUpdateCalled)
+            XCTAssertFalse(vault.wasBrokerSavedCalled)
+        } else {
+            XCTFail("Mock vault issue")
+        }
+    }
+
+    func testWhenSavedBrokerIsOnTheCurrentVersion_thenWeDoNotUpdateIt() {
+        if let vault = self.vault {
+            let sut = DataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault)
+            repository.lastRunDate = nil
+            resources.brokersList = [.init(id: 1, name: "Broker", steps: [Step](), version: "1.0.1", schedulingConfig: .mock)]
+            vault.shouldReturnNewVersionBroker = true
+
+            sut.checkForUpdatesInBrokerJSONFiles()
+
+            XCTAssertTrue(repository.wasSaveLastRunDateCalled)
+            XCTAssertTrue(resources.wasFetchBrokerFromResourcesFilesCalled)
+            XCTAssertFalse(vault.wasBrokerUpdateCalled)
+        } else {
+            XCTFail("Mock vault issue")
+        }
+    }
+
+    func testWhenFileBrokerIsNotStored_thenWeAddTheBrokerAndScanOperations() {
+        if let vault = self.vault {
+            let sut = DataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault)
+            repository.lastRunDate = nil
+            resources.brokersList = [.init(id: 1, name: "Broker", steps: [Step](), version: "1.0.0", schedulingConfig: .mock)]
+
+            sut.checkForUpdatesInBrokerJSONFiles()
+
+            XCTAssertTrue(repository.wasSaveLastRunDateCalled)
+            XCTAssertTrue(resources.wasFetchBrokerFromResourcesFilesCalled)
+            XCTAssertFalse(vault.wasBrokerUpdateCalled)
+            XCTAssertTrue(vault.wasBrokerSavedCalled)
+        } else {
+            XCTFail("Mock vault issue")
+        }
+    }
+
+    private func substract(hours: Int, to date: Date) -> Date {
+        let calendar = Calendar.current
+        var dateComponents = DateComponents()
+        dateComponents.hour = -hours
+
+        if let modifiedDate = calendar.date(byAdding: dateComponents, to: date) {
+            return modifiedDate
+        } else {
+            fatalError("There was an issue changing the date hours.")
+        }
+    }
+
+}

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -19,6 +19,8 @@
 import Foundation
 import Combine
 import BrowserServicesKit
+import SecureStorage
+import GRDB
 @testable import DataBrokerProtection
 
 extension BrokerProfileQueryData {
@@ -320,5 +322,206 @@ final class MockAuthenticationRepository: AuthenticationRepository {
         shouldSendNilAccessToken = false
         wasInviteCodeSaveCalled = false
         wasAccessTokenSaveCalled = false
+    }
+}
+
+final class BrokerUpdaterRepositoryMock: BrokerUpdaterRepository {
+    var wasSaveLastRunDateCalled = false
+    var lastRunDate: Date?
+
+    func saveLastRunDate(date: Date) {
+        wasSaveLastRunDateCalled = true
+    }
+
+    func getLastRunDate() -> Date? {
+        return lastRunDate
+    }
+
+    func reset() {
+        wasSaveLastRunDateCalled = false
+        lastRunDate = nil
+    }
+}
+
+final class ResourcesRepositoryMock: ResourcesRepository {
+    var wasFetchBrokerFromResourcesFilesCalled = false
+    var brokersList: [DataBroker]?
+
+    func fetchBrokerFromResourceFiles() -> [DataBroker]? {
+        wasFetchBrokerFromResourcesFilesCalled = true
+        return brokersList
+    }
+
+    func reset() {
+        wasFetchBrokerFromResourcesFilesCalled = false
+        brokersList?.removeAll()
+        brokersList = nil
+    }
+}
+
+final class EmptySecureStorageKeyStoreProviderMock: SecureStorageKeyStoreProvider {
+    var generatedPasswordEntryName: String = ""
+
+    var l1KeyEntryName: String = ""
+
+    var l2KeyEntryName: String = ""
+
+    var keychainServiceName: String = ""
+
+    func attributesForEntry(named: String, serviceName: String) -> [String: Any] {
+        return [String: Any]()
+    }
+}
+
+final class EmptySecureStorageCryptoProviderMock: SecureStorageCryptoProvider {
+    var passwordSalt: Data = Data()
+
+    var keychainServiceName: String = ""
+
+    var keychainAccountName: String = ""
+}
+
+final class SecureStorageDatabaseProviderMock: SecureStorageDatabaseProvider {
+    let db: DatabaseWriter
+
+    init() throws {
+        do {
+            self.db = try DatabaseQueue()
+        } catch {
+            throw DataBrokerProtectionError.unknown("")
+        }
+    }
+}
+
+final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecureVault {
+    var shouldReturnOldVersionBroker = false
+    var shouldReturnNewVersionBroker = false
+    var wasBrokerUpdateCalled = false
+    var wasBrokerSavedCalled = false
+
+    typealias DatabaseProvider = SecureStorageDatabaseProviderMock
+
+    required init(providers: SecureStorageProviders<SecureStorageDatabaseProviderMock>) {
+    }
+
+    func reset() {
+        shouldReturnOldVersionBroker = false
+        shouldReturnNewVersionBroker = false
+        wasBrokerUpdateCalled = false
+        wasBrokerSavedCalled = false
+    }
+
+    func save(profile: DataBrokerProtectionProfile) throws -> Int64 {
+        return 1
+    }
+
+    func fetchProfile(with id: Int64) throws -> DataBrokerProtectionProfile? {
+        return nil
+    }
+
+    func save(broker: DataBroker) throws -> Int64 {
+        wasBrokerSavedCalled = true
+        return 1
+    }
+
+    func update(_ broker: DataBroker, with id: Int64) throws {
+        wasBrokerUpdateCalled = true
+    }
+
+    func fetchBroker(with id: Int64) throws -> DataBroker? {
+        return nil
+    }
+
+    func fetchBroker(with name: String) throws -> DataBroker? {
+        if shouldReturnOldVersionBroker {
+            return .init(id: 1, name: "Broker", steps: [Step](), version: "1.0.0", schedulingConfig: .mock)
+        } else if shouldReturnNewVersionBroker {
+            return .init(id: 1, name: "Broker", steps: [Step](), version: "1.0.1", schedulingConfig: .mock)
+        }
+
+        return nil
+    }
+
+    func fetchAllBrokers() throws -> [DataBroker] {
+        return [DataBroker]()
+    }
+
+    func save(profileQuery: ProfileQuery, profileId: Int64) throws -> Int64 {
+        return 1
+    }
+
+    func fetchProfileQuery(with id: Int64) throws -> ProfileQuery? {
+        return nil
+    }
+
+    func fetchAllProfileQueries(for profileId: Int64) throws -> [ProfileQuery] {
+        return [ProfileQuery]()
+    }
+
+    func save(brokerId: Int64, profileQueryId: Int64, lastRunDate: Date?, preferredRunDate: Date?) throws {
+
+    }
+
+    func updatePreferredRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64) throws {
+    }
+
+    func updateLastRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64) throws {
+    }
+
+    func fetchScan(brokerId: Int64, profileQueryId: Int64) throws -> ScanOperationData? {
+        return nil
+    }
+
+    func fetchAllScans() throws -> [ScanOperationData] {
+        return [ScanOperationData]()
+    }
+
+    func save(brokerId: Int64, profileQueryId: Int64, extractedProfile: ExtractedProfile, lastRunDate: Date?, preferredRunDate: Date?) throws {
+    }
+
+    func save(brokerId: Int64, profileQueryId: Int64, extractedProfileId: Int64, lastRunDate: Date?, preferredRunDate: Date?) throws {
+    }
+
+    func updatePreferredRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64, extractedProfileId: Int64) throws {
+    }
+
+    func updateLastRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64, extractedProfileId: Int64) throws {
+    }
+
+    func fetchOptOut(brokerId: Int64, profileQueryId: Int64, extractedProfileId: Int64) throws -> OptOutOperationData? {
+        return nil
+    }
+
+    func fetchOptOuts(brokerId: Int64, profileQueryId: Int64) throws -> [OptOutOperationData] {
+        return [OptOutOperationData]()
+    }
+
+    func fetchAllOptOuts() throws -> [OptOutOperationData] {
+        return [OptOutOperationData]()
+    }
+
+    func save(historyEvent: HistoryEvent, brokerId: Int64, profileQueryId: Int64) throws {
+    }
+
+    func save(historyEvent: HistoryEvent, brokerId: Int64, profileQueryId: Int64, extractedProfileId: Int64) throws {
+    }
+
+    func fetchEvents(brokerId: Int64, profileQueryId: Int64) throws -> [HistoryEvent] {
+        return [HistoryEvent]()
+    }
+
+    func save(extractedProfile: ExtractedProfile, brokerId: Int64, profileQueryId: Int64) throws -> Int64 {
+        return 1
+    }
+
+    func fetchExtractedProfile(with id: Int64) throws -> ExtractedProfile? {
+        return nil
+    }
+
+    func fetchExtractedProfiles(for brokerId: Int64, with profileQueryId: Int64) throws -> [ExtractedProfile] {
+        return [ExtractedProfile]()
+    }
+
+    func updateRemovedDate(for extractedProfileId: Int64, with date: Date?) throws {
     }
 }


### PR DESCRIPTION
## Task

https://app.asana.com/0/1203581873609357/1205378118665592/f

## Description

This adds the following changes:

**When inserting/editing a profile**
- When we insert a new profile, we get the list of brokers from the resources list and create the scan operations along with the profile queries.
- When we edit the profile, we do the same flow but fetch the brokers from the database

**Before the scheduler starts running the operations**
Here, we check for updates to the broker's list or new ones added. Because this operation could have an impact on performance (it has to go through the JSON files, decode them, and compare them to the database ones) it will run if it didn’t run in the last 24 hours (this constant can be changed)


## Steps to test

**Scenario 1 - User inserts a new profile**
- Start from scratch (delete `Vault.db`)
- Create a new profile
- Check that scan operations are created for all the broker JSON files (fake ones should not be included)

**Scenario 2 - User edits a profile**
- Edit the profile
- Check that new scan operations are created with the new profile queries and the broker that is in the database (not in resources)

**Scenario 3 - There are updates to a broker JSON file**
- Have a profile, run some scans, and then stop the app
- Delete `UserDefaults` by running `defaults com.duckduckgo.macos.browser.debug`
- Grab one of the broker JSON files and increase the version number
- Run the app again, the broker JSON file should be updated in the database before running

**Scenario 4 - There is a new JSON file**
- Have a profile, run some scans and then stop the app
- Delete `UserDefaults` by running `defaults com.duckduckgo.macos.browser.debug`
- Create a new broker JSON file
- Run the app again, the broker JSON file should be updated in the database and the new scan operations should be added
