### PR TITLE
Fixes crash in XPCClient due to lack of thread safety

### DIFF
--- a/LocalPackages/XPCHelper/Sources/XPCHelper/XPCClient.swift
+++ b/LocalPackages/XPCHelper/Sources/XPCHelper/XPCClient.swift
@@ -18,6 +18,15 @@
 
 import Foundation
 
+/// This actor is meant to support synchronized access to the XPC connection
+///
+@globalActor
+private struct XPCConnectionActor {
+    actor ActorType { }
+
+    static let shared: ActorType = ActorType()
+}
+
 /// An XPC client
 ///
 public final class XPCClient<ClientInterface: AnyObject, ServerInterface: AnyObject> {
@@ -32,10 +41,12 @@ public final class XPCClient<ClientInterface: AnyObject, ServerInterface: AnyObj
 
     /// The internal connection, which may still not have been created.
     ///
+    @XPCConnectionActor
     private var internalConnection: NSXPCConnection?
 
     /// A convenience to access the existing connection or make a new one if it doesn't already exist.
     ///
+    @XPCConnectionActor
     private var connection: NSXPCConnection {
         guard let internalConnection else {
             let newConnection = makeConnection()
@@ -50,7 +61,9 @@ public final class XPCClient<ClientInterface: AnyObject, ServerInterface: AnyObj
     ///
     public weak var delegate: ClientInterface? {
         didSet {
-            connection.exportedObject = delegate
+            Task { @XPCConnectionActor in
+                connection.exportedObject = delegate
+            }
         }
     }
 
@@ -78,11 +91,13 @@ public final class XPCClient<ClientInterface: AnyObject, ServerInterface: AnyObj
         connection.remoteObjectInterface = serverInterface
 
         let closeConnection = { [weak self] in
-           guard let self else {
-               return
-           }
+            guard let self else {
+                return
+            }
 
-           self.internalConnection = nil
+            Task { @XPCConnectionActor in
+                self.internalConnection = nil
+            }
         }
 
         connection.interruptionHandler = closeConnection
@@ -92,40 +107,23 @@ public final class XPCClient<ClientInterface: AnyObject, ServerInterface: AnyObj
         return connection
     }
 
-    /// Returns a proxy for the server object.
-    ///
-    /// It's important to not store the object returned by this method, because calling this method ensures a
-    /// normalized handling of connection issues and reconnection logic.
-    ///
-    /// This is quite obscure, but XPC services with a completion block don't execute their completion block
-    /// if the XPC endpoint isn't running.  The error handler block below detects errors while waiting for a reply.
-    ///
-    /// Refs:
-    ///  https://developer.apple.com/forums/thread/713429?answerId=725930022#725930022
-    ///
-    ///
-    ///
-    public func server(xpcReplyErrorHandler: @escaping (Error) -> Void) -> ServerInterface? {
-        connection.remoteObjectProxyWithErrorHandler({ error in
-            xpcReplyErrorHandler(error)
-        }) as? ServerInterface
-    }
+    public func execute(call: @escaping (ServerInterface) -> Void, xpcReplyErrorHandler: @escaping (Error) -> Void) {
+        Task { @XPCConnectionActor in
+            guard let serverInterface = connection.remoteObjectProxyWithErrorHandler({ error in
+                // This will be called if there's an error while waiting for an XPC response.
+                // Ref: https://developer.apple.com/documentation/foundation/nsxpcproxycreating/1415611-remoteobjectproxywitherrorhandle
+                //
+                // Since when there's an error while waiting for a response a completion callback will not be called, this
+                // allows us to call the completion callback ourselves.
+                xpcReplyErrorHandler(error)
+            }) as? ServerInterface else {
+                // This won't collide with the error handling above, as if this error happens there won't be any XPC
+                // request to begin with.
+                xpcReplyErrorHandler(ConnectionError.noRemoteObjectProxy)
+                return
+            }
 
-    public func execute(call: (ServerInterface) -> Void, xpcReplyErrorHandler: @escaping (Error) -> Void) {
-        guard let serverInterface = connection.remoteObjectProxyWithErrorHandler({ error in
-            // This will be called if there's an error while waiting for an XPC response.
-            // Ref: https://developer.apple.com/documentation/foundation/nsxpcproxycreating/1415611-remoteobjectproxywitherrorhandle
-            //
-            // Since when there's an error while waiting for a response a completion callback will not be called, this
-            // allows us to call the completion callback ourselves.
-            xpcReplyErrorHandler(error)
-        }) as? ServerInterface else {
-            // This won't collide with the error handling above, as if this error happens there won't be any XPC
-            // request to begin with.
-            xpcReplyErrorHandler(ConnectionError.noRemoteObjectProxy)
-            return
+            call(serverInterface)
         }
-
-        call(serverInterface)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205948792159941/f

## Description

Fixes a concurrency issue with the `connection` property in `XPCClient`.

## Details

My theory considering the crash logs, is that `internalConnection` was being `nil`ed by a thread while another one was accessing it.

Example crash reports:
- [XPCClient.connection.getter EXC_BAD_ACCESS 2023-11-13 15:16:39.2449 +0000](https://app.asana.com/0/1200541656900018/1205941693241378/f)
- [XPCClient.delegate.didset EXC_BAD_ACCESS 2023-11-13 09:17:02.8713 -0500](https://app.asana.com/0/1200541656900018/1205940963347939/f)

## Testing

Because this is a concurrency issue it's hard to validate the fix - please review the code and help me ensure thread safety is in place.

Do make sure the VPN works well with this change.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
