### PR TITLE
Make sure Catalina build is in the appcast

### DIFF
--- a/scripts/appcast_manager/appcastManager.swift
+++ b/scripts/appcast_manager/appcastManager.swift
@@ -2,6 +2,7 @@
 
 // swiftlint:disable line_length
 // swiftlint:disable file_header
+// swiftlint:disable function_body_length
 
 import Foundation
 
@@ -547,3 +548,4 @@ func verifyAppcastContainsBuild(_ buildVersion: String, in filePath: URL) -> Boo
 }
 
 // swiftlint:enable line_length
+// swiftlint:enable function_body_length


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205377076593202/f
CC:

**Description**:
Small adjustment of our appcast management script to ensure the last build for macOS Catalina remains in the appcast after each run of the script

**Steps to test this PR**:
1. Download the dmg with version 1.56.99 from https://app.asana.com/0/0/1205376965590644/f and save it to `~/Downloads`
2. Add sample release notes into `~/Downloads/release-notes.txt`
3. Execute `./scripts/appcast_manager/appcastManager.swift --release-to-internal-channel --dmg ~/Downloads/duckduckgo-1.56.99.dmg --release-notes ~/Downloads/release-notes.txt`
4. Make sure the script successfully added 1.56.99 into the appcast2.xml
5. Verify the version 1.55.0 is still in the appcast2.xml

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
