### PR TITLE
Only run SwiftLint on debug builds

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -76,9 +76,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
 
     private var didFinishLaunching = false
 
-
-
-
 #if SPARKLE
     var updateController: UpdateController!
 #endif


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199333091098016/1206052939549077/f
Tech Design URL:
CC:

**Description**:

This PR updates our lint script to only run SwiftLint on debug builds.

On CI we use a separate GitHub Action that lints all files strictly, so we don't need `lint.sh` there, and locally it's possible for SwiftLint to stop an archive build even when it doesn't actually matter that there are lint violations.

**Steps to test this PR**:
1. Check that CI has failed this PR's SwiftLint run, as I have introduced a deliberate failure
2. Check that you can run `./scripts/archive.sh release` on this branch and it succeeds

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
