### PR TITLE
Update preferred run date when adding scans for new broker

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProtectionBrokerUpdater.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProtectionBrokerUpdater.swift
@@ -154,7 +154,7 @@ struct DataBrokerProtectionBrokerUpdater {
         let profileQueryIDs = profileQueries.compactMap({ $0.id })
 
         for profileQueryId in profileQueryIDs {
-            try vault.save(brokerId: brokerId, profileQueryId: profileQueryId, lastRunDate: nil, preferredRunDate: nil)
+            try vault.save(brokerId: brokerId, profileQueryId: profileQueryId, lastRunDate: nil, preferredRunDate: Date())
         }
     }
 

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionUpdaterTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionUpdaterTests.swift
@@ -121,6 +121,7 @@ final class DataBrokerProtectionUpdaterTests: XCTestCase {
             let sut = DataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault)
             repository.lastRunDate = nil
             resources.brokersList = [.init(id: 1, name: "Broker", steps: [Step](), version: "1.0.0", schedulingConfig: .mock)]
+            vault.profileQueries = [.mock]
 
             sut.checkForUpdatesInBrokerJSONFiles()
 
@@ -128,6 +129,10 @@ final class DataBrokerProtectionUpdaterTests: XCTestCase {
             XCTAssertTrue(resources.wasFetchBrokerFromResourcesFilesCalled)
             XCTAssertFalse(vault.wasBrokerUpdateCalled)
             XCTAssertTrue(vault.wasBrokerSavedCalled)
+            XCTAssertTrue(areDatesEqualIgnoringSeconds(
+                date1: Date(),
+                date2: vault.lastPreferredRunDateOnScan)
+            )
         } else {
             XCTFail("Mock vault issue")
         }

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -412,6 +412,8 @@ final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecureVault
     var shouldReturnNewVersionBroker = false
     var wasBrokerUpdateCalled = false
     var wasBrokerSavedCalled = false
+    var lastPreferredRunDateOnScan: Date?
+    var profileQueries = [ProfileQuery]()
 
     typealias DatabaseProvider = SecureStorageDatabaseProviderMock
 
@@ -423,6 +425,8 @@ final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecureVault
         shouldReturnNewVersionBroker = false
         wasBrokerUpdateCalled = false
         wasBrokerSavedCalled = false
+        lastPreferredRunDateOnScan = nil
+        profileQueries.removeAll()
     }
 
     func save(profile: DataBrokerProtectionProfile) throws -> Int64 {
@@ -469,11 +473,11 @@ final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecureVault
     }
 
     func fetchAllProfileQueries(for profileId: Int64) throws -> [ProfileQuery] {
-        return [ProfileQuery]()
+        return profileQueries
     }
 
     func save(brokerId: Int64, profileQueryId: Int64, lastRunDate: Date?, preferredRunDate: Date?) throws {
-
+        lastPreferredRunDateOnScan = preferredRunDate
     }
 
     func updatePreferredRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64) throws {


### PR DESCRIPTION
## Task

https://app.asana.com/0/1203581873609357/1205662485070281/f

## Description

When adding a new broker, we need to set the `preferredRunDate` to the current date so it starts in the next scheduler run. Previously, it was `nil` which was an error because the scan was never going to run.