### PR TITLE
Fixes an issue with the download button and popover.

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -513,15 +513,9 @@ final class NavigationBarViewController: NSViewController {
                     && WindowControllersManager.shared.lastKeyMainWindowController?.window === self.downloadsButton.window
 
                 if shouldShowPopover {
-                    // The following lines ensure that if the popover is shown, the downloads button is also shown.
-                    // Ref: https://app.asana.com/0/1177771139624306/1205405170812428/f
-                    //
-                    self.downloadsButton.isHidden = false
-                    DispatchQueue.main.async {
-                        self.popovers.showDownloadsPopoverAndAutoHide(usingView: self.downloadsButton,
-                                                                      popoverDelegate: self,
-                                                                      downloadsDelegate: self)
-                    }
+                    self.popovers.showDownloadsPopoverAndAutoHide(usingView: self.downloadsButton,
+                                                                  popoverDelegate: self,
+                                                                  downloadsDelegate: self)
                 } else {
                     if update.item.isBurner {
                         self.invalidateDownloadButtonHidingTimer()
@@ -599,7 +593,11 @@ final class NavigationBarViewController: NSViewController {
         downloadsButton.image = hasActiveDownloads ? Self.Constants.activeDownloadsImage : Self.Constants.inactiveDownloadsImage
         let isTimerActive = downloadsButtonHidingTimer != nil
 
-        downloadsButton.isHidden = !(hasActiveDownloads || isTimerActive)
+        if popovers.isDownloadsPopoverShown {
+            downloadsButton.isHidden = false
+        } else {
+            downloadsButton.isHidden = !(hasActiveDownloads || isTimerActive)
+        }
 
         if !downloadsButton.isHidden { setDownloadButtonHidingTimer() }
         downloadsButton.isMouseDown = popovers.isDownloadsPopoverShown


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205437616200914/f
Tech Design URL:
CC:

## Description

Sometimes the downloads button in the navigation bar is not shown when it should, causing the downloads popover to be pointing to the wrong navigation bar button.

## Testing

### To see the original issue:

This works best on a good connection, since it's caused by the download being really fast.

1. Run the last internal build (1.55.0) or `develop`.
2. Go to any site with images.
3. Right click on an image, "Save Image As..."
4. Save the image somewhere
5. Notice how the downloads popover points to the wrong button, or no button at all.

<img width="473" alt="Screenshot 2023-09-07 at 00 07 50" src="https://github.com/duckduckgo/macos-browser/assets/1836005/3d9c1cf1-751f-4268-a127-8ecf2913046e">

### To test the fix:

Run the same steps in this branch.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
