### PR TITLE
Prevent users from entering javascript: URLs into address bar

### DIFF
--- a/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -444,4 +444,24 @@ extension URL {
         }
         return self.absoluteString
     }
+
+    // MARK: - JavaScript URLs
+
+    var isJavaScriptURL: Bool {
+        guard let scheme = self.scheme?.lowercased() else { return false }
+
+        if scheme == "javascript" || scheme.hasPrefix("javascript:") {
+            return true
+        }
+
+        return false
+    }
+
+    func stripJavaScriptScheme() -> URL {
+        if self.isJavaScriptURL {
+            let cleanUrlString = self.absoluteString.replacingOccurrences(of: "javascript", with: "")
+            return URL(string: cleanUrlString) ?? self
+        }
+        return self
+    }
 }

--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -300,8 +300,11 @@ final class AddressBarTextField: NSTextField {
             return
         }
 
+        // Block user-entered JavaScript URLs
+        let cleanProvidedUrl = providedUrl.stripJavaScriptScheme()
+
 #if APPSTORE
-        if providedUrl.isFileURL, let window = self.window {
+        if cleanProvidedUrl.isFileURL, let window = self.window {
             let alert = NSAlert.cannotOpenFileAlert()
             alert.beginSheetModal(for: window) { response in
                 switch response {
@@ -316,7 +319,7 @@ final class AddressBarTextField: NSTextField {
         }
 #endif
 
-        selectedTabViewModel.tab.setUrl(providedUrl, userEntered: userEnteredValue)
+        selectedTabViewModel.tab.setUrl(cleanProvidedUrl, userEntered: userEnteredValue)
 
         self.window?.makeFirstResponder(nil)
     }

--- a/UnitTests/Common/Extensions/URLExtensionTests.swift
+++ b/UnitTests/Common/Extensions/URLExtensionTests.swift
@@ -116,4 +116,18 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertNil(notURL)
     }
 
+    func testWhenJavaScriptUrlIsEntered_ThenItShouldBeStripped() {
+        let data: [(inUrl: URL?, expectedUrl: URL?)] = [
+            (URL(string: "javascript:/duckduckgo.com"), URL(string: ":/duckduckgo.com")),
+            (URL(string: "javascript:alert(1)"), URL(string: ":alert(1)")),
+            (URL(string: "javascript://alert(1)"), URL(string: "://alert(1)")),
+            (URL(string: "javascript.com"), URL(string: "javascript.com")),
+            (URL(string: "https://javascript.com"), URL(string: "https://javascript.com"))
+        ]
+
+        for (inUrl, expectedUrl) in data {
+            XCTAssertEqual(inUrl?.stripJavaScriptScheme(), expectedUrl)
+        }
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205376531515101/f

**Description**:
The browser currently allows users to enter javascript: URLs directly into the address bar. This can lead to several security issues, such as address bar spoofing, phishing, UXSS, etc.

Instead, I propose that we follow best practices and strip out the javascript scheme from the address bar when directly entered by users.

**Steps to test this PR**:
1. Paste the following string into the address bar: `javascript://duckduckgo.com/%0adocument.write(atob('PGgxPlBvQyBieSBDdXJlNTM8L2gxPg=='));document.close();w=open();w.close()`
2. Ensure that no page is loaded and that the address bar is not spoofed
3. Visit https://jsfiddle.net/rootkid/gmrnscL4/
4. Click "click me"
5. Ensure navigation is allowed

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
