### PR TITLE
Set tab created by in-context signup for burner state

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,7 +129,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
       "state" : {
         "revision" : "4684440d03304e7638a2c8086895367e90987463",
         "version" : "1.2.1"

--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -575,13 +575,21 @@ extension MainViewController {
 
     @IBAction func mergeAllWindows(_ sender: Any?) {
         guard let mainWindowController = WindowControllersManager.shared.lastKeyMainWindowController else { return }
-        let otherWindowControllers = WindowControllersManager.shared.mainWindowControllers.filter { $0 !== mainWindowController }
+        assert(!self.isBurner)
+
+        let otherWindowControllers = WindowControllersManager.shared.mainWindowControllers.filter {
+            $0 !== mainWindowController && $0.mainViewController.isBurner == false
+        }
+        let excludedWindowControllers = WindowControllersManager.shared.mainWindowControllers.filter {
+            $0 === mainWindowController || $0.mainViewController.isBurner == true
+        }
+
         let otherMainViewControllers = otherWindowControllers.compactMap { $0.mainViewController }
         let otherTabCollectionViewModels = otherMainViewControllers.map { $0.tabCollectionViewModel }
         let otherTabs = otherTabCollectionViewModels.flatMap { $0.tabCollection.tabs }
         let otherLocalHistoryOfRemovedTabs = Set(otherTabCollectionViewModels.flatMap { $0.tabCollection.localHistoryOfRemovedTabs })
 
-        WindowsManager.closeWindows(except: view.window)
+        WindowsManager.closeWindows(except: excludedWindowControllers.compactMap(\.window))
 
         tabCollectionViewModel.append(tabs: otherTabs)
         tabCollectionViewModel.tabCollection.localHistoryOfRemovedTabs += otherLocalHistoryOfRemovedTabs
@@ -854,7 +862,7 @@ extension MainViewController: NSMenuItemValidation {
 
         // Merge all windows
         case #selector(MainViewController.mergeAllWindows(_:)):
-            return WindowControllersManager.shared.mainWindowControllers.count > 1
+            return WindowControllersManager.shared.mainWindowControllers.filter({ !$0.mainViewController.isBurner }).count > 1 && !self.isBurner
 
         // Move Tab to New Window, Select Next/Prev Tab
         case #selector(MainViewController.moveTabToNewWindow(_:)):

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -48,7 +48,7 @@ final class BrowserTabViewController: NSViewController {
     private var cancellables = Set<AnyCancellable>()
     private var mouseDownCancellable: AnyCancellable?
 
-    private var previouslySelectedTab: Tab?
+    private weak var previouslySelectedTab: Tab?
 
     private var hoverLabelWorkItem: DispatchWorkItem?
 
@@ -131,6 +131,8 @@ final class BrowserTabViewController: NSViewController {
 
     @objc
     private func onDuckDuckGoEmailIncontextSignup(_ notification: Notification) {
+        guard WindowControllersManager.shared.lastKeyMainWindowController === self.view.window?.windowController else { return }
+
         self.previouslySelectedTab = tabCollectionViewModel.selectedTab
         let tab = Tab(content: .url(EmailUrls().emailProtectionInContextSignupLink), shouldLoadInBackground: true, burnerMode: tabCollectionViewModel.burnerMode)
         tabCollectionViewModel.append(tab: tab)
@@ -138,15 +140,19 @@ final class BrowserTabViewController: NSViewController {
 
     @objc
     private func onCloseDuckDuckGoEmailProtection(_ notification: Notification) {
-        guard let activeTab = tabCollectionViewModel.selectedTabViewModel?.tab else { return }
-        if activeTab.url != nil && EmailUrls().isDuckDuckGoEmailProtection(url: activeTab.url!) {
+        guard WindowControllersManager.shared.lastKeyMainWindowController === self.view.window?.windowController,
+              let previouslySelectedTab else { return }
+
+        if let activeTab = tabCollectionViewModel.selectedTabViewModel?.tab,
+           let url = activeTab.url,
+           EmailUrls().isDuckDuckGoEmailProtection(url: url) {
+
             self.closeTab(activeTab)
         }
-        if let previouslySelectedTab = self.previouslySelectedTab {
-            tabCollectionViewModel.select(tab: previouslySelectedTab)
-            previouslySelectedTab.webView.evaluateJavaScript("window.openAutofillAfterClosingEmailProtectionTab()", in: nil, in: WKContentWorld.defaultClient)
-            self.previouslySelectedTab = nil
-        }
+
+        tabCollectionViewModel.select(tab: previouslySelectedTab)
+        previouslySelectedTab.webView.evaluateJavaScript("window.openAutofillAfterClosingEmailProtectionTab()", in: nil, in: WKContentWorld.defaultClient)
+        self.previouslySelectedTab = nil
     }
 
     @objc

--- a/DuckDuckGo/Windows/View/WindowsManager.swift
+++ b/DuckDuckGo/Windows/View/WindowsManager.swift
@@ -26,8 +26,9 @@ final class WindowsManager {
         return NSApplication.shared.windows
     }
 
-    class func closeWindows(except window: NSWindow? = nil) {
-        for controller in WindowControllersManager.shared.mainWindowControllers where controller.window !== window {
+    class func closeWindows(except windows: [NSWindow] = []) {
+        for controller in WindowControllersManager.shared.mainWindowControllers {
+            guard let window = controller.window, !windows.contains(window) else { continue }
             controller.close()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205271981624866/f
Tech Design URL:
CC:

**Description**:
Fix crash when user attempts to use in-context signup on a burner tab


https://github.com/duckduckgo/macos-browser/assets/635903/72c7fe30-8914-4e0b-a3ce-f7e2a9de92f6


**Steps to test this PR**:
1. Open a burner tab
2. Clear debugging state using Debug > Reset Data > Reset Email Protection inContext Signup Prompt
3. Go to a website with an email input, e.g. https://duckduckgo.com/newsletter
4. Click into the input and select "Hide your email and block trackers" in the autofill dropdown
5. App should open a new tab starting the Email Protection signup, and not crash

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
