### PR TITLE
Fixes issue with password saving when using Bitwarden

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12059,8 +12059,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 75.2.1;
+				branch = "daniel/bitwarden-fix";
+				kind = branch;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "61947c2a53c43bd388f84001981e106c93775add",
-        "version" : "75.2.1"
+        "branch" : "daniel/bitwarden-fix",
+        "revision" : "cd4f62261a45a04f14eb1d53b845f2c540a8a09a"
       }
     },
     {
@@ -129,7 +129,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
         "revision" : "4684440d03304e7638a2c8086895367e90987463",
         "version" : "1.2.1"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205398889304566/f
BSK PR:  https://github.com/duckduckgo/BrowserServicesKit/pull/486


**Description**:
Fixes an issue that causes passwords to be saved to local vault when Bitwarden is enabled.

**Steps to test this PR**:
1. Enable Bitwarden
2. Go to [fill.dev ](https://fill.dev/form/registration-username)
3. Enter a username
4. Generate a password
5. Submit the form
6. Observe that a prompt to save the password in Bitwarden is shown (Hit save)
7. Check the password is properly saved in Bitwarden

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
