### PR TITLE
Fixes a bug where an observer was not being released

### DIFF
--- a/DuckDuckGo/Waitlist/Views/WaitlistModalViewController.swift
+++ b/DuckDuckGo/Waitlist/Views/WaitlistModalViewController.swift
@@ -31,6 +31,7 @@ final class WaitlistModalViewController<ContentView: View>: NSViewController {
     private let defaultSize = CGSize(width: 360, height: 650)
     private let model: WaitlistViewModel
     private let contentView: ContentView
+    private var dismissObserver: NSObjectProtocol?
 
     private var heightConstraint: NSLayoutConstraint?
 
@@ -42,6 +43,12 @@ final class WaitlistModalViewController<ContentView: View>: NSViewController {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        if let dismissObserver {
+            NotificationCenter.default.removeObserver(dismissObserver)
+        }
     }
 
     public override func loadView() {
@@ -69,7 +76,7 @@ final class WaitlistModalViewController<ContentView: View>: NSViewController {
             hostingView.rightAnchor.constraint(equalTo: view.rightAnchor)
         ])
 
-        NotificationCenter.default.addObserver(forName: .waitlistModalViewControllerShouldDismiss, object: nil, queue: .main) { [weak self] _ in
+        dismissObserver = NotificationCenter.default.addObserver(forName: .waitlistModalViewControllerShouldDismiss, object: nil, queue: .main) { [weak self] _ in
             self?.dismissModal()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206008228716273/f

## Description

Removes an observer that was not being removed.

This is likely causing [these crashes](https://errors.duckduckgo.com/organizations/ddg/issues/6351/events/1d03b006862611ee954f4fd90fbc32da/?project=6&query=is%3Aunresolved&referrer=previous-event&statsPeriod=14d&stream_index=0).

## Testing

Make sure the waitlist modal works fine.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
