### PR TITLE
Basic NetP Remote Messaging, Part 1: Remove hardcoded "beta ended" message

### DIFF
--- a/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
+++ b/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
@@ -100,10 +100,6 @@ extension UserText {
     static let networkProtectionWaitlistButtonJoinWaitlist = NSLocalizedString("network-protection.waitlist.button.join-waitlist", value: "Join the Waitlist", comment: "Join Waitlist button for Network Protection join waitlist screen")
     static let networkProtectionWaitlistButtonAgreeAndContinue = NSLocalizedString("network-protection.waitlist.button.agree-and-continue", value: "Agree and Continue", comment: "Agree and Continue button for Network Protection join waitlist screen")
 
-    static let networkProtectionBetaEndedCardTitle = NSLocalizedString("network-protection.waitlist.beta-ended-card.title", value: "VPN Beta Closed", comment: "Title for the Network Protection beta ended card")
-    static let networkProtectionBetaEndedCardText = NSLocalizedString("network-protection.waitlist.beta-ended-card.text", value: "Thank you for participating! We look forward to sharing more with you in future product announcements.", comment: "Text for the Network Protection beta ended card")
-    static let networkProtectionBetaEndedCardAction = NSLocalizedString("network-protection.waitlist.beta-ended-card.action", value: "Dismiss", comment: "Action text for the Network Protection beta ended card")
-
 }
 
 // MARK: - Network Protection Terms of Service

