### PR TITLE
Assign no action to menu item if it represents a bookmark folder

### DIFF
--- a/DuckDuckGo/Common/Extensions/NSMenuItemExtension.swift
+++ b/DuckDuckGo/Common/Extensions/NSMenuItemExtension.swift
@@ -54,7 +54,7 @@ extension NSMenuItem {
         title = bookmarkViewModel.menuTitle
         image = bookmarkViewModel.menuFavicon
         representedObject = bookmarkViewModel.entity
-        action = #selector(MainViewController.openBookmark(_:))
+        action = bookmarkViewModel.entity.isFolder ? nil : #selector(MainViewController.openBookmark(_:))
     }
 
     convenience init(bookmarkViewModels: [BookmarkViewModel]) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206012852959154/f

**Description**:
Triggering openBookmark for a bookmarks folder didn't do anything, but was closing the menu,
so we fix it by not performing any action, thus preventing menu from disappearing on click.

**Steps to test this PR**:
1. Have nested bookmark folders
2. Show bookmarks bar
3. From bookmarks bar, click a folder and click a nested folder; verify that the menu doesn't disappear (and that folder contents are displayed in a submenu)
4. Repeat the same with three-dots menu in the toolbar's right hand side. Click the menu -> Bookmarks -> bookmark folder. Verify that clicking a bookmark folder doesn't make the menu disappear.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
