### PR TITLE
Run swiftlint also on pushes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,8 +11,6 @@ jobs:
 
     name: SwiftLint
 
-    if: github.event_name == 'pull_request'
-
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205237866452338/1205684028849868/f

**Description**:
Run swiftlint on pushes to satisfy the requirement of calling Asana integration (that needs all jobs to run).
This change follows how iOS workflow is set up - it also runs swiftlint on pushes and pull requests.

**Steps to test this PR**:
No steps to test, but [here's a workflow re-run](https://github.com/duckduckgo/macos-browser/actions/runs/6460999101/attempts/2) that should trigger "Close Asana Task" job, but didn't, because swiftlint wasn't run (because it was disabled on pushes). For reference, see the relevant part of the iOS workflow [here](https://github.com/duckduckgo/iOS/blob/develop/.github/workflows/pr.yml#L9-L20).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
