### PR TITLE
prevent WKFullScreenWindowController crashing after `close` call

### DIFF
--- a/DuckDuckGo/Main/View/MainViewController.swift
+++ b/DuckDuckGo/Main/View/MainViewController.swift
@@ -450,8 +450,6 @@ final class MainViewController: NSViewController {
         adjustFirstResponder()
     }
 
-    private(set) var isHandlingKeyDownEvent: Bool = false
-
 }
 extension MainViewController: NSDraggingDestination {
 
@@ -492,12 +490,8 @@ extension MainViewController {
     }
 
     func customKeyDown(with event: NSEvent) -> Bool {
-        isHandlingKeyDownEvent = true
-        defer {
-            isHandlingKeyDownEvent = false
-        }
-       guard let locWindow = self.view.window,
-          NSApplication.shared.keyWindow === locWindow else { return false }
+        guard let locWindow = self.view.window,
+              NSApplication.shared.keyWindow === locWindow else { return false }
 
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             .subtracting(.capsLock)

--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -296,6 +296,13 @@ extension MainViewController {
         // instead of closing a pinned tab we select the first regular tab
         // (this is in line with Safari behavior)
         // If there are no regular tabs, we close the window.
+        var isHandlingKeyDownEvent: Bool {
+            guard sender is NSMenuItem,
+                  let currentEvent = NSApp.currentEvent,
+                  case .keyDown = currentEvent.type,
+                  currentEvent.modifierFlags.contains(.command) else { return false }
+             return true
+        }
         if isHandlingKeyDownEvent, tab.isPinned {
             if tabCollectionViewModel.tabCollection.tabs.isEmpty {
                 view.window?.performClose(sender)

--- a/DuckDuckGo/Tab/View/WebView.swift
+++ b/DuckDuckGo/Tab/View/WebView.swift
@@ -40,7 +40,9 @@ final class WebView: WKWebView {
         stopLoading()
         stopMediaCapture()
         stopAllMediaPlayback()
-        fullscreenWindowController?.close()
+        if isInFullScreenMode {
+            fullscreenWindowController?.window?.toggleFullScreen(self)
+        }
         if isInspectorShown {
             closeDeveloperTools()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1204100113054436/f

**Description**:
- on `WKFullScreenWindowController.close()` call it unsets its `_webView` property but the controller remains associated with the Web View
- Next time Full Screen is requested the controller tries to add its `_webView` which is `nil` to a window -> crash
- The `close()` was called when a pinned tab was closed in full screen mode with Cmd+W to exit full screen mode
-- Cmd+W hotkey checking was done incorrectly: it only worked when the pinned tab was not presenting in Full Screen mode - also fixed
- https://errors.duckduckgo.com/organizations/ddg/issues/3411/?project=6&referrer=release-issue-stream

**Steps to test this PR**:
1. Open a video, enter fullscreen, 3-finger swipe back to the browser screen
2. Pin the tab presenting in Full Screen
3. Hit Cmd+W
4. Validate the pinned tab is not closed but the video is stopped and full screen mode is off
5. Activate the pinned tab again and enter Full Screen -> validate full screen works.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
