### PR TITLE
Fix assertion when editing bookmark from the popover

### DIFF
--- a/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -1034,10 +1034,9 @@ fileprivate extension BookmarkEntity {
     func update(with bookmark: Bookmark, favoritesFoldersToAddFavorite: [BookmarkEntity], favoritesDisplayMode: FavoritesDisplayMode) {
         url = bookmark.url
         title = bookmark.title
-        let isFavorite = isFavorite(on: favoritesDisplayMode.displayedFolder)
-        if bookmark.isFavorite && !isFavorite {
+        if bookmark.isFavorite && Set(favoritesFoldersToAddFavorite) != favoriteFoldersSet {
             addToFavorites(folders: favoritesFoldersToAddFavorite)
-        } else if !bookmark.isFavorite && isFavorite {
+        } else if !bookmark.isFavorite && !favoriteFoldersSet.isEmpty {
             removeFromFavorites(with: favoritesDisplayMode)
         }
     }

--- a/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
+++ b/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
@@ -836,7 +836,7 @@ final class LocalBookmarkStoreTests: XCTestCase {
             bookmarkMO.addToFavorites(folders: [nonNativeFolder])
             try! context.save()
 
-            var bookmark = Bookmark.from(managedObject: bookmarkMO, favoritesDisplayMode: bookmarkStore.favoritesDisplayMode) as! Bookmark
+            let bookmark = Bookmark.from(managedObject: bookmarkMO, favoritesDisplayMode: bookmarkStore.favoritesDisplayMode) as! Bookmark
 
             bookmark.isFavorite = false
             bookmarkStore.update(bookmark: bookmark)
@@ -872,7 +872,7 @@ final class LocalBookmarkStoreTests: XCTestCase {
             bookmarkMO.addToFavorites(with: .displayNative(.mobile), in: context)
             try! context.save()
 
-            var bookmark = Bookmark.from(managedObject: bookmarkMO, favoritesDisplayMode: bookmarkStore.favoritesDisplayMode) as! Bookmark
+            let bookmark = Bookmark.from(managedObject: bookmarkMO, favoritesDisplayMode: bookmarkStore.favoritesDisplayMode) as! Bookmark
 
             bookmark.isFavorite = true
             bookmarkStore.update(bookmark: bookmark)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1205949780297090/f

**Description:**
Check if bookmark is favorite before editing favorite state.

**Steps to test this PR**:
1. Run the app from Xcode
2. Visit a URL
3. Add a bookmark
4. Edit a bookmark in the popover from the address bar's bookmark button (on the right hand side)
5. Verify that the app doesn't crash

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
