### PR TITLE
Use Development environment for Sync by default in Debug builds

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -304,7 +304,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
         let environment = ServerEnvironment(
             UserDefaultsWrapper(
                 key: .syncEnvironment,
-                defaultValue: ServerEnvironment.production.description
+                defaultValue: defaultEnvironment.description
             ).wrappedValue
         ) ?? defaultEnvironment
 #else


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1205489036222324/f

**Description**:
When running the app from Xcode, use Development environment for Sync by default.

**Steps to test this PR**:
1. Clean app data
2. Run the app from Xcode
3. Identify as internal user
4. Enable Sync logging via Main Menu -> Debug -> Logging -> Sync
5. Sign up for Sync (Settings -> Sync)
6. Verify that requests are being sent to Development environment (dev-sync-use.duckduckgo.com).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
