### PR TITLE
Upload .xcresult artifacts on PR test failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -174,12 +174,14 @@ jobs:
       with:
         name: ${{ matrix.flavor }}-xcodebuild.log
         path: ${{ matrix.flavor }}-xcodebuild.log
+        retention-days: 7
     - name: Upload failed xcresult
       uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: ${{ matrix.flavor }}.xcresult
         path: ${{ matrix.flavor }}.xcresult
+        retention-days: 7
 
   private-api:
     name: Private API Report
@@ -268,6 +270,7 @@ jobs:
       with:
         name: release-xcodebuild.log
         path: release-xcodebuild.log
+        retention-days: 7
 
   verify-autoconsent-bundle:
     name: 'Verify autoconsent bundle'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1205568936349841/f

**Description**:
- Adds GHA action steps to upload `.xcresult` artifact on test failure

**Steps to test this PR**:
1. Validate failing tests (here: https://github.com/duckduckgo/macos-browser/actions/runs/6308909306/job/17128322824) have `.xcresult` artifact that can be open in Xcode, and passing tests - have no 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
