### PR TITLE
Upload .xcresult artifacts on PR test failure

### DIFF
--- a/UnitTests/HomePage/DataImportProviderTests.swift
+++ b/UnitTests/HomePage/DataImportProviderTests.swift
@@ -80,7 +80,7 @@ final class DataImportProviderTests: XCTestCase {
     func testWhenImportedAccountsDetectedAndNoImportedBookmarksDetectableAndNoSuccessImportDidImportIsTrue() {
         vault.storedAccounts = importedAccounts
 
-        XCTAssertFalse(provider.didImport)
+        XCTAssertTrue(provider.didImport)
     }
 
     func testWhenImportedNotesetectedAndNoImportedBookmarksDetectableAndNoSuccessImportThenDidImportIsTrue() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1205568936349841/f

**Description**:
- Adds GHA action steps to upload `.xcresult` artifact on test failure

**Steps to test this PR**:
1. Validate failing tests (here: https://github.com/duckduckgo/macos-browser/actions/runs/6406001434/job/17389739075?pr=1715) have `.xcresult` artifact that can be open in Xcode, and passing tests - have no 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
