### PR TITLE
Fix issue with waitlist notification

### DIFF
--- a/DuckDuckGo/Waitlist/Models/WaitlistViewModel.swift
+++ b/DuckDuckGo/Waitlist/Models/WaitlistViewModel.swift
@@ -173,14 +173,40 @@ final class WaitlistViewModel: ObservableObject {
     private func requestNotificationPermission() {
         Task {
             do {
-                let permissionGranted = try await notificationService.requestAuthorization(options: [.alert])
-                self.viewState = .joinedWaitlist(permissionGranted ? .notificationAllowed : .notificationsDisabled)
+                let currentStatus = await notificationService.authorizationStatus()
+                let permissionGranted: Bool
+
+                switch currentStatus {
+                case .notDetermined:
+                    permissionGranted = try await notificationService.requestAuthorization(options: [.alert])
+                case .authorized, .provisional:
+                    permissionGranted = true
+                case .denied:
+                    openAppNotificationSettings()
+                    permissionGranted = false
+                @unknown default:
+                    permissionGranted = false
+                }
+                if permissionGranted {
+                     self.viewState = .joinedWaitlist(.notificationAllowed)
+                 } else {
+                     await perform(action: .close)
+                 }
             } catch {
                 await checkNotificationPermissions()
             }
         }
+    }
 
-        self.viewState = .joinedWaitlist(.notificationAllowed)
+    private func openAppNotificationSettings() {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.duckduckgo"
+        let settingsPath = "x-apple.systempreferences:com.apple.preference.notifications"
+        let urlComponents = NSURLComponents(string: settingsPath)
+        urlComponents?.queryItems = [URLQueryItem(name: "id", value: bundleID)]
+
+        if let appSettings = urlComponents?.url {
+            NSWorkspace.shared.open(appSettings)
+        }
     }
 
     private func showTermsAndConditions() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1206048907053748/f

**Description**:
Fix issue where clicking on "enable notifications" for an user that had denied permissions before would enter a loop.

**Steps to test this PR**:
1. Reset the notification state for the DDG app (Open notification settings, right click in our app, reset notifications)
<img width="461" alt="image" src="https://github.com/duckduckgo/macos-browser/assets/782316/3bfa8b6b-c8c0-42d1-8b77-49b01f5ca1be">

1. Join the DBP waitlist, and enable notifications, it should go to the thank you panel 
2. Remove the app notification permission in system settings
3. Open Personal Information Removal
4. It should give you an option to enable notifications
5. Click on it, it should open system preferences with our app selected
6. Enable notifications
7. Open Personal Information Removal
8. It should display the "you're in the waitlist" message without an enable notification button 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
