### PR TITLE
Remove build variant label from About settings

### DIFF
--- a/DuckDuckGo/Preferences/View/PreferencesAboutView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesAboutView.swift
@@ -64,8 +64,6 @@ extension Preferences {
                         model.openURL(.aboutDuckDuckGo)
                     }
 
-                    Text("Build variant: \(variant)")
-
                     TextButton(UserText.privacyPolicy) {
                         model.openURL(.privacyPolicy)
                     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1205949780297106/f

**Steps to test this PR**:
1. Go to Settings -> About
2. Verify that "Build variant: default" label is not shown.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
