### PR TITLE
Encapsulate handling one profile at the Repository level

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDataManager.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDataManager.swift
@@ -81,7 +81,7 @@ public class DataBrokerProtectionDataManager: DataBrokerProtectionDataManaging {
             return cache.brokerProfileQueryData
         }
 
-        let queryData = database.fetchAllBrokerProfileQueryData(for: 1) // We assume one profile for now
+        let queryData = database.fetchAllBrokerProfileQueryData()
         cache.brokerProfileQueryData = queryData
         return queryData
     }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
@@ -103,8 +103,7 @@ final class DataBrokerProtectionProcessor {
             brokerUpdater.checkForUpdatesInBrokerJSONFiles()
         }
 
-        let profileId: Int64 = 1 // We assume one profile for now
-        let brokersProfileData = database.fetchAllBrokerProfileQueryData(for: profileId)
+        let brokersProfileData = database.fetchAllBrokerProfileQueryData()
         let dataBrokerOperationCollections = createDataBrokerOperationCollections(from: brokersProfileData,
                                                                                   operationType: operationType,
                                                                                   priorityDate: priorityDate,

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProfileQueryOperationManagerTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProfileQueryOperationManagerTests.swift
@@ -606,7 +606,7 @@ final class MockDatabase: DataBrokerProtectionRepository {
         }
     }
 
-    func fetchAllBrokerProfileQueryData(for profileId: Int64) -> [BrokerProfileQueryData] {
+    func fetchAllBrokerProfileQueryData() -> [BrokerProfileQueryData] {
         wasFetchAllBrokerProfileQueryDataCalled = true
         return [BrokerProfileQueryData]()
     }


### PR DESCRIPTION
## Asana task

https://app.asana.com/0/1203581873609357/1205571167278408/f

## Description

Encapsulate how we fetch the unique profile ID. Now the logic is inside the repository layer, and other parts communication with that layer do not need to care about profile IDs.