### PR TITLE
Opt-out pixels improvements

### DIFF
--- a/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -115,29 +115,31 @@ public class DataBrokerProtectionPixelsHandler: EventMapping<DataBrokerProtectio
             case .error(let error, _):
                 Pixel.fire(.debug(event: .dataBrokerProtectionError, error: error), withAdditionalParameters: event.params)
             case .optOutStart:
-                Pixel.fire(.debug(event: .optOutStart), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutStart, withAdditionalParameters: event.params)
             case .optOutEmailGenerate:
-                Pixel.fire(.debug(event: .optOutEmailGenerate), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutEmailGenerate, withAdditionalParameters: event.params)
             case .optOutCaptchaParse:
-                Pixel.fire(.debug(event: .optOutCaptchaParse), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutCaptchaParse, withAdditionalParameters: event.params)
             case .optOutCaptchaSend:
-                Pixel.fire(.debug(event: .optOutCaptchaSend), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutCaptchaSend, withAdditionalParameters: event.params)
             case .optOutCaptchaSolve:
-                Pixel.fire(.debug(event: .optOutCaptchaSolve), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutCaptchaSolve, withAdditionalParameters: event.params)
             case .optOutSubmit:
-                Pixel.fire(.debug(event: .optOutSubmit), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutSubmit, withAdditionalParameters: event.params)
             case .optOutEmailReceive:
-                Pixel.fire(.debug(event: .optOutEmailReceive), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutEmailReceive, withAdditionalParameters: event.params)
             case .optOutEmailConfirm:
-                Pixel.fire(.debug(event: .optOutEmailConfirm), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutEmailConfirm, withAdditionalParameters: event.params)
             case .optOutValidate:
-                Pixel.fire(.debug(event: .optOutValidate), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutValidate, withAdditionalParameters: event.params)
             case .optOutFinish:
-                Pixel.fire(.debug(event: .optOutFinish), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutFinish, withAdditionalParameters: event.params)
+            case .optOutSubmitSuccess:
+                Pixel.fire(.optOutSubmitSuccess, withAdditionalParameters: event.params)
             case .optOutSuccess:
-                Pixel.fire(.debug(event: .optOutSuccess), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutSuccess, withAdditionalParameters: event.params)
             case .optOutFailure:
-                Pixel.fire(.debug(event: .optOutFailure), withAdditionalParameters: event.params)
+                Pixel.fire(.optOutFailure, withAdditionalParameters: event.params)
             }
         }
     }

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -164,6 +164,26 @@ extension Pixel {
         case setnewHomePage
 
         case dailyPixel(Event, isFirst: Bool)
+#if DBP
+        // SLO and SLI Pixels: https://app.asana.com/0/1203581873609357/1205337273100857/f
+
+        // Stage Pixels
+        case optOutStart
+        case optOutEmailGenerate
+        case optOutCaptchaParse
+        case optOutCaptchaSend
+        case optOutCaptchaSolve
+        case optOutSubmit
+        case optOutEmailReceive
+        case optOutEmailConfirm
+        case optOutValidate
+        case optOutFinish
+
+        // Process Pixels
+        case optOutSubmitSuccess
+        case optOutSuccess
+        case optOutFailure
+#endif
 
         enum Debug {
 
@@ -307,26 +327,9 @@ extension Pixel {
             case invalidPayload(Configuration)
 
             case burnerTabMisplaced
+
 #if DBP
             case dataBrokerProtectionError
-
-            // SLO and SLI Pixels: https://app.asana.com/0/1203581873609357/1205337273100857/f
-
-            // Stage Pixels
-            case optOutStart
-            case optOutEmailGenerate
-            case optOutCaptchaParse
-            case optOutCaptchaSend
-            case optOutCaptchaSolve
-            case optOutSubmit
-            case optOutEmailReceive
-            case optOutEmailConfirm
-            case optOutValidate
-            case optOutFinish
-
-            // Process Pixels
-            case optOutSuccess
-            case optOutFailure
 #endif
         }
 
@@ -478,9 +481,25 @@ extension Pixel.Event {
 
         case .dailyPixel(let pixel, isFirst: let isFirst):
             return pixel.name + (isFirst ? "_d" : "_c")
+#if DBP
+            // Stage Pixels
+        case .optOutStart: return "dbp_macos_optout_stage_start"
+        case .optOutEmailGenerate: return "dbp_macos_optout_stage_email-generate"
+        case .optOutCaptchaParse: return "dbp_macos_optout_stage_captcha-parse"
+        case .optOutCaptchaSend: return "dbp_macos_optout_stage_captcha-send"
+        case .optOutCaptchaSolve: return "dbp_macos_optout_stage_captcha-solve"
+        case .optOutSubmit: return "dbp_macos_optout_stage_submit"
+        case .optOutEmailReceive: return "dbp_macos_optout_stage_email-receive"
+        case .optOutEmailConfirm: return "dbp_macos_optout_stage_email-confirm"
+        case .optOutValidate: return "dbp_macos_optout_stage_validate"
+        case .optOutFinish: return "dbp_macos_optout_stage_finish"
 
+            // Process Pixels
+        case .optOutSubmitSuccess: return "dbp_macos_optout_process_submit-success"
+        case .optOutSuccess: return "dbp_macos_optout_process_success"
+        case .optOutFailure: return "dbp_macos_optout_process_failure"
+#endif
         }
-
     }
 }
 
