### PR TITLE
Hide the NetP waitlist sign up prompt if dismissed

### DIFF
--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -145,10 +145,9 @@ public struct UserDefaultsWrapper<T> {
         // Network Protection
 
         case networkProtectionExcludedRoutes = "netp.excluded-routes"
-
         case networkProtectionTermsAndConditionsAccepted = "network-protection.waitlist-terms-and-conditions.accepted"
-
         case shouldShowNetworkProtectionSystemExtensionUpgradePrompt = "network-protection.show-system-extension-upgrade-prompt"
+        case networkProtectionWaitlistSignUpPromptDismissed = "network-protection.waitlist.sign-up-prompt-dismissed"
 
         // Network Protection: Shared Defaults
         // ---

--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
@@ -522,6 +522,7 @@ final class NetworkProtectionDebugMenu: NSMenu {
     @objc func resetNetworkProtectionWaitlistState(_ sender: Any?) {
         NetworkProtectionWaitlist().waitlistStorage.deleteWaitlistState()
         UserDefaults().removeObject(forKey: UserDefaultsWrapper<Bool>.Key.networkProtectionTermsAndConditionsAccepted.rawValue)
+        UserDefaults().removeObject(forKey: UserDefaultsWrapper<Bool>.Key.networkProtectionWaitlistSignUpPromptDismissed.rawValue)
         NotificationCenter.default.post(name: .networkProtectionWaitlistAccessChanged, object: nil)
     }
 

--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
@@ -202,12 +202,14 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
                 return
             }
 
-            let isWaitlistUser = NetworkProtectionWaitlist().waitlistStorage.isWaitlistUser
+            let waitlist = NetworkProtectionWaitlist()
+            let isWaitlistUser = waitlist.waitlistStorage.isWaitlistUser
             let hasAuthToken = NetworkProtectionKeychainTokenStore().isFeatureActivated
 
             // If the user hasn't signed up to the waitlist or doesn't have an auth token through some other method, then show them the badged icon
-            // to get their attention and encourage them to sign up.
-            if !isWaitlistUser && !hasAuthToken {
+            // to get their attention and encourage them to sign up. Also avoid showing the button is the user has opened the waitlist UI but
+            // dismissed it.
+            if !isWaitlistUser && !hasAuthToken && !waitlist.waitlistSignUpPromptDismissed {
                 showButton = true
                 return
             }

--- a/DuckDuckGo/Waitlist/Views/WaitlistViewControllerPresenter.swift
+++ b/DuckDuckGo/Waitlist/Views/WaitlistViewControllerPresenter.swift
@@ -59,6 +59,13 @@ struct NetworkProtectionWaitlistViewControllerPresenter: WaitlistViewControllerP
 
                 let viewController = WaitlistModalViewController(viewModel: viewModel, contentView: NetworkProtectionWaitlistRootView())
                 windowController.mainViewController.beginSheet(viewController) { _ in
+                    // If the user dismissed the waitlist flow without signing up, hide the button.
+                    var waitlist = NetworkProtectionWaitlist()
+                    if !waitlist.waitlistStorage.isOnWaitlist {
+                        waitlist.waitlistSignUpPromptDismissed = true
+                        NotificationCenter.default.post(name: .networkProtectionWaitlistAccessChanged, object: nil)
+                    }
+
                     completion?()
                 }
             }

--- a/DuckDuckGo/Waitlist/Waitlist.swift
+++ b/DuckDuckGo/Waitlist/Waitlist.swift
@@ -171,6 +171,9 @@ struct NetworkProtectionWaitlist: Waitlist {
     let waitlistRequest: WaitlistRequest
     private let networkProtectionCodeRedemption: NetworkProtectionCodeRedeeming
 
+    @UserDefaultsWrapper(key: .networkProtectionWaitlistSignUpPromptDismissed, defaultValue: false)
+    var waitlistSignUpPromptDismissed: Bool
+
     var shouldShowWaitlistViewController: Bool {
         return isOnWaitlist || readyToAcceptTermsAndConditions
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1205961562051241/f
Tech Design URL:
CC:

**Description**:

This PR updates the NetP waitlist flow to hide after the user opens the waitlist UI, but doesn't sign up, to prevent the badging sticking around permanently.

**Steps to test this PR**:
1. Reset your NetP state (including waitlist state) via the Debug menu
2. After you've done this, you should see a badge in the toolbar with the NetP icon
3. Click it, and then click Dismiss to close the flow
4. The badge should disappear
5. Check that you can still access the waitlist flow via the options menu

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
