### PR TITLE
Fix Microsoft teams links opening in macOS browser

### DIFF
--- a/DuckDuckGo/Tab/Navigation/ExternalAppSchemeHandler.swift
+++ b/DuckDuckGo/Tab/Navigation/ExternalAppSchemeHandler.swift
@@ -80,6 +80,7 @@ extension ExternalAppSchemeHandler: NavigationResponder {
         navigationAction.targetFrame?.webView?.removeFocusFromWebView()
 
         if let targetSecurityOrigin = navigationAction.targetFrame?.securityOrigin,
+           !targetSecurityOrigin.host.isEmpty,
            navigationAction.sourceFrame.securityOrigin != targetSecurityOrigin {
             return .cancel
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205558973738863/f
Tech Design URL:
CC: @mallexxx 

**Description**:

This PR fixes an issue with Microsoft teams links not opening in our browser correctly.

This issue was due to a somewhat recently added security origin check - on Teams, the target origin is blank, so the check is rejected and the navigation is cancelled.

This check now verifies that there is at least a target origin available to check before comparing it.

**Steps to test this PR**:
1. Check that openURL behaviour is otherwise working as expected
2. Install Microsoft Teams from [this link](https://www.microsoft.com/en-ca/microsoft-teams/download-app) - you don't need to have an account, you just need to have it installed so that the browser can detect it as installed
3. Check that you can visit a Teams link and open it in the app - try [this link](https://teams.live.com/meet/9327999675116?p=z1DJgLq4sYHjX8bz), but I don't know if the links have an expiration, I'm not a Teams guy 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
