### PR TITLE
Fixes connection reassertion and provides a mechanism to make the tester simulate a failure

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12295,7 +12295,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 91a44e4ca50d4ffe27dd15ff8ab81a6aab0dac12;
+				revision = b36c82700cd47716ae4401757e07c848496d040d;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -128,7 +128,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
       "state" : {
         "revision" : "4684440d03304e7638a2c8086895367e90987463",
         "version" : "1.2.1"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1205601368549677/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/518
iOS PR: https://github.com/duckduckgo/iOS/pull/2050

**Description**:

This is a PR I'm opening targetting the parent PR with suggested changes.

This PR:
- Fixes the reassertion logic
- Proposes a different mechanism to make the tester fail and recover that mimicks more closely how it'll look like in real life.

## Testing

1. Start Network Protection
2. If this is the first time launching, agree to any notifications prompt.
3. Go to the Debug menu and simulate a connection interruption (Debug -> Network Protection -> Simulate Failure -> Connection Interruption
4. **Observe the interruption notification**
5. Go back to Network Protection Status View
6. **Observe the status is reconnecting**
7. Wait for the reconnected notification.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
