### PR TITLE
Update BSK with autofill 9.0.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14066,8 +14066,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 191cf182eed2f515a8f63a2cc6134233314f5801;
+				kind = exactVersion;
+				version = 82.0.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "dd595d952e0076a7a01d086ed2424838dcd985af",
-        "version" : "82.0.0"
+        "revision" : "8f7a94a70812862203955b3d2bbb909420fa55dd",
+        "version" : "82.0.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "6dd7d696d4e666cedb2f1890a46fe53615226646",
-        "version" : "8.4.2"
+        "revision" : "c8e895c8fd50dc76e8d8dc827a636ad77b7f46ff",
+        "version" : "9.0.0"
       }
     },
     {

--- a/LocalPackages/Account/Package.swift
+++ b/LocalPackages/Account/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Account"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.0.1"),
         .package(path: "../Purchase")
     ],
     targets: [

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.0.1"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions")
     ],

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.0.1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205747234047385/1205747234047385
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.0.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/537

## Description
Updates Autofill to version [9.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.0.0).

### Autofill 9.0.0 release notes
## What's Changed
* Set up in-context signup for Android by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/397


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.4.2...9.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).