### PR TITLE
Queue access to XPCConnectionsManager's connections for thread safety

### DIFF
--- a/LocalPackages/XPCHelper/Sources/XPCHelper/XPCServer.swift
+++ b/LocalPackages/XPCHelper/Sources/XPCHelper/XPCServer.swift
@@ -23,19 +23,24 @@ private class XPCConnectionsManager: NSObject, NSXPCListenerDelegate {
 
     private let clientInterface: NSXPCInterface
     private let serverInterface: NSXPCInterface
-    private let queue = DispatchQueue(label: "com.duckduckgo.XPCConnectionsManager.queue")
+    private let queue: DispatchQueue
     weak var delegate: AnyObject?
 
     /// The active connections
     ///
     private(set) var connections = Set<NSXPCConnection>()
 
-    init(clientInterface: NSXPCInterface, serverInterface: NSXPCInterface) {
+    init(clientInterface: NSXPCInterface,
+         serverInterface: NSXPCInterface,
+         queue: DispatchQueue = DispatchQueue(label: "com.duckduckgo.XPCConnectionsManager.queue")) {
+
         self.clientInterface = clientInterface
         self.serverInterface = serverInterface
+        self.queue = queue
     }
 
     func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+
         queue.sync {
             newConnection.exportedInterface = serverInterface
             newConnection.exportedObject = delegate


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200541656900018/1205999262061597/f

## Description

Fixes a threading issue in `XPCConnectionsManager`.

Here's a link to [the Sentry crashes](https://errors.duckduckgo.com/organizations/ddg/issues/6221/?project=6&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=3).

## Testing

Since this is a threading issue it'll be hard to reproduce the crash.  That said, you can make sure NetP works fine.

1. Disable the VPN launch agent using `launchctl remove com.duckduckgo.macos.vpn.debug`
2. Run the app and connect NetP.  The menu agent should launch and be visible in the status bar.
3. Ensure XPC works well by interacting with the in-browser NetP status view (in the More menu).

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
