### PR TITLE
Update BSK with autofill 8.4.1

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12294,8 +12294,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = c3287c0e996e2bb620ee7d3e38d54e137f550adc;
+				kind = exactVersion;
+				version = 80.2.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "e7d516c7f7c2a4c588336afdf8bd2ac48457e1e4",
-        "version" : "80.1.0"
+        "revision" : "e955f958201a91ef353c55236361e095357e9505",
+        "version" : "80.2.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "f3eccad8647fdba2b5d180a02a0513c61375b8fb",
-        "version" : "8.4.0"
+        "revision" : "55466f10a339843cb79a27af62d5d61c030740b2",
+        "version" : "8.4.1"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "80.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "80.2.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [

--- a/LocalPackages/NetworkProtectionUI/Package.swift
+++ b/LocalPackages/NetworkProtectionUI/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "80.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "80.2.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205602928782192/1205602928782192
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.1
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/517

## Description
Updates Autofill to version [8.4.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.1).

### Autofill 8.4.1 release notes
## What's Changed
* Precompile regexes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/382
* Add perf tests by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/383
* deps: remove deprecated content-scope-utils by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/384
* Update dependencies by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/368
* Fix perf regressions by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/385


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.4.0...8.4.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).