### PR TITLE
Home Button Alignment improvements

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -662,6 +662,7 @@ final class NavigationBarViewController: NSViewController {
                     navigationButtons.setCustomSpacing(Constants.homeButtonSeparatorSpacing, after: navigationButtons.views[0])
                     navigationButtons.setCustomSpacing(Constants.homeButtonSeparatorSpacing, after: navigationButtons.views[1])
                     homeButtonSeparator.heightAnchor.constraint(equalToConstant: Constants.homeButtonSeparatorHeight).isActive = true
+                    homeButtonSeparator.translatesAutoresizingMaskIntoConstraints = false
                     NSLayoutConstraint.activate([NSLayoutConstraint(item: homeButtonSeparator as Any,
                                                                         attribute: .centerY,
                                                                         relatedBy: .equal,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205920921975917/f

**Description**:
Adjusts Home button separator spacing and margins to match design recommendations.

<img width="940" alt="Screenshot 2023-11-16 at 12 20 04 PM" src="https://github.com/duckduckgo/macos-browser/assets/1156669/52a97384-3aba-4c1e-97a2-d7859ea28903">

**Steps to test this PR**:
1. Put the home button in the left
2. Confirm it looks as outlined above


—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
