### PR TITLE
Fix Xcode 15 crash in Autofill popover

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -876,9 +876,7 @@ extension NavigationBarViewController: OptionsButtonMenuDelegate {
 
     func optionsButtonMenuRequestedNetworkProtectionPopover(_ menu: NSMenu) {
 #if NETWORK_PROTECTION
-        if #available(macOS 11.4, *) {
-            toggleNetworkProtectionPopover()
-        }
+        toggleNetworkProtectionPopover()
 #else
         fatalError("Tried to open Network Protection when it was disabled")
 #endif

--- a/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementLoginItemView.swift
@@ -469,6 +469,9 @@ private struct NotesView: View {
             .padding(.bottom, itemSpacing)
 
         if model.isEditing || model.isNew {
+#if APPSTORE
+            FocusableTextEditor()
+#else
             if #available(macOS 12, *) {
                 FocusableTextEditor()
             } else {
@@ -491,6 +494,7 @@ private struct NotesView: View {
                         }
                     )
             }
+#endif
         } else {
             Text(model.notes)
                 .padding(.bottom, interItemSpacing)

--- a/DuckDuckGo/Tab/View/WebViewContainerView.swift
+++ b/DuckDuckGo/Tab/View/WebViewContainerView.swift
@@ -133,7 +133,7 @@ final class WebViewContainerView: NSView {
                     // this would slightly break UX in case multiple Full Screen windows are open but it fixes the bug
                     if #available(macOS 12.0, *) {
                         webView.closeAllMediaPresentations {}
-                    } else if #available(macOS 11.4, *) {
+                    } else {
                         webView.closeAllMediaPresentations()
                     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1205520112784531/f

**Description**:
- fixes Xcode 15 App Store build in autofill popover
- clean some leftovers after Catalina drop

**Steps to test this PR**:
1. clean build App Store target using XCode 15 - ensure there‘s no warning at `PasswordManagementLoginItemView.swift:472` and similar
2. Open Autofill popover (I had it crashing with 1 login item present) - ensure there‘s no crash

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
