### PR TITLE
Fix pinned tabs reordering; Dragging out single tab from window

### DIFF
--- a/DuckDuckGo/PinnedTabs/View/PinnedTabsHostingView.swift
+++ b/DuckDuckGo/PinnedTabs/View/PinnedTabsHostingView.swift
@@ -23,6 +23,10 @@ final class PinnedTabsHostingView: NSHostingView<PinnedTabsView> {
 
     let middleClickPublisher: AnyPublisher<CGPoint, Never>
 
+    override var mouseDownCanMoveWindow: Bool {
+        false
+    }
+
     override func otherMouseDown(with event: NSEvent) {
         guard event.buttonNumber == 2 else { return }
 

--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -80,7 +80,7 @@ final class TabBarViewController: NSViewController {
             let pinnedTabsView = PinnedTabsView(model: pinnedTabsViewModel)
             self.pinnedTabsViewModel = pinnedTabsViewModel
             self.pinnedTabsView = pinnedTabsView
-            self.pinnedTabsHostingView = .init(rootView: pinnedTabsView)
+            self.pinnedTabsHostingView = PinnedTabsHostingView(rootView: pinnedTabsView)
         } else {
             self.pinnedTabsViewModel = nil
             self.pinnedTabsView = nil
@@ -381,7 +381,8 @@ final class TabBarViewController: NSViewController {
     }
 
     private func moveToNewWindow(from index: Int, droppingPoint: NSPoint? = nil, burner: Bool) {
-        guard tabCollectionViewModel.tabCollection.tabs.count > 1 else { return }
+        // only allow dragging Tab out when there‘s tabs (or pinned tabs) left
+        guard tabCollectionViewModel.tabCollection.tabs.count > 1 || pinnedTabsViewModel?.items.isEmpty == false else { return }
         guard let tabViewModel = tabCollectionViewModel.tabViewModel(at: index) else {
             assertionFailure("TabBarViewController: Failed to get tab view model")
             return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205529576422074/f

**Description**:
- Fix pinned tabs reordering
- Allow dragging out a single tab from window with pinned tabs

**Steps to test this PR**:
1. Open a window, create several pinned tabs, validate pinned tabs reordering works and doesn‘t move the window
2. Open a single regular tab, order it out of the window: validate a new window is created and the old window remains with a pinned tab open
3. Open a Fire Window with a single tab. Validate dragging out a single tab doesn‘t work

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
