### PR TITLE
Add underlying error info to the config fetch error

### DIFF
--- a/DuckDuckGo/Configuration/ConfigurationManager.swift
+++ b/DuckDuckGo/Configuration/ConfigurationManager.swift
@@ -35,6 +35,11 @@ final class ConfigurationManager {
         case bloomFilterExclusionsNotFound
         case bloomFilterExclusionsPersistenceFailed
 
+        func withUnderlyingError(_ underlyingError: Swift.Error) -> Swift.Error {
+            let nsError = self as NSError
+            return NSError(domain: nsError.domain, code: nsError.code, userInfo: [NSUnderlyingErrorKey: underlyingError])
+        }
+
     }
 
     enum Constants {
@@ -215,7 +220,7 @@ final class ConfigurationManager {
                 try await PrivacyFeatures.httpsUpgrade.persistBloomFilter(specification: spec, data: bloomFilterData)
             } catch {
                 assertionFailure("persistBloomFilter failed: \(error)")
-                throw Error.bloomFilterPersistenceFailed
+                throw Error.bloomFilterPersistenceFailed.withUnderlyingError(error)
             }
             await PrivacyFeatures.httpsUpgrade.loadData()
         }.value
@@ -230,7 +235,7 @@ final class ConfigurationManager {
             do {
                 try await PrivacyFeatures.httpsUpgrade.persistExcludedDomains(excludedDomains)
             } catch {
-                throw Error.bloomFilterExclusionsPersistenceFailed
+                throw Error.bloomFilterExclusionsPersistenceFailed.withUnderlyingError(error)
             }
             await PrivacyFeatures.httpsUpgrade.loadData()
         }.value


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199333091098016/1205566431395918/f
Tech Design URL:
CC: @brindy 

**Description**:

This PR updates the `cfgfetch` pixel to include underlying error info.

Because this PR doesn't technically add any new parameters - in this case we're using the debug pixel which has always sent underlying error info - I haven't run a privacy triage. Feel free to request one.

**Steps to test this PR**:

To test this we need to induce a failure in the ConfigurationFetcher.

1. Turn on Pixel logging via Debug -> Logging
2. Now you can either find a way to cause a real failure, or simulate a failure with the following steps by going to `ConfigurationManager.swift` and adding the following code to the top of `updateBloomFilter()`

```
let underlyingError = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)
throw Error.bloomFilterPersistenceFailed.withUnderlyingError(underlyingError)
```

After you do this, check that the pixel log contains the same basic error info that it has now, plus a new domain/code for the underlying error. Now take the underlying code to [OSStatus.com](https://osstatus.com) and verify that it matches the fake error that was added. The log should look like this:

```
2023-09-24 22:15:26.969071-0700 DuckDuckGo App Store[50987:3240610] [Pixel] m.mac.debug.cfgfetch {
    d = "DuckDuckGo_Privacy_Browser.ConfigurationManager.Error";
    e = 3;
    ud = NSCocoaErrorDomain;
    ue = 640;
}
```

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
