### PR TITLE
Only show DBP for US users

### DIFF
--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -335,6 +335,10 @@ final class MoreOptionsMenu: NSMenu {
             regionCode = Locale.current.regionCode
         }
 
+        #if DEBUG // Always assume US for debug builds
+        regionCode = "US"
+        #endif
+
         // Only show Private Information Removal (DBP) for US based users
         if (regionCode ?? "US") == "US" {
             let dataBrokerProtectionItem = NSMenuItem(title: UserText.dataBrokerProtectionOptionsMenuItem,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1205660000891177/f
Tech Design URL: https://app.asana.com/0/1204586965688315/1205744067595006/f
CC:

**Description**:
This PR gates DBP for US users only

**Steps to test this PR**:
1. Make sure your locale is set to the US. "Private Information Removal" should show in the more menu
2. Set your locale to another country (or flip the `==` to `!=`). "Private Information Removal" should *not* show in the more menu

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
