### PR TITLE
Skip Make Release Build in PR Checks on Dependabot pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR Checks
 
 on: 
   push:
-    branches: [ develop, "release/**", "dominik/gha-dependabot-pr-checks" ]
+    branches: [ develop, "release/**" ]
   pull_request:
 
 
@@ -207,7 +207,9 @@ jobs:
   release-build:
 
     name: Make Release Build
-    if: github.actor != 'ayoy'
+
+    # Dependabot doesn't have access to all secrets, so we skip this job
+    if: github.actor != 'dependabot[bot]'
 
     strategy:
       matrix:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1205917416666553/f

**Description**:
Dependabot doesn't have access to signing certificates and provisioning profiles so let's skip
the release build check when dependabot is the PR author.

**Steps to test this PR**:
It's not possible to test until we merge it and dependabot makes a new PR.
You can check how the checks look like when I set it to skip release build when I was the author:
https://github.com/duckduckgo/macos-browser/actions/runs/6817027006

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
