### PR TITLE
implement options visibility management

### DIFF
--- a/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/ManagementDialogModel.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/ManagementDialogModel.swift
@@ -22,7 +22,7 @@ import Combine
 public protocol ManagementDialogModelDelegate: AnyObject {
     var isUnifiedFavoritesEnabled: Bool { get set }
 
-    func recoverDevice(using recoveryCode: String)
+    func recoverDevice(using recoveryCode: String, isActiveDevice: Bool)
     func saveRecoveryPDF()
     func turnOffSync()
     func updateDeviceName(_ name: String)

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/Dialogs/RecoverAccountView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/Dialogs/RecoverAccountView.swift
@@ -23,6 +23,7 @@ struct RecoverAccountView: View {
     @EnvironmentObject var model: ManagementDialogModel
     @EnvironmentObject var recoveryCodeModel: RecoveryCodeViewModel
     let isRecovery: Bool
+    let isActiveDevice: Bool
     var instructionText: String {
         if isRecovery {
             return UserText.recoverSyncedDataExplanation
@@ -38,7 +39,7 @@ struct RecoverAccountView: View {
     }
 
     func submitRecoveryCode() {
-        model.delegate?.recoverDevice(using: recoveryCodeModel.recoveryCode)
+        model.delegate?.recoverDevice(using: recoveryCodeModel.recoveryCode, isActiveDevice: isActiveDevice)
     }
 
     var body: some View {

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/ManagementDialog.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/ManagementDialog.swift
@@ -55,9 +55,9 @@ public struct ManagementDialog: View {
         Group {
             switch model.currentDialog {
             case .recoverAccount:
-                RecoverAccountView(isRecovery: true)
+                RecoverAccountView(isRecovery: true, isActiveDevice: false)
             case .manuallyEnterCode:
-                RecoverAccountView(isRecovery: false)
+                RecoverAccountView(isRecovery: false, isActiveDevice: true)
             case .deviceSynced(let devices, let shouldShowOptions):
                 DeviceSyncedView(devices: devices, shouldShowOptions: shouldShowOptions, isSingleDevice: false)
             case .firstDeviceSetup:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205692136545021/f

**Description**: Make option visible in sync set up only for second active device

**Steps to test this PR**:
1. When creating an account through single device setup, check options are NOT shown.
2.  When inserting code from another (unconnected) device check the options are shown. 
4. When logging into an account by inserting code from another (connected) device check that if the device is the second the options are shown, if not second check they are not shown
5. When logging into an account by scanning the QR code (or copying code) with/into another device check options are NEVER shown  

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
