### PR TITLE
fix crash in address bar selection macOS 12

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
@@ -34,6 +34,7 @@ final class AddressBarTextEditor: NSTextView {
 
     @available(macOS 12.0, *)
     override var textLayoutManager: NSTextLayoutManager? {
+        // uses NSTextLayoutManager by default in macOS 13, ignored in macOS 12
         if let textLayoutManager = super.textLayoutManager,
            !(textLayoutManager.textSelectionNavigation is AddressBarTextSelectionNavigation) {
             textLayoutManager.textSelectionNavigation = AddressBarTextSelectionNavigation(dataSource: textLayoutManager)
@@ -207,9 +208,13 @@ final class AddressBarTextEditor: NSTextView {
 
     // MARK: - Moving selection by word
 
-    @available(macOS, deprecated: 12.0, message: "Move this logic to AddressBarTextSelectionNavigation")
+    @available(macOS, deprecated: 13.0, message: "Move this logic to AddressBarTextSelectionNavigation")
     override func selectionRange(forProposedRange proposedCharRange: NSRange, granularity: NSSelectionGranularity) -> NSRange {
         let string = self.string
+        var proposedCharRange = proposedCharRange
+        if proposedCharRange.length < 0 {
+            proposedCharRange = NSRange(location: string.length(), length: 0)
+        }
         guard let selectableRange = addressBar?.stringValueWithoutSuffixRange,
               var clampedRange = Range(proposedCharRange, in: string)?.clamped(to: selectableRange) else { return proposedCharRange }
         guard !selectableRange.isEmpty else { return NSRange(selectableRange, in: string) }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1205575278721549/f

**Description**:
- fix address bar on the address bar invalid selection range

**Steps to test this PR**:
1. enter something in the address bar on macOS Monterey
2. mouse down to the right of the "– Search with DuckDuckGo" and move selection to the left -> validate there‘s no crash and selection is set to the end of the entered search term

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