--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -112,7 +112,6 @@ public struct UserDefaultsWrapper<T> {
         case homePageIsContinueSetupVisible = "home.page.is.continue.setup.visible"
         case homePageIsRecentActivityVisible = "home.page.is.recent.activity.visible"
         case homePageIsFirstSession = "home.page.is.first.session"
-        case homePageShowNetworkProtectionBetaEndedNotice = "home.page.network-protection.show-beta-ended-notice"
 
         case appIsRelaunchingAutomatically = "app-relaunching-automatically"
 
@@ -174,6 +173,7 @@ public struct UserDefaultsWrapper<T> {
     enum RemovedKeys: String, CaseIterable {
         case passwordManagerDoNotPromptDomains = "com.duckduckgo.passwordmanager.do-not-prompt-domains"
         case incrementalFeatureFlagTestHasSentPixel = "network-protection.incremental-feature-flag-test.has-sent-pixel"
+        case homePageShowNetworkProtectionBetaEndedNotice = "home.page.network-protection.show-beta-ended-notice"
     }
 
     private let key: Key

--- a/DuckDuckGo/HomePage/Model/HomePageContinueSetUpModel.swift
+++ b/DuckDuckGo/HomePage/Model/HomePageContinueSetUpModel.swift
@@ -103,9 +103,6 @@ extension HomePage.Models {
         @UserDefaultsWrapper(key: .homePageShowSurveyDay7, defaultValue: true)
         private var shouldShowSurveyDay7: Bool
 
-        @UserDefaultsWrapper(key: .homePageShowNetworkProtectionBetaEndedNotice, defaultValue: true)
-        private var shouldShowNetworkProtectionBetaEndedNotice: Bool
-
         @UserDefaultsWrapper(key: .homePageIsFirstSession, defaultValue: true)
         private var isFirstSession: Bool
 
@@ -188,8 +185,6 @@ extension HomePage.Models {
                 visitSurvey(day: .day0)
             case .surveyDay7:
                 visitSurvey(day: .day7)
-            case .networkProtectionBetaEndedNotice:
-                removeItem(for: .networkProtectionBetaEndedNotice)
             }
         }
         // swiftlint:enable cyclomatic_complexity
@@ -210,8 +205,6 @@ extension HomePage.Models {
                 shouldShowSurveyDay0 = false
             case .surveyDay7:
                 shouldShowSurveyDay7 = false
-            case .networkProtectionBetaEndedNotice:
-                shouldShowNetworkProtectionBetaEndedNotice = false
             }
             refreshFeaturesMatrix()
         }
@@ -219,10 +212,6 @@ extension HomePage.Models {
         // swiftlint:disable cyclomatic_complexity
         func refreshFeaturesMatrix() {
             var features: [FeatureType] = []
-
-            if shouldNetworkProtectionBetaEndedNoticeBeVisible {
-                features.append(.networkProtectionBetaEndedNotice)
-            }
 
             for feature in listOfFeatures {
                 switch feature {
@@ -254,8 +243,6 @@ extension HomePage.Models {
                     if shouldSurveyDay7BeVisible {
                         features.append(feature)
                     }
-                case .networkProtectionBetaEndedNotice:
-                    break // Do nothing, as the NetP beta ended notice will always be added to the start of the list
                 }
             }
             featuresMatrix = features.chunked(into: itemsPerRow)
@@ -353,50 +340,6 @@ extension HomePage.Models {
             firstLaunchDate <= oneWeekAgo
         }
 
-        /// The Network Protection beta ended card should only be displayed under the following conditions:
-        ///
-        /// 1. The user has gone through the waitlist AND used Network Protection at least once
-        /// 2. The `waitlistBetaActive` flag has been set to disabled
-        /// 3. The user has not already dismissed the card
-        private var shouldNetworkProtectionBetaEndedNoticeBeVisible: Bool {
-#if NETWORK_PROTECTION
-            // 1. The user has signed up for the waitlist AND used Network Protection at least once:
-
-            let waitlistStorage = NetworkProtectionWaitlist().waitlistStorage
-            let isWaitlistUser = waitlistStorage.isWaitlistUser && waitlistStorage.isInvited
-
-            guard isWaitlistUser else {
-                return false
-            }
-
-            let activationStore = WaitlistActivationDateStore()
-            guard activationStore.daysSinceActivation() != nil else {
-                return false
-            }
-
-            // 2. The `waitlistBetaActive` flag has been set to disabled
-
-            let featureOverrides = DefaultWaitlistBetaOverrides()
-            let waitlistFlagEnabled: Bool
-
-            switch featureOverrides.waitlistActive {
-            case .useRemoteValue: waitlistFlagEnabled = privacyConfig.isSubfeatureEnabled(NetworkProtectionSubfeature.waitlistBetaActive)
-            case .on: waitlistFlagEnabled = true
-            case .off: waitlistFlagEnabled = false
-            }
-
-            guard !waitlistFlagEnabled else {
-                return false
-            }
-
-            // 3. The user has not already dismissed the card
-
-            return shouldShowNetworkProtectionBetaEndedNotice
-#else
-            return false
-#endif
-        }
-
         private enum SurveyDay {
             case day0
             case day7
@@ -436,7 +379,6 @@ extension HomePage.Models {
         case importBookmarksAndPasswords
         case surveyDay0
         case surveyDay7
-        case networkProtectionBetaEndedNotice
 
         var title: String {
             switch self {
@@ -454,8 +396,6 @@ extension HomePage.Models {
                 return UserText.newTabSetUpSurveyDay0CardTitle
             case .surveyDay7:
                 return UserText.newTabSetUpSurveyDay7CardTitle
-            case .networkProtectionBetaEndedNotice:
-                return UserText.networkProtectionBetaEndedCardTitle
             }
         }
 
@@ -475,8 +415,6 @@ extension HomePage.Models {
                 return UserText.newTabSetUpSurveyDay0Summary
             case .surveyDay7:
                 return UserText.newTabSetUpSurveyDay7Summary
-            case .networkProtectionBetaEndedNotice:
-                return UserText.networkProtectionBetaEndedCardText
             }
         }
 
@@ -496,8 +434,6 @@ extension HomePage.Models {
                 return UserText.newTabSetUpSurveyDay0Action
             case .surveyDay7:
                 return UserText.newTabSetUpSurveyDay7Action
-            case .networkProtectionBetaEndedNotice:
-                return UserText.networkProtectionBetaEndedCardAction
             }
         }
 
@@ -519,8 +455,6 @@ extension HomePage.Models {
                 return NSImage(named: "Survey-128")!.resized(to: iconSize)!
             case .surveyDay7:
                 return NSImage(named: "Survey-128")!.resized(to: iconSize)!
-            case .networkProtectionBetaEndedNotice:
-                return NSImage(named: "VPN-Ended")!.resized(to: iconSize)!
             }
         }
     }

--- a/UnitTests/HomePage/ContinueSetUpModelTests.swift
+++ b/UnitTests/HomePage/ContinueSetUpModelTests.swift
@@ -99,7 +99,7 @@ final class ContinueSetUpModelTests: XCTestCase {
 
         vm.shouldShowAllFeatures = true
 
-        expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .networkProtectionBetaEndedNotice])
+        expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7])
 
         XCTAssertEqual(vm.visibleFeaturesMatrix, expectedMatrix)
     }
@@ -164,11 +164,11 @@ final class ContinueSetUpModelTests: XCTestCase {
 
         XCTAssertEqual(vm.visibleFeaturesMatrix[0][0], HomePage.Models.FeatureType.defaultBrowser)
         // All cases minus two since it will show only one of the surveys and no NetP card
-        XCTAssertEqual(vm.visibleFeaturesMatrix.reduce([], +).count, HomePage.Models.FeatureType.allCases.count - 2)
+        XCTAssertEqual(vm.visibleFeaturesMatrix.reduce([], +).count, HomePage.Models.FeatureType.allCases.count - 1)
     }
 
     func testWhenTogglingShowAllFeatureThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7])
 
         vm.shouldShowAllFeatures = true
 
