### PR TITLE
Further improve PixelKit daily pixel logic

### DIFF
--- a/LocalPackages/PixelKit/Sources/PixelKit/PixelKit.swift
+++ b/LocalPackages/PixelKit/Sources/PixelKit/PixelKit.swift
@@ -138,15 +138,13 @@ public final class PixelKit {
         case .dailyOnly:
             if !pixelHasBeenFiredToday(pixelName, dailyPixelStorage: defaults, calendar: self.pixelCalendar) {
                 fireRequest(pixelName + "_d", headers, newParams, allowedQueryReservedCharacters, true, { _ in })
+                updatePixelLastFireDate(pixelName: pixelName)
             }
-
-            updatePixelLastFireDate(pixelName: pixelName)
         case .dailyAndContinuous:
             if !pixelHasBeenFiredToday(pixelName, dailyPixelStorage: defaults, calendar: self.pixelCalendar) {
                 fireRequest(pixelName + "_d", headers, newParams, allowedQueryReservedCharacters, true, { _ in })
+                updatePixelLastFireDate(pixelName: pixelName)
             }
-
-            updatePixelLastFireDate(pixelName: pixelName)
 
             fireRequest(pixelName + "_c", headers, newParams, allowedQueryReservedCharacters, true, onComplete)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205913042786021/f
Tech Design URL:
CC: @diegoreymendez 

**Description**:

This PR makes the daily pixel logic consistent across the board by only updating the timestamp when the pixel call has happened.

The previous logic was fine since the check happened _before_ the timestamp was updated, but I'd still rather only update the timestamp when running the pixel logic.

**Steps to test this PR**:
1. Check that daily pixels work

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
