### PR TITLE
Fix DBP on close notification

### DIFF
--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -151,7 +151,9 @@ final class BrowserTabViewController: NSViewController {
 
     @objc
     private func onCloseDataBrokerProtection(_ notification: Notification) {
-        guard let activeTab = tabCollectionViewModel.selectedTabViewModel?.tab else { return }
+        guard let activeTab = tabCollectionViewModel.selectedTabViewModel?.tab,
+              view.window?.isKeyWindow == true else { return }
+
         self.closeTab(activeTab)
 
         if let previouslySelectedTab = self.previouslySelectedTab {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/inbox/1201011656765575/1205520119443892/1205538300711845/f

**Description**:
Fixes issue where closing the DBP redeem code would close all active tabs from all windows

**Steps to test this PR**:
1. Check video in the task to see how to reproduce
2. Open multiple windows and add random tabs
3. Go to the menu, select Personal Information Removal
4. Cancel the redeem popup
5. Check if only the redeem tab was closed

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
