### PR TITLE
Add retry option for CCF operations

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/CCF/ActionsHandler.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/CCF/ActionsHandler.swift
@@ -27,6 +27,16 @@ final class ActionsHandler {
         self.step = step
     }
 
+    func currentAction() -> Action? {
+        guard let lastExecutedActionIndex = self.lastExecutedActionIndex else { return nil }
+
+        if lastExecutedActionIndex < step.actions.count {
+            return step.actions[lastExecutedActionIndex]
+        } else {
+            return nil
+        }
+    }
+
     func nextAction() -> Action? {
         guard let lastExecutedActionIndex = self.lastExecutedActionIndex else {
             // If last executed action index is nil. Means we didn't execute any action, so we return the first action.

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OptOutOperation.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OptOutOperation.swift
@@ -38,6 +38,7 @@ final class OptOutOperation: DataBrokerOperation {
     var stageCalculator: DataBrokerProtectionStageDurationCalculator?
     private let operationAwaitTime: TimeInterval
     let shouldRunNextStep: () -> Bool
+    var retriesCountOnError: Int = 0
 
     init(privacyConfig: PrivacyConfigurationManaging,
          prefs: ContentScopeProperties,
@@ -97,6 +98,7 @@ final class OptOutOperation: DataBrokerOperation {
     }
 
     func executeNextStep() async {
+        retriesCountOnError = 0 // We reset the retries on error when it is successful
         os_log("OPTOUT Waiting %{public}f seconds...", log: .action, operationAwaitTime)
         try? await Task.sleep(nanoseconds: UInt64(operationAwaitTime) * 1_000_000_000)
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/ScanOperation.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/ScanOperation.swift
@@ -38,13 +38,14 @@ final class ScanOperation: DataBrokerOperation {
     var stageCalculator: DataBrokerProtectionStageDurationCalculator?
     private let operationAwaitTime: TimeInterval
     let shouldRunNextStep: () -> Bool
+    var retriesCountOnError: Int = 0
 
     init(privacyConfig: PrivacyConfigurationManaging,
          prefs: ContentScopeProperties,
          query: BrokerProfileQueryData,
          emailService: EmailServiceProtocol = EmailService(),
          captchaService: CaptchaServiceProtocol = CaptchaService(),
-         operationAwaitTime: TimeInterval = 1,
+         operationAwaitTime: TimeInterval = 3,
          shouldRunNextStep: @escaping () -> Bool
     ) {
         self.privacyConfig = privacyConfig
@@ -92,6 +93,7 @@ final class ScanOperation: DataBrokerOperation {
     }
 
     func executeNextStep() async {
+        retriesCountOnError = 0 // We reset the retries on error when it is successful
         os_log("SCAN Waiting %{public}f seconds...", log: .action, operationAwaitTime)
 
         try? await Task.sleep(nanoseconds: UInt64(operationAwaitTime) * 1_000_000_000)


### PR DESCRIPTION
## Asana
https://app.asana.com/0/1203581873609357/1205476538384291/f

## Description
Adds the possibility for CCF actions to be retried on error instead of failing. For the moment, we are only doing it for the `GetCaptchaInfoAction` but it could be done for other ones too.

## Steps to test
You could add some custom code to run the first action on the scan (navigate), set the retries count to 3, and see that the action is being retried instead of failing the whole scan. You can also add some code to make it pass after the last try to see the count gets reset to 0.