### PR TITLE
Fix: external application requests via redirect URLs shows wrong origin.

### DIFF
--- a/DuckDuckGo/Tab/Navigation/ExternalAppSchemeHandler.swift
+++ b/DuckDuckGo/Tab/Navigation/ExternalAppSchemeHandler.swift
@@ -53,8 +53,8 @@ final class ExternalAppSchemeHandler {
 
 extension ExternalAppSchemeHandler: NavigationResponder {
 
-    @MainActor
-    func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
+    // swiftlint:disable:next function_body_length
+    @MainActor func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
         let externalUrl = navigationAction.url
         // only proceed with non-external-scheme navigations
         guard externalUrl.isExternalSchemeLink, let scheme = externalUrl.scheme else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1176047645786601/1204521390227183/f


**Description**:
If the external application URL was the result of a cross-origin redirect, then we display the wrong origin in the external application request popup. Instead, I propose we check if redirects occurred, and use the origin of the most recent redirect as the first choice for the domain displayed to the user.

This is only a proposed fix, and will likely need a thorough review to ensure we don't cause breakage in legitimate external application requests.

**Steps to test this PR**:
1. Visit https://alesandroortiz.com/security/chromium/external-protocol/spoof-links.html
2. Click **Tel**
3. Check the origin in the popup is aogarantiza.com and not alesandroortiz.com
4. Manually enter tel://155555 into address bar
5. Ensure popup appears with origin "155555"
6. Visit this test page: https://crossorigin.site/tel.html
7. Click the button
8. Ensure the origin is displayed as "crossorigin.site"

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
