### PR TITLE
Add toggling of NetP Notifications to iOS

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14338,8 +14338,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = f2a5d102da34842b3ef02c876a1a539648bd5930;
+				kind = exactVersion;
+				version = 82.1.0;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "f2a5d102da34842b3ef02c876a1a539648bd5930"
+        "revision" : "71e916d070cedcba9ccb3ce9431797260bf5cbea",
+        "version" : "82.1.0"
       }
     },
     {
@@ -128,7 +129,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
         "revision" : "4684440d03304e7638a2c8086895367e90987463",
         "version" : "1.2.1"

--- a/LocalPackages/Account/Package.swift
+++ b/LocalPackages/Account/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Account"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "f2a5d102da34842b3ef02c876a1a539648bd5930"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.1.0"),
         .package(path: "../Purchase")
     ],
     targets: [

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", revision: "f2a5d102da34842b3ef02c876a1a539648bd5930"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.1.0"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.0.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "82.1.0"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205768725084797/f
BSK: https://github.com/duckduckgo/BrowserServicesKit/pull/541

**Description**:
These changes are for iOS and doesn’t include any logical changes for macOS. Just creates a some classes that need to be injected and are currently not on macOS.

**Steps to test this PR**:
1. CI should be enough but you can try to build this manually as a sanity check. Have a look at the BSK PR first perhaps to get the idea.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
