### PR TITLE
Run integration tests separate from unit tests and retry them on failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR Checks
 
 on: 
   push:
-    branches: [ develop, "release/**", "dominik/retry-integration-tests" ]
+    branches: [ develop, "release/**" ]
   pull_request:
 
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1205262831112238/f

**Description**:
This change splits tests run in PR Checks into two xcodebuild invocations:
* first skips tests in Integration Tests target,
* second run only tests in Integration Tests, and retries them on failure up to 3 times (using built-in xcodebuild mechanism).

**Steps to test this PR**:
Ensure that CI is green.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
