### PR TITLE
Fix bug where VPN location isn't respected

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12725,8 +12725,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 654d53326f1b8d182749c1c171da42f5f83e9725;
+				kind = exactVersion;
+				version = 85.1.0;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "654d53326f1b8d182749c1c171da42f5f83e9725"
+        "revision" : "820203512819e81c4dd5ff0b53711d0010a8253c",
+        "version" : "85.1.0"
       }
     },
     {

--- a/LocalPackages/Account/Package.swift
+++ b/LocalPackages/Account/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Account"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", revision: "654d53326f1b8d182749c1c171da42f5f83e9725"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "85.1.0"),
         .package(path: "../Purchase")
     ],
     targets: [

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", revision: "654d53326f1b8d182749c1c171da42f5f83e9725"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "85.1.0"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", revision: "654d53326f1b8d182749c1c171da42f5f83e9725"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "85.1.0"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206025077480506/f
BSK: https://github.com/duckduckgo/BrowserServicesKit/pull/576

Description:
There was a bug with location switching where the user’s choice wasn’t always being respected. I noticed that there was a place where we weren’t passing it. I also noticed that we’re sometimes not using the selected environment because of the default function arguments, so I also updated them as it’s a somewhat related issue.

Steps to test this PR:
- Just make sure NetP / env selection still works

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
