### PR TITLE
remove deduplication of "Passwords found"

### DIFF
--- a/DuckDuckGo/DataImport/Logins/CSV/CSVImporter.swift
+++ b/DuckDuckGo/DataImport/Logins/CSV/CSVImporter.swift
@@ -100,16 +100,11 @@ final class CSVImporter: DataImporter {
     }
 
     func totalValidLogins() -> Int {
-        guard let fileContents = try? String(contentsOf: fileURL, encoding: .utf8) else {
-            return 0
-        }
-
-        var seen: [String: Bool] = [:]
+        guard let fileContents = try? String(contentsOf: fileURL, encoding: .utf8) else { return 0 }
 
         let logins = Self.extractLogins(from: fileContents, defaultColumnPositions: self.defaultColumnPositions)
-        let uniqueLogins = logins.filter { seen.updateValue(true, forKey: "\($0.url)-\($0.username)") == nil }
 
-        return uniqueLogins.count
+        return logins.count
     }
 
     static func extractLogins(from fileContents: String,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205657302703973/f

**Description**:
- Removed deduplication in password import number of "Passwords found"

**Steps to test this PR**:
1. Make a passwords CSV with at least 1 duplicated record of host+username
2. Import passwords, note number of "Passwords found" when the file is chosen, it should match the number of "imported passwords"

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
