### PR TITLE
Fix migrated firefox bookmark database import

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,7 +129,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
       "state" : {
         "revision" : "4684440d03304e7638a2c8086895367e90987463",
         "version" : "1.2.1"

--- a/DuckDuckGo/DataImport/Bookmarks/Firefox/FirefoxBookmarksReader.swift
+++ b/DuckDuckGo/DataImport/Bookmarks/Firefox/FirefoxBookmarksReader.swift
@@ -25,6 +25,14 @@ final class FirefoxBookmarksReader {
         static let placesDatabaseName = "places.sqlite"
     }
 
+    private enum BookmarkGUID {
+        static let root = "root________"
+        static let menu = "menu________"
+        static let toolbar = "toolbar_____"
+        static let tags = "tags________"
+        static let unfiled = "unfiled_____"
+    }
+
     enum ImportError: Error {
         case noBookmarksFileFound
         case failedToTemporarilyCopyFile
@@ -61,9 +69,10 @@ final class FirefoxBookmarksReader {
                 assert(rootEntries.count == 1, "moz_bookmarks should only have one root entry")
 
                 let topLevelFolders = try FolderRow.fetchAll(database, sql: foldersWithParentQuery(), arguments: [rootEntry.id])
-                let tagsFolder = topLevelFolders.first { $0.title == "tags" }
+                let tagsFolder = topLevelFolders.first { $0.guid == BookmarkGUID.tags }
 
                 let allBookmarks = try BookmarkRow.fetchAll(database, sql: allBookmarksQuery())
+                    .filter { !($0.url.hasPrefix("place:") || $0.url.hasPrefix("about:")) }
                 let allFolders = try FolderRow.fetchAll(database, sql: allFoldersQuery(), arguments: [tagsFolder?.id ?? 0])
 
                 let foldersByParent: [Int: [FolderRow]] = allFolders.reduce(into: [:]) { result, folder in
@@ -108,11 +117,13 @@ final class FirefoxBookmarksReader {
         let id: Int
         let title: String
         let parent: Int
+        let guid: String
 
         init(row: Row) {
             id = row["id"]
             title = row["title"]
             parent = row["parent"]
+            guid = row["guid"]
         }
     }
 
@@ -131,9 +142,9 @@ final class FirefoxBookmarksReader {
     }
 
     private func mapDatabaseBookmarksToImportedBookmarks(_ databaseBookmarks: DatabaseBookmarks) -> ImportedBookmarks {
-        let menu = databaseBookmarks.topLevelFolders.first(where: { $0.title == "menu" })
-        let toolbar = databaseBookmarks.topLevelFolders.first(where: { $0.title == "toolbar" })
-        let unfiled = databaseBookmarks.topLevelFolders.first(where: { $0.title == "unfiled" })
+        let menu = databaseBookmarks.topLevelFolders.first(where: { $0.guid == BookmarkGUID.menu })
+        let toolbar = databaseBookmarks.topLevelFolders.first(where: { $0.guid == BookmarkGUID.toolbar })
+        let unfiled = databaseBookmarks.topLevelFolders.first(where: { $0.guid == BookmarkGUID.unfiled })
 
         let menuBookmarksAndFolders = children(parentID: menu?.id, bookmarks: databaseBookmarks)
         let toolbarBookmarksAndFolders = children(parentID: toolbar?.id, bookmarks: databaseBookmarks)
@@ -174,11 +185,11 @@ final class FirefoxBookmarksReader {
     // MARK: - Database Queries
 
     func rootEntryQuery() -> String {
-        return "SELECT id,type,title,parent FROM moz_bookmarks WHERE guid = 'root________';"
+        return "SELECT id,type,title,parent,guid FROM moz_bookmarks WHERE guid = '\(BookmarkGUID.root)';"
     }
 
     func foldersWithParentQuery() -> String {
-        return "SELECT id,type,title,parent FROM moz_bookmarks WHERE parent = ?;"
+        return "SELECT id,type,title,parent,guid FROM moz_bookmarks WHERE parent = ?;"
     }
 
     func allBookmarksQuery() -> String {
@@ -205,7 +216,8 @@ final class FirefoxBookmarksReader {
         SELECT
             id,
             title,
-            parent
+            parent,
+            guid
         FROM
             moz_bookmarks
         WHERE


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1203417037390120/f

**Description**:
- fix localized/legacy folder names import: import FF folders by guid

**Steps to test this PR**:
1. backup&remove FF profile data from `~/Library/Application Support/Firefox`
2. download non-english locale Firefox versions from:
  - https://download.cdn.mozilla.net/pub/firefox/releases/55.0.3/mac/
  - https://download.cdn.mozilla.net/pub/firefox/releases/72.0.2/mac/
  - https://download.cdn.mozilla.net/pub/firefox/releases/117.0.1/mac/
3. install&launch FF v.55, quit
4. overwrite&launch FF v.72, validate bookmark folders have localized names, add couple of bookmarks, quit
5. overwrite&launch FF v.117, quit
6. Validate File->Import bookmarks->Firefox->Import imports the bookmarks

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