@@ -733,24 +752,8 @@ extension Pixel.Event.Debug {
         case .invalidPayload(let configuration): return "m_d_\(configuration.rawValue)_invalid_payload".lowercased()
 
         case .burnerTabMisplaced: return "burner_tab_misplaced"
-
 #if DBP
         case .dataBrokerProtectionError: return "data_broker_error"
-        // Stage Pixels
-        case .optOutStart: return "dbp.macos.optout.stage.start"
-        case .optOutEmailGenerate: return "dbp.macos.optout.stage.email-generate"
-        case .optOutCaptchaParse: return "dbp.macos.optout.stage.captcha-parse"
-        case .optOutCaptchaSend: return "dbp.macos.optout.stage.captcha-send"
-        case .optOutCaptchaSolve: return "dbp.macos.optout.stage.captcha-solve"
-        case .optOutSubmit: return "dbp.macos.optout.stage.submit"
-        case .optOutEmailReceive: return "dbp.macos.optout.stage.email-receive"
-        case .optOutEmailConfirm: return "dbp.macos.optout.stage.email-confirm"
-        case .optOutValidate: return "dbp.macos.optout.stage.validate"
-        case .optOutFinish: return "dbp.macos.optout.stage.finish"
-
-        // Process Pixels
-        case .optOutSuccess: return "dbp.macos.optout.process.success"
-        case .optOutFailure: return "dbp.macos.optout.process.failure"
 #endif
         }
     }

--- a/DuckDuckGo/Statistics/PixelParameters.swift
+++ b/DuckDuckGo/Statistics/PixelParameters.swift
@@ -153,6 +153,22 @@ extension Pixel.Event {
              .disableHomeButton,
              .setnewHomePage:
             return nil
+#if DBP
+        case .optOutStart,
+            .optOutEmailGenerate,
+            .optOutCaptchaParse,
+            .optOutCaptchaSend,
+            .optOutCaptchaSolve,
+            .optOutSubmit,
+            .optOutEmailReceive,
+            .optOutEmailConfirm,
+            .optOutValidate,
+            .optOutFinish,
+            .optOutSubmitSuccess,
+            .optOutSuccess,
+            .optOutFailure:
+          return nil
+#endif
         }
     }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OptOutOperation.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OptOutOperation.swift
