### PR TITLE
Fix crash with wrong constraint

### DIFF
--- a/DuckDuckGo/Main/View/MainWindowController.swift
+++ b/DuckDuckGo/Main/View/MainWindowController.swift
@@ -168,8 +168,7 @@ final class MainWindowController: NSWindowController {
         let constraints = tabBarViewController.view.addConstraints(to: newParentView, [
             .leading: .leading(),
             .trailing: .trailing(),
-            .top: .top(),
-            .height: .const(tabBarViewController.view.frame.height)
+            .top: .top()
         ])
         NSLayoutConstraint.activate(constraints)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205677294210571/f

**Description**:
Fix issue that was causing Xcode to crash when the fire button was clicked

**Steps to test this PR**:
1. Open app from Xcode
2. Use Fire button
3. Check if there's no regression to [this task](https://app.asana.com/0/1199230911884351/1205442101039758/f)

