### PR TITLE
Onboarding flow fix for macOS Sonoma

### DIFF
--- a/DuckDuckGo/Main/View/MainWindowController.swift
+++ b/DuckDuckGo/Main/View/MainWindowController.swift
@@ -193,6 +193,7 @@ final class MainWindowController: NSWindowController {
 extension MainWindowController: NSWindowDelegate {
 
     func windowDidBecomeKey(_ notification: Notification) {
+        NotificationCenter.default.post(name: .windowDidBecomeKey, object: nil)
         mainViewController.windowDidBecomeMain()
 
         if (notification.object as? NSWindow)?.isPopUpWindow == false {
@@ -322,5 +323,11 @@ fileprivate extension NavigationBarViewController {
                 addressBarViewController?.passiveTextField
         ]
     }
+
+}
+
+extension Notification.Name {
+
+    static let windowDidBecomeKey = Notification.Name(rawValue: "windowDidBecomeKey")
 
 }

--- a/DuckDuckGo/Preferences/Model/DefaultBrowserPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/DefaultBrowserPreferences.swift
@@ -89,8 +89,10 @@ final class DefaultBrowserPreferences: ObservableObject {
     init(defaultBrowserProvider: DefaultBrowserProvider = SystemDefaultBrowserProvider()) {
         self.defaultBrowserProvider = defaultBrowserProvider
 
-        appDidBecomeActiveCancellable = NotificationCenter.default
+        let notificationCenter = NotificationCenter.default
+        appDidBecomeActiveCancellable = notificationCenter
             .publisher(for: NSApplication.didBecomeActiveNotification)
+            .merge(with: notificationCenter.publisher(for: .windowDidBecomeKey))
             .sink { [weak self] _ in
                 self?.checkIfDefault()
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205532863342570/f

**Description**:
On macOS Sonoma, `NSApplication.didBecomeActiveNotification` is not fired after the macOS dialog to change the default browser is dismissed. It broke the onboarding flow. This PR fixes the issue. 

**Steps to test this PR**:
1. Go to `about:welcome`
2. Continue through the onboarding flow (you can skip the import) until you reach setting DuckDuckGo as the default browser
3. Click on "Let's do it"
4. Select your preference in the system dialog
5. Verify the onboarding changed to the last view beginning with "You're all set!"

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
