### PR TITLE
fix bug where when in case of error address shown address bar is wrong

### DIFF
--- a/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -209,6 +209,7 @@ final class TabViewModel {
         guard !errorViewState.isVisible else {
             let failingUrl = tab.error?.failingUrl
             let failingUrlHost = failingUrl?.host?.droppingWwwPrefix() ?? ""
+            addressBarString = failingUrl?.absoluteString ?? ""
             passiveAddressBarString = appearancePreferences.showFullURL ? addressBarString : failingUrlHost
             return
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205409067235154/f

**Description**: Fix a bug where when Invalid certificate error the address bar displays the URL of referring site, not the bad URL

**Steps to test this PR**:
- Visit https://github.com/chzyer/readline
- Go to the Backers section
- Click on the picture of the first backer (a person with black hair and a teal t-shirt)
- The link redirects to apex.sh, which has an invalid certificate
- You’ll see a message that the certificate is invalid
- Check the address bar shows apex.sh (not github)
- Click on the address bar and check that address bar shows the full apex.sh address (not github)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
