### PR TITLE
Fixes an issue that crashes the NetP extension

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14430,8 +14430,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 83.0.0;
+				kind = revision;
+				revision = 1c4b477106e41b81a4c9ef2b37008ff414bd8390;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "f7e20cd37bbc0d25ae3c3f25ef52d319366613e7",
-        "version" : "83.0.0"
+        "revision" : "1c4b477106e41b81a4c9ef2b37008ff414bd8390"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205948641232666/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/561
iOS PR: iOS will be integrated against the latest BSK, in a follow up PR.

## Description

Fixes a crasher in NetP iOS and macOS.

## Testing

There's not a lot to test, it seems I merged a test line by mistake to BSK.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