@@ -109,6 +109,7 @@ final class OptOutOperation: DataBrokerOperation {
         } else {
             await webViewHandler?.finish() // If we executed all steps we release the web view
             stageCalculator?.fireOptOutValidate()
+            stageCalculator?.fireOptOutSubmitSuccess()
             complete(())
         }
     }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionPixels.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionPixels.swift
@@ -45,13 +45,13 @@ final class DataBrokerProtectionStageDurationCalculator {
         let durationSinceLastStage = now.timeIntervalSince(lastStateTime) * 1000
         self.lastStateTime = now
 
-        return durationSinceLastStage
+        return durationSinceLastStage.rounded(.towardZero)
     }
 
     /// Returned in milliseconds
     func durationSinceStartTime() -> Double {
         let now = Date()
-        return now.timeIntervalSince(startTime) * 1000
+        return (now.timeIntervalSince(startTime) * 1000).rounded(.towardZero)
     }
 
     func fireOptOutStart() {
@@ -90,6 +90,10 @@ final class DataBrokerProtectionStageDurationCalculator {
         handler.fire(.optOutValidate(dataBroker: dataBroker, attemptId: attemptId, duration: durationSinceLastStage()))
     }
 
+    func fireOptOutSubmitSuccess() {
+        handler.fire(.optOutSubmitSuccess(dataBroker: dataBroker, attemptId: attemptId, duration: durationSinceLastStage()))
+    }
+
     func fireOptOutFailure() {
         handler.fire(.optOutFailure(dataBroker: dataBroker, attemptId: attemptId, duration: durationSinceStartTime()))
     }
@@ -118,6 +122,7 @@ public enum DataBrokerProtectionPixels {
     case optOutFinish(dataBroker: String, attemptId: UUID, duration: Double)
 
     // Process Pixels
+    case optOutSubmitSuccess(dataBroker: String, attemptId: UUID, duration: Double)
     case optOutSuccess(dataBroker: String, attemptId: UUID, duration: Double)
     case optOutFailure(dataBroker: String, attemptId: UUID, duration: Double)
 }
@@ -125,16 +130,6 @@ public enum DataBrokerProtectionPixels {
 public extension DataBrokerProtectionPixels {
 
     var params: [String: String] {
-        var pixelParams = internalParams
-
-        if let appVersion = AppVersionProvider().appVersion() {
-            pixelParams[Consts.appVersionParamKey] = appVersion
-        }
-
-        return pixelParams
-    }
-
-    private var internalParams: [String: String] {
         switch self {
         case .error(let error, let dataBroker):
             if case let .actionFailed(actionID, message) = error {
@@ -164,6 +159,8 @@ public extension DataBrokerProtectionPixels {
         case .optOutValidate(let dataBroker, let attemptId, let duration):
             return [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration)]
         case .optOutFinish(let dataBroker, let attemptId, let duration):
+            return [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration)]
+        case .optOutSubmitSuccess(let dataBroker, let attemptId, let duration):
             return [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration)]
         case .optOutSuccess(let dataBroker, let attemptId, let duration):
             return [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration)]

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -576,6 +576,8 @@ public class MockDataBrokerProtectionPixelsHandler: EventMapping<DataBrokerProte
                 print("PIXEL: optOutValidate")
             case .optOutFinish:
                 print("PIXEL: optOutFinish")
+            case .optOutSubmitSuccess:
+                print("PIXEL: optOutSubmitSuccess")
             case .optOutSuccess:
                 print("PIXEL: optOutSuccess")
             case .optOutFailure:


### PR DESCRIPTION
## Asana
https://app.asana.com/0/1199230911884351/1205337273100857/f

## Description
This pull request adds the following changes:
- Removes the opt-out pixels from the Pixel.Debug type, this is because we do not want the send the `m_mac_debug_` prefix.
- Changes the `.` to `_` in the Pixel names
- Removes the decimal place on the duration param (from `456.1234` to `456`)
- Adds the new `submit-success` Pixel