### PR TITLE
Refactor DBP invite code storage to use the keychain

### DIFF
--- a/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
@@ -70,7 +70,7 @@ final class DataBrokerProtectionDebugMenu: NSMenu {
 
     @objc private func resetWaitlistState() {
         DataBrokerProtectionWaitlist().waitlistStorage.deleteWaitlistState()
-        UserDefaultsAuthenticationData().reset()
+        KeychainAuthenticationData().reset()
         UserDefaults().removeObject(forKey: UserDefaultsWrapper<Bool>.Key.dataBrokerProtectionTermsAndConditionsAccepted.rawValue)
         NotificationCenter.default.post(name: .dataBrokerProtectionWaitlistAccessChanged, object: nil)
         os_log("DBP waitlist state cleaned", log: .dataBrokerProtection)

--- a/DuckDuckGo/DBP/DataBrokerProtectionManager.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionManager.swift
@@ -26,7 +26,7 @@ public final class DataBrokerProtectionManager {
 
     static let shared = DataBrokerProtectionManager()
 
-    private let authenticationRepository: AuthenticationRepository = UserDefaultsAuthenticationData()
+    private let authenticationRepository: AuthenticationRepository = KeychainAuthenticationData()
     private let authenticationService: DataBrokerProtectionAuthenticationService = AuthenticationService()
     private let redeemUseCase: DataBrokerProtectionRedeemUseCase
     private let fakeBrokerFlag: DataBrokerDebugFlag = DataBrokerDebugFlagFakeBroker()

--- a/DuckDuckGo/Waitlist/Waitlist.swift
+++ b/DuckDuckGo/Waitlist/Waitlist.swift
@@ -274,7 +274,7 @@ struct DataBrokerProtectionWaitlist: Waitlist {
             store: WaitlistKeychainStore(waitlistIdentifier: Self.identifier),
             request: ProductWaitlistRequest(productName: Self.apiProductName),
             redeemUseCase: RedeemUseCase(),
-            redeemAuthenticationRepository: UserDefaultsAuthenticationData()
+            redeemAuthenticationRepository: KeychainAuthenticationData()
         )
     }
 

--- a/DuckDuckGoDBPBackgroundAgent/DataBrokerProtectionBackgroundManager.swift
+++ b/DuckDuckGoDBPBackgroundAgent/DataBrokerProtectionBackgroundManager.swift
@@ -26,7 +26,7 @@ public final class DataBrokerProtectionBackgroundManager {
 
     static let shared = DataBrokerProtectionBackgroundManager()
 
-    private let authenticationRepository: AuthenticationRepository = UserDefaultsAuthenticationData()
+    private let authenticationRepository: AuthenticationRepository = KeychainAuthenticationData()
     private let authenticationService: DataBrokerProtectionAuthenticationService = AuthenticationService()
     private let redeemUseCase: DataBrokerProtectionRedeemUseCase
     private let fakeBrokerFlag: DataBrokerDebugFlag = DataBrokerDebugFlagFakeBroker()

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/RedeemCodeServices.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/RedeemCodeServices.swift
@@ -63,7 +63,7 @@ public final class RedeemUseCase: DataBrokerProtectionRedeemUseCase {
     private let authenticationRepository: AuthenticationRepository
 
     public init(authenticationService: DataBrokerProtectionAuthenticationService = AuthenticationService(),
-                authenticationRepository: AuthenticationRepository = UserDefaultsAuthenticationData()) {
+                authenticationRepository: AuthenticationRepository = KeychainAuthenticationData()) {
         self.authenticationService = authenticationService
         self.authenticationRepository = authenticationRepository
     }
@@ -93,13 +93,13 @@ public final class RedeemUseCase: DataBrokerProtectionRedeemUseCase {
     }
 }
 
-// ⚠️ NOTE: This is just a temporary solution. We should not store the access token on User Defaults.
-// The access token will be saved in the secure database once we have that in place.
-public final class UserDefaultsAuthenticationData: AuthenticationRepository {
-    struct Keys {
-        static let accessTokenKey = "dbp:accessTokenKey"
-        static let inviteCodeKey = "dbp:inviteCodeKey"
+public final class KeychainAuthenticationData: AuthenticationRepository {
+    enum DBPWaitlistKeys: String {
+        case accessTokenKey = "dbp:accessTokenKey"
+        case inviteCodeKey = "dbp:inviteCodeKey"
     }
+
+    let keychainPrefix = Bundle.main.bundleIdentifier ?? "com.duckduckgo"
 
     // Initialize this constant with the DBP API Dev Access Token on Bitwarden if you do not want to use the redeem endpoint.
     private let developmentToken: String? = nil
@@ -107,24 +107,87 @@ public final class UserDefaultsAuthenticationData: AuthenticationRepository {
     public init() {}
 
     public func getInviteCode() -> String? {
-        UserDefaults.standard.string(forKey: Keys.inviteCodeKey)
+        return getString(forField: .inviteCodeKey)
     }
 
     public func getAccessToken() -> String? {
-        UserDefaults.standard.string(forKey: Keys.accessTokenKey) ?? developmentToken
+        getString(forField: .accessTokenKey)
     }
 
     public func save(accessToken: String) {
-        UserDefaults.standard.set(accessToken, forKey: Keys.accessTokenKey)
+        add(string: accessToken, forField: .accessTokenKey)
     }
 
     public func save(inviteCode: String) {
-        UserDefaults.standard.set(inviteCode, forKey: Keys.inviteCodeKey)
+        add(string: inviteCode, forField: .inviteCodeKey)
     }
 
     public func reset() {
-        UserDefaults.standard.removeObject(forKey: Keys.inviteCodeKey)
-        UserDefaults.standard.removeObject(forKey: Keys.accessTokenKey)
+        deleteItem(forField: .inviteCodeKey)
+        deleteItem(forField: .accessTokenKey)
+    }
+
+    // MARK: - Keychain Read
+
+    private func getString(forField field: DBPWaitlistKeys) -> String? {
+        guard let data = retrieveData(forField: field),
+              let string = String(data: data, encoding: String.Encoding.utf8) else {
+            return nil
+        }
+        return string
+    }
+
+    private func retrieveData(forField field: DBPWaitlistKeys) -> Data? {
+        var query = defaultAttributes(serviceName: keychainServiceName(for: field))
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnData as String] = true
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let existingItem = item as? Data else {
+            return nil
+        }
+
+        return existingItem
+    }
+
+    // MARK: - Keychain Write
+
+    private func add(string: String, forField field: DBPWaitlistKeys) {
+        guard let stringData = string.data(using: .utf8) else {
+            return
+        }
+
+        deleteItem(forField: field)
+        add(data: stringData, forField: field)
+    }
+
+    private func add(data: Data, forField field: DBPWaitlistKeys) {
+        var query = defaultAttributes(serviceName: keychainServiceName(for: field))
+        query[kSecValueData as String] = data
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    private func deleteItem(forField field: DBPWaitlistKeys) {
+        let query = defaultAttributes(serviceName: keychainServiceName(for: field))
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // MARK: -
+
+    private func defaultAttributes(serviceName: String) -> [String: Any] {
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrSynchronizable as String: false,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecAttrAccessGroup as String: Bundle.main.appGroupName,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+    }
+
+    func keychainServiceName(for field: DBPWaitlistKeys) -> String {
+        [keychainPrefix, "waitlist", field.rawValue].joined(separator: ".")
     }
 }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/InviteCodeFlow/DataBrokerProtectionInviteCodeViewModels.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/InviteCodeFlow/DataBrokerProtectionInviteCodeViewModels.swift
@@ -64,7 +64,7 @@ final class DataBrokerProtectionInviteCodeViewModel: InviteCodeViewModel {
     @Published var showProgressView = false
 
     init(delegate: DataBrokerProtectionInviteCodeViewModelDelegate,
-         authenticationRepository: AuthenticationRepository = UserDefaultsAuthenticationData(),
+         authenticationRepository: AuthenticationRepository = KeychainAuthenticationData(),
          authenticationService: DataBrokerProtectionAuthenticationService = AuthenticationService()) {
         self.delegate = delegate
         self.redeemUseCase = RedeemUseCase(authenticationService: authenticationService, authenticationRepository: authenticationRepository)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1205314679733970/f
Tech Design URL:
CC:

**Description**:
This PR refactors DBP to store the invite code and access token in the keychain instead of `UserDefaults`

**Steps to test this PR**:
1. In `MoreOptionsMenu` comment lines 152-154 and 156 to force the invite code dialog
2. Redeem an invite code for DBP. (**Note:** You may need to force the prod redemption endpoint depending on your code. `RedeemCodeServices.swift` Lines 212-216)
3. Re-open the app. You should be able to access DBP.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
