### PR TITLE
Fix flaky testOnTurnOffSyncThenSyncServiceIsDisconnected

### DIFF
--- a/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/UnitTests/Sync/SyncPreferencesTests.swift
@@ -95,14 +95,14 @@ final class SyncPreferencesTests: XCTestCase {
         XCTAssertEqual(managementDialogModel.currentDialog, .removeDevice(device))
     }
 
-    @MainActor func testOnTurnOffSyncThenSyncServiceIsDisconnected() {
+    @MainActor func testOnTurnOffSyncThenSyncServiceIsDisconnected() async {
         let expectation = XCTestExpectation(description: "Disconnect completed")
         Task {
             syncPreferences.turnOffSync()
             XCTAssertNil(managementDialogModel.currentDialog)
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 5.0)
+        await fulfillment(of: [expectation], timeout: 5.0)
         XCTAssertTrue(ddgSyncing.disconnectCalled)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205237866452338/1205614387976178/f

**Description**:
Make test function async and await expectation fulfillment.

**Steps to test this PR**:
Verify that testOnTurnOffSyncThenSyncServiceIsDisconnected does not fail in CI.
Feel free to rerun the pipeline a few times.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
