### PR TITLE
Pixel m_mac_user_has_pinned_tab removed

### DIFF
--- a/DuckDuckGo/PinnedTabs/Model/PinnedTabsManager.swift
+++ b/DuckDuckGo/PinnedTabs/Model/PinnedTabsManager.swift
@@ -97,12 +97,6 @@ final class PinnedTabsManager {
             }
     }
 
-    func reportUsage() {
-        if !tabCollection.tabs.isEmpty {
-            Pixel.fire(.userHasPinnedTab)
-        }
-    }
-
     // MARK: - Private
 
     private let didUnpinTabSubject = PassthroughSubject<Int, Never>()

--- a/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -56,9 +56,6 @@ final class StatisticsLoader {
                 PixelExperiment.fireDay21To27SerpPixel()
                 PixelExperiment.fireFirstSerpPixel()
                 Pixel.fire(.serp)
-                Task {
-                    await WindowControllersManager.shared.pinnedTabsManager.reportUsage()
-                }
             } else if !self.statisticsStore.isAppRetentionFiredToday {
                 self.refreshAppRetentionAtb(completion: completion)
             } else {

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -135,9 +135,6 @@ extension Pixel {
         case recentActivitySectionHidden
         case continueSetUpSectionHidden
 
-        // Pinned tabs
-        case userHasPinnedTab
-
         // Fire Button
         case fireButtonFirstBurn
         case fireButton(option: FireButtonOption)
@@ -425,10 +422,6 @@ extension Pixel.Event {
             return "m_mac.recent-activity-section-hidden"
         case .continueSetUpSectionHidden:
             return "m_mac.continue-setup-section-hidden"
-
-        // Pinned tabs
-        case .userHasPinnedTab:
-            return "m_mac_user_has_pinned_tab"
 
         // Fire Button
         case .fireButtonFirstBurn:

--- a/DuckDuckGo/Statistics/PixelParameters.swift
+++ b/DuckDuckGo/Statistics/PixelParameters.swift
@@ -132,7 +132,6 @@ extension Pixel.Event {
              .favoriteSectionHidden,
              .recentActivitySectionHidden,
              .continueSetUpSectionHidden,
-             .userHasPinnedTab,
              .fireButtonFirstBurn,
              .fireButton,
              .duckPlayerDailyUniqueView,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205208220010052/f

**Description**:
Removal of a temporary pixel named m_mac_user_has_pinned_tab

**Steps to test this PR**:
1. Enable pixel logging in Debug menu
2. Pin a tab (if you don't have a pinned tab already)
3. Trigger search action from the address bar
4. Make sure SERP site is presented
5. Verify pixel named m_mac_user_has_pinned_tab is not fired

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
