### PR TITLE
Move scheduler call to a background thread

### DIFF
--- a/DuckDuckGo/AppDelegate/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate/AppDelegate.swift
@@ -221,7 +221,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
 #endif
 
 #if DBP
-        DataBrokerProtectionManager.shared.runOperationsAndStartSchedulerIfPossible()
+        DispatchQueue.global(qos: .background).async {
+            DataBrokerProtectionManager.shared.runOperationsAndStartSchedulerIfPossible()
+        }
 #endif
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1205747491352618/f

**Description**:
Move the initial call for the scheduler to a background thread

**Steps to test this PR**:
1. Start the app, do a scan
2. Once you have the results, force close the app
3. Run the app again, wait for the operations to start
4. Check if the operations are running (I suggest forcing the showWebView to true in the `runOperationsAndStartSchedulerIfPossible` function)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
