### PR TITLE
Set scan operation preferred run date to run today when created

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDatabase.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDatabase.swift
@@ -326,7 +326,7 @@ extension DataBrokerProtectionDatabase {
 
         for brokerId in brokerIDs {
             for profileQueryId in profileQueryIDs {
-                try vault.save(brokerId: brokerId, profileQueryId: profileQueryId, lastRunDate: nil, preferredRunDate: nil)
+                try vault.save(brokerId: brokerId, profileQueryId: profileQueryId, lastRunDate: nil, preferredRunDate: Date())
             }
         }
     }


### PR DESCRIPTION
## Task
https://app.asana.com/0/1204006570077678/1205980506388104/f

## Description
Fixes an issue where the remaining scans were not being picked if the initial scan stopped because the background agent crashed.

## Steps to test

1. Delete the database and start from scratch (drag the C-S-S DBP fork)
2. Create a profile and start the initial scan
3. Kill the background agent (you can do it by force stopping it via Activity Monitor)
4. The background agent should recover and the scheduler too
5. The remaining scans should be done