@@ -196,7 +196,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenIsDefaultBrowserAndTogglingShowAllFeatureThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.defaultBrowser, .surveyDay7, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.defaultBrowser, .surveyDay7])
 
         capturingDefaultBrowserProvider.isDefault = true
         vm = HomePage.Models.ContinueSetUpModel.fixture(defaultBrowserProvider: capturingDefaultBrowserProvider)
@@ -212,7 +212,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenAskedToPerformActionForImportPromptThrowsThenItOpensImportWindow() {
-        let numberOfFeatures = HomePage.Models.FeatureType.allCases.count - 2
+        let numberOfFeatures = HomePage.Models.FeatureType.allCases.count - 1
         vm.shouldShowAllFeatures = true
         XCTAssertEqual(vm.visibleFeaturesMatrix.flatMap { $0 }.count, numberOfFeatures)
 
@@ -224,7 +224,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenUserHasUsedImportAndTogglingShowAllFeatureThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .importBookmarksAndPasswords, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .importBookmarksAndPasswords])
 
         capturingDataImportProvider.didImport = true
         vm = HomePage.Models.ContinueSetUpModel.fixture(dataImportProvider: capturingDataImportProvider)
@@ -246,7 +246,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenUserHasEmailProtectionEnabledThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .emailProtection, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .emailProtection])
 
         emailStorage.isEmailProtectionEnabled = true
         vm = HomePage.Models.ContinueSetUpModel.fixture(emailManager: emailManager)
@@ -262,7 +262,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenAskedToPerformActionForCookieConsentThenShowsCookiePopUp() {
-        let numberOfFeatures = HomePage.Models.FeatureType.allCases.count - 2
+        let numberOfFeatures = HomePage.Models.FeatureType.allCases.count - 1
         vm.shouldShowAllFeatures = true
         XCTAssertEqual(vm.visibleFeaturesMatrix.flatMap { $0 }.count, numberOfFeatures)
 
@@ -273,7 +273,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenUserHasCookieConsentEnabledThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .cookiePopUp, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .cookiePopUp])
 
         privacyPreferences.autoconsentEnabled = true
         vm = HomePage.Models.ContinueSetUpModel.fixture(privacyPreferences: privacyPreferences)
@@ -295,7 +295,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenUserHasDuckPlayerEnabledAndOverlayButtonNotPressedThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .duckplayer, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .duckplayer])
 
         duckPlayerPreferences.youtubeOverlayAnyButtonPressed = false
         duckPlayerPreferences.duckPlayerModeBool = true
@@ -312,7 +312,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenUserHasDuckPlayerDisabledAndOverlayButtonNotPressedThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .duckplayer, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .duckplayer])
 
         duckPlayerPreferences.youtubeOverlayAnyButtonPressed = false
         duckPlayerPreferences.duckPlayerModeBool = false
@@ -329,7 +329,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenUserHasDuckPlayerOnAlwaysAskAndOverlayButtonNotPressedThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7])
 
         duckPlayerPreferences.youtubeOverlayAnyButtonPressed = false
         duckPlayerPreferences.duckPlayerModeBool = nil
@@ -346,7 +346,7 @@ final class ContinueSetUpModelTests: XCTestCase {
     }
 
     @MainActor func testWhenUserHasDuckPlayerOnAlwaysAskAndOverlayButtonIsPressedThenCorrectElementsAreVisible() {
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .duckplayer, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .duckplayer])
 
         duckPlayerPreferences.youtubeOverlayAnyButtonPressed = true
         duckPlayerPreferences.duckPlayerModeBool = nil
@@ -398,7 +398,7 @@ final class ContinueSetUpModelTests: XCTestCase {
 
     @MainActor func testDismissedItemsAreRemovedFromVisibleMatrixAndChoicesArePersisted() {
         vm.shouldShowAllFeatures = true
-        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7, .networkProtectionBetaEndedNotice])
+        let expectedMatrix = expectedFeatureMatrixWithout(types: [.surveyDay7])
         XCTAssertEqual(expectedMatrix, vm.visibleFeaturesMatrix)
 
         vm.removeItem(for: .surveyDay0)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205553443275689/f
Tech Design URL:
CC:

**Description**:

This PR removes the temporary hardcoded beta ended message that was displayed to users who had a build without remote messaging. This functionality will be replaced in the next PR with an approach that is controllable from a JSON file in S3.

**Steps to test this PR**:
1. Reset NetP state completely
2. Turn on the NetP waitlist active and waitlist beta feature flags in the debug menu
3. Join the waitlist
4. After you join the waitlist, use the debug menu to bypass the invite code flow and let you into the beta by entering your own invite code
5. Turn the waitlist active flag off
6. Check that no new message appears in the new tab page, even after opening new tabs/windows

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
