### PR TITLE
DBP: Fix issue with preferredRunDate

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OperationPreferredDateCalculator.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OperationPreferredDateCalculator.swift
@@ -49,7 +49,11 @@ struct OperationPreferredDateCalculator {
             newDate = Date().addingTimeInterval(schedulingConfig.confirmOptOutScan.hoursToSeconds)
         }
 
-        return returnMostRecentDate(newDate, currentPreferredRunDate)
+        if let newDate = newDate {
+            return returnMostRecentDate(newDate, currentPreferredRunDate)
+        } else {
+            return nil
+        }
     }
 
     func dateForOptOutOperation(currentPreferredRunDate: Date?,
@@ -81,7 +85,11 @@ struct OperationPreferredDateCalculator {
             newDate = nil
         }
 
-        return returnMostRecentDate(newDate, currentPreferredRunDate)
+        if let newDate = newDate {
+            return returnMostRecentDate(newDate, currentPreferredRunDate)
+        } else {
+            return nil
+        }
     }
 
     private func returnMostRecentDate(_ date1: Date?, _ date2: Date?) -> Date? {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/OperationPreferredDateCalculatorTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/OperationPreferredDateCalculatorTests.swift
@@ -59,7 +59,7 @@ final class OperationPreferredDateCalculatorTests: XCTestCase {
 
         let calculator = OperationPreferredDateCalculator()
 
-        let actualScanDate = try calculator.dateForScanOperation(currentPreferredRunDate: nil,
+        let actualScanDate = try calculator.dateForScanOperation(currentPreferredRunDate: Date(),
                                                                  historyEvents: historyEvents,
                                                                  extractedProfileID: nil,
                                                                  schedulingConfig: schedulingConfig,
@@ -490,7 +490,26 @@ final class OperationPreferredDateCalculatorTests: XCTestCase {
         XCTAssertTrue(areDatesEqualIgnoringSeconds(date1: expectedOptOutDate, date2: actualOptOutDate))
     }
 
-    func testOptOutConfirmed_thenOptOutIsNil() throws {
+    func testOptOutConfirmedWithCurrentPreferredDate_thenOptOutIsNil() throws {
+        let expectedOptOutDate: Date? = nil
+
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 1,
+                         brokerId: 1,
+                         profileQueryId: 1,
+                         type: .optOutConfirmed)]
+
+        let calculator = OperationPreferredDateCalculator()
+
+        let actualOptOutDate = try calculator.dateForOptOutOperation(currentPreferredRunDate: Date(),
+                                                                     historyEvents: historyEvents,
+                                                                     extractedProfileID: nil,
+                                                                     schedulingConfig: schedulingConfig)
+
+        XCTAssertTrue(areDatesEqualIgnoringSeconds(date1: expectedOptOutDate, date2: actualOptOutDate))
+    }
+
+    func testOptOutConfirmedWithoutCurrentPreferredDate_thenOptOutIsNil() throws {
         let expectedOptOutDate: Date? = nil
 
         let historyEvents = [
@@ -509,7 +528,26 @@ final class OperationPreferredDateCalculatorTests: XCTestCase {
         XCTAssertTrue(areDatesEqualIgnoringSeconds(date1: expectedOptOutDate, date2: actualOptOutDate))
     }
 
-    func testOptOutRequested_thenOptOutIsNil() throws {
+    func testOptOutRequestedWithCurrentPreferredDate_thenOptOutIsNil() throws {
+        let expectedOptOutDate: Date? = nil
+
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 1,
+                         brokerId: 1,
+                         profileQueryId: 1,
+                         type: .optOutRequested)]
+
+        let calculator = OperationPreferredDateCalculator()
+
+        let actualOptOutDate = try calculator.dateForOptOutOperation(currentPreferredRunDate: Date(),
+                                                                     historyEvents: historyEvents,
+                                                                     extractedProfileID: nil,
+                                                                     schedulingConfig: schedulingConfig)
+
+        XCTAssertTrue(areDatesEqualIgnoringSeconds(date1: expectedOptOutDate, date2: actualOptOutDate))
+    }
+
+    func testOptOutRequestedWithoutCurrentPreferredDate_thenOptOutIsNil() throws {
         let expectedOptOutDate: Date? = nil
 
         let historyEvents = [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1205731619649198/f

**Description**:
OptOut operations were not set to nil after they were ran

**Steps to test this PR**:
([Prepare the database](https://app.asana.com/0/1204586965688315/1205631383946751/f) to be visible before doing this)
1. Run the scan on a query that has results
2. Let the opt-out run
3. Check if the opt-out operation preferredRunDate is set to nil as it should
