### PR TITLE
fix Safari import not working

### DIFF
--- a/DuckDuckGo/DataImport/View/DataImportViewController.swift
+++ b/DuckDuckGo/DataImport/View/DataImportViewController.swift
@@ -26,12 +26,12 @@ final class DataImportViewController: NSViewController {
     @UserDefaultsWrapper(key: .homePageContinueSetUpImport, defaultValue: nil)
     var successfulImportHappened: Bool?
 
-    enum Constants {
+    private enum Constants {
         static let storyboardName = "DataImport"
         static let identifier = "DataImportViewController"
     }
 
-    enum InteractionState: Equatable {
+    private enum InteractionState: Equatable {
         case unableToImport
         case permissionsRequired([DataImport.DataType])
         case ableToImport
@@ -66,7 +66,7 @@ final class DataImportViewController: NSViewController {
         }
     }
 
-    static func create() -> DataImportViewController {
+    private static func create() -> DataImportViewController {
         let storyboard = NSStoryboard(name: Constants.storyboardName, bundle: nil)
         return storyboard.instantiateController(identifier: Constants.identifier)
     }
@@ -194,7 +194,7 @@ final class DataImportViewController: NSViewController {
         }
     }
 
-    func refreshDataImporter() {
+    private func refreshDataImporter() {
         let bookmarkImporter = CoreDataBookmarkImporter(bookmarkManager: LocalBookmarkManager.shared)
 
         do {
@@ -226,7 +226,7 @@ final class DataImportViewController: NSViewController {
         }
     }
 
-    var loginsSelected: Bool {
+    private var loginsSelected: Bool {
         if let browserViewController = self.currentChildViewController as? BrowserImportViewController {
             return browserViewController.selectedImportOptions.contains(.logins)
         }
@@ -376,11 +376,11 @@ final class DataImportViewController: NSViewController {
         cancelButton.title = UserText.navigateBack
     }
 
-    var selectedProfile: DataImport.BrowserProfile? {
+    private var selectedProfile: DataImport.BrowserProfile? {
         return browserImportViewController?.selectedProfile
     }
 
-    var selectedImportOptions: [DataImport.DataType] {
+    private var selectedImportOptions: [DataImport.DataType] {
         guard let importer = self.dataImporter else {
             assertionFailure("\(#file): No data importer or profile found")
             return []


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205385207418837/f

**Description**:
- Fixes Data importer not working without import source popup change

**Steps to test this PR**:
1. Modify `ThirtPartyBrowser.bundleIdentifiers` so that chrome/edge/ff have wrong bundle identifiers and not present in the import list
2. Make sure `DataImportViewController.ViewState.defaultState()` has `.safari` as a `firstInstalledBrowser` when Import dialog is open and Safari is selected.
3. Click Import: dialog should proceed to permissions/bookmark import screeen

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
