### PR TITLE
Fix crash in FF bookmarks import

### DIFF
--- a/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -182,7 +182,7 @@ final class LocalBookmarkStore: BookmarkStore {
                 let processedErrors = CoreDataErrorsParser.parse(error: innerError as NSError)
 
                 Pixel.fire(.debug(event: .bookmarksSaveFailed, error: error),
-                               withAdditionalParameters: processedErrors.errorPixelParameters)
+                           withAdditionalParameters: processedErrors.errorPixelParameters)
             } else {
                 Pixel.fire(.debug(event: .bookmarksSaveFailed, error: localError))
             }
@@ -191,7 +191,7 @@ final class LocalBookmarkStore: BookmarkStore {
             let processedErrors = CoreDataErrorsParser.parse(error: error)
 
             Pixel.fire(.debug(event: .bookmarksSaveFailed, error: error),
-                           withAdditionalParameters: processedErrors.errorPixelParameters)
+                       withAdditionalParameters: processedErrors.errorPixelParameters)
         }
     }
 

--- a/DuckDuckGo/DataImport/Bookmarks/Firefox/FirefoxBookmarksReader.swift
+++ b/DuckDuckGo/DataImport/Bookmarks/Firefox/FirefoxBookmarksReader.swift
@@ -195,7 +195,7 @@ final class FirefoxBookmarksReader {
             moz_bookmarks.parent
         FROM
             moz_bookmarks
-        LEFT JOIN
+        INNER JOIN
             moz_places
         ON
             moz_bookmarks.fk = moz_places.id


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1205581432534881/f

**Description**:
- Fix GRDB bookmark row init crash due to missing (`NULL`) values in the right side of the LEFT JOIN

**Steps to test this PR**:
1. Validate FF import bookmarks works

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
