### PR TITLE
Append build number to metricKit crash version

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14210,8 +14210,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 24f601a50b1437b0adc68873ed9bea6f40ae513f;
+				kind = exactVersion;
+				version = 81.4.0;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "24f601a50b1437b0adc68873ed9bea6f40ae513f"
+        "revision" : "4cf8e857cd78e15c64ba37839634970fc675947c",
+        "version" : "81.4.0"
       }
     },
     {

--- a/LocalPackages/Account/Package.swift
+++ b/LocalPackages/Account/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Account"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "81.3.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "81.4.0"),
         .package(path: "../Purchase")
     ],
     targets: [

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", revision: "24f601a50b1437b0adc68873ed9bea6f40ae513f"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "81.4.0"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", revision: "24f601a50b1437b0adc68873ed9bea6f40ae513f"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "81.4.0"),
         .package(path: "../XPC"),
         .package(path: "../SwiftUIExtensions")
     ],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1205691485107802/f

**Description**:

See: [Comment by Lorenzo on iOS Weekly Maintenance](https://app.asana.com/0/0/1205671501750315/1205697291522645/f) for context.

The crashes are not shown in the Crash per launches/version board because the format of the version we report with the crash pixel has changed. We used to report the full version, including the build number (so, 4 numbers in the version), but starting from 7.92.0 it looks like we report only 3 numbers. Since we still send the full version number for Launches (ml.ios.*), the query fails.
It’s related to this PR: https://github.com/duckduckgo/iOS/pull/2046.
We can monitor crashes for 7.92.0 in Kibana.

**Steps to test this PR**:
1. Run the app via Xcode, and take note of the current app version
2. Now kill the app via Xcode 🙂 (this is so that the app will record a crash metric in step 4, it won't do so if a debugger is attached)
3. Open the app directly, without launching it from Xcode
4. Go to the Debug menu and tap "Crash (fatal error)”
5. Before launching the app again, change the version number using ./scripts/set_version.sh to some other value, it's not important what it is as long as it's different
6. Launch the app via Xcode
7. Check that you see that the crash pixel m_d_crash has fired in the Xcode console logs, and that it contains the appVersion parameter set to the original app version, before you changed it in step 5 **with the build number (formatted x.x.x.x)**

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
