### PR TITLE
Add new line to DBP T&C

### DIFF
--- a/DuckDuckGo/Waitlist/Views/WaitlistSteps/WaitlistTermsAndConditionsView.swift
+++ b/DuckDuckGo/Waitlist/Views/WaitlistSteps/WaitlistTermsAndConditionsView.swift
@@ -184,6 +184,7 @@ struct DataBrokerProtectionTermsAndConditionsContentView: View {
                 } else {
                     Text("• Our main Privacy Policy also applies here.")
                 }
+                Text("• This beta product may collect more diagnostic data than our typical products. Examples of such data include: alerts of low memory, application restarts, and user engagement with product features.")
             }
             .padding(.leading, groupLeadingPadding)
 


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/0/1203581873609357/1205919865558363/f
Tech Design URL:
CC:

**Description**:
Add new item for DBP T&C

**Steps to test this PR**:
* In WaitlistViewMode, in the init method force the waitlist state to .termsAndConditions
`*   viewState = .termsAndConditions`
(You can apply this patch if you want)
```swift
diff --git forkSrcPrefix/DuckDuckGo/Waitlist/Models/WaitlistViewModel.swift forkDstPrefix/DuckDuckGo/Waitlist/Models/WaitlistViewModel.swift
index d97085c7d4abf5da0ff0fb8b28aaa5eb7dc0a5ec..2ce9461bebc2da60e17fc844c6ab12148f151f17 100644
--- forkSrcPrefix/DuckDuckGo/Waitlist/Models/WaitlistViewModel.swift
+++ forkDstPrefix/DuckDuckGo/Waitlist/Models/WaitlistViewModel.swift
@@ -82,17 +82,9 @@ final class WaitlistViewModel: ObservableObject {
         self.notificationService = notificationService
         self.termsAndConditionActionHandler = termsAndConditionActionHandler
         self.featureSetupHandler = featureSetupHandler
-        if waitlistStorage.getWaitlistTimestamp() != nil, waitlistStorage.getWaitlistInviteCode() == nil {
-            viewState = .joinedWaitlist(notificationPermissionState)
 
-            Task { @MainActor in
-                await checkNotificationPermissions()
-            }
-        } else if waitlistStorage.getWaitlistInviteCode() != nil {
-            viewState = .invited
-        } else {
-            viewState = .notOnWaitlist
-        }
+        viewState = .termsAndConditions
+
     }
 
     convenience init(waitlist: Waitlist,
```
* Open the DBP feature from the browser menu
* Check if the new paragraph was added to the T&C
