### PR TITLE
Autofill update for iOS de-duplication of prompted logins

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12294,8 +12294,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "anya/autofill-ios-prompt-deduplication";
-				kind = branch;
+				kind = exactVersion;
+				version = 78.2.0;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "anya/autofill-ios-prompt-deduplication",
-        "revision" : "d7d074305845d89cdfad5d99c0d0aa41f8528aa5"
+        "revision" : "8ba1d3b7f3e2291fc344cd5b83b66c1336e35a32",
+        "version" : "78.2.0"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "78.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "78.2.0"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [

--- a/LocalPackages/NetworkProtectionUI/Package.swift
+++ b/LocalPackages/NetworkProtectionUI/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "78.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "78.2.0"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1205369440069075/f
Tech Design URL:
CC:

**Description**:
BSK update for iOS bringing it into parity with macOS de-duplication of logins when prompting to autofill

**Steps to test this PR**:
1. Smoke test that there has been no change around prompted logins 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
