### PR TITLE
Fixes an issue that crashes the NetP extension

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14430,8 +14430,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 1c4b477106e41b81a4c9ef2b37008ff414bd8390;
+				kind = exactVersion;
+				version = "83.0.0-1";
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "1c4b477106e41b81a4c9ef2b37008ff414bd8390"
+        "revision" : "1c4b477106e41b81a4c9ef2b37008ff414bd8390",
+        "version" : "83.0.0-1"
       }
     },
     {

--- a/LocalPackages/Account/Package.swift
+++ b/LocalPackages/Account/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Account"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "83.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "83.0.0-1"),
         .package(path: "../Purchase")
     ],
     targets: [

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "83.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "83.0.0-1"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "83.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "83.0.0-1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205948641232666/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/561
iOS PR: iOS will be integrated against the latest BSK, in a follow up PR.

## Description

Fixes a crasher in NetP iOS and macOS.

## Testing

There's not a lot to test, it seems I merged a test line by mistake to BSK.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
