### PR TITLE
Use sites scanned by broker instead of number of scans in the UI

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/UIMapper.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/UIMapper.swift
@@ -49,12 +49,17 @@ struct MapperToUI {
     }
 
     func initialScanState(_ brokerProfileQueryData: [BrokerProfileQueryData]) -> DBPUIInitialScanState {
-        let totalScans = brokerProfileQueryData.reduce(0) { accumulator, element in
-            return accumulator + element.totalScans
+        // Total and current scans are misleading. The UI are counting this per broker and
+        // not by the total real cans that the app is doing.
+        let profileQueriesGroupedByBroker = Dictionary.init(grouping: brokerProfileQueryData, by: { $0.dataBroker.name })
+
+        let totalScans = profileQueriesGroupedByBroker.reduce(0) { accumulator, element in
+            return accumulator + element.value.totalScans
         }
-        let currentScans = brokerProfileQueryData.reduce(0) { accumulator, element in
-            return accumulator + element.currentScans
+        let currentScans = profileQueriesGroupedByBroker.reduce(0) { accumulator, element in
+            return accumulator + element.value.currentScans
         }
+
         let scanProgress = DBPUIScanProgress(currentScans: currentScans, totalScans: totalScans)
         let matches = mapMatchesToUI(brokerProfileQueryData)
 
@@ -62,9 +67,11 @@ struct MapperToUI {
     }
 
     private func mapMatchesToUI(_ brokerProfileQueryData: [BrokerProfileQueryData]) -> [DBPUIDataBrokerProfileMatch] {
-        let matches = brokerProfileQueryData.compactMap {
+        return brokerProfileQueryData.flatMap {
+            var profiles = [DBPUIDataBrokerProfileMatch]()
             for extractedProfile in $0.extractedProfiles where !$0.profileQuery.deprecated {
-                var profiles = [mapToUI($0.dataBroker, extractedProfile: extractedProfile)]
+                profiles.append(mapToUI($0.dataBroker, extractedProfile: extractedProfile))
+
                 if !$0.dataBroker.mirrorSites.isEmpty {
                     let mirrorSitesMatches = $0.dataBroker.mirrorSites.compactMap { mirrorSite in
                         if mirrorSite.shouldWeIncludeMirrorSite() {
@@ -75,14 +82,10 @@ struct MapperToUI {
                     }
                     profiles.append(contentsOf: mirrorSitesMatches)
                 }
-
-                return profiles
             }
 
-            return nil
+            return profiles
         }
-
-        return matches.flatMap { $0 }
     }
 
     func maintenanceScanState(_ brokerProfileQueryData: [BrokerProfileQueryData]) -> DBPUIScanAndOptOutMaintenanceState {
@@ -206,22 +209,6 @@ extension String {
 
 fileprivate extension BrokerProfileQueryData {
 
-    var totalScans: Int {
-        if profileQuery.deprecated {
-            return 0
-        } else {
-            return 1 + dataBroker.mirrorSites.filter { $0.shouldWeIncludeMirrorSite() }.count
-        }
-    }
-
-    var currentScans: Int {
-        if scanOperationData.lastRunDate != nil && !profileQuery.deprecated {
-            return 1 + dataBroker.mirrorSites.filter { $0.shouldWeIncludeMirrorSite() }.count
-        } else {
-            return 0
-        }
-    }
-
     var sitesScanned: [String] {
         if scanOperationData.lastRunDate != nil {
             let scanEvents = scanOperationData.scanStartedEvents()
@@ -241,6 +228,34 @@ fileprivate extension BrokerProfileQueryData {
         }
 
         return [String]()
+    }
+}
+
+fileprivate extension Array where Element == BrokerProfileQueryData {
+
+    var totalScans: Int {
+        guard let broker = self.first?.dataBroker else { return 0 }
+
+        let areAllQueriesDeprecated = allSatisfy { $0.profileQuery.deprecated }
+
+        if areAllQueriesDeprecated {
+            return 0
+        } else {
+            return 1 + broker.mirrorSites.filter { $0.shouldWeIncludeMirrorSite() }.count
+        }
+    }
+
+    var currentScans: Int {
+        guard let broker = self.first?.dataBroker else { return 0 }
+
+        let areAllQueriesDeprecated = allSatisfy { $0.profileQuery.deprecated }
+        let areAllQueriesNotStartedScanning = allSatisfy { $0.scanOperationData.lastRunDate == nil }
+
+        if areAllQueriesDeprecated || areAllQueriesNotStartedScanning {
+            return 0
+        } else {
+            return 1 + broker.mirrorSites.filter { $0.shouldWeIncludeMirrorSite() }.count
+        }
     }
 }
 

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/MapperToUITests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/MapperToUITests.swift
@@ -29,33 +29,61 @@ final class MapperToUITests: XCTestCase {
 
         let result = sut.initialScanState(brokerProfileQueryData)
 
-        XCTAssertEqual(result.scanProgress.totalScans, brokerProfileQueryData.count)
         XCTAssertEqual(result.scanProgress.currentScans, 0)
         XCTAssertTrue(result.resultsFound.isEmpty)
     }
 
-    func testWhenAScanRan_thenCurrentScansGetsUpdated() {
-        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(), .mock(), .mock(lastRunDate: Date())]
+    func testWhenBrokerHasMoreThanOneProfileQuery_thenIsCountedAsOneInTotalScans() {
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            .mock(dataBrokerName: "Broker #1"),
+            .mock(dataBrokerName: "Broker #1"),
+            .mock(dataBrokerName: "Broker #2")
+        ]
 
         let result = sut.initialScanState(brokerProfileQueryData)
 
-        XCTAssertEqual(result.scanProgress.totalScans, brokerProfileQueryData.count)
+        XCTAssertEqual(result.scanProgress.totalScans, 2)
+    }
+
+    func testWhenAScanRanOnOneBroker_thenCurrentScansReflectsThatScansWereDoneOnThatBroker() {
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            .mock(dataBrokerName: "Broker #1"),
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date()),
+            .mock(dataBrokerName: "Broker #2")
+        ]
+
+        let result = sut.initialScanState(brokerProfileQueryData)
+
         XCTAssertEqual(result.scanProgress.currentScans, 1)
         XCTAssertTrue(result.resultsFound.isEmpty)
     }
 
     func testWhenAScanRanAndHasAMatch_thenResultsFoundIsUpdated() {
-        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(), .mock(), .mock(lastRunDate: Date(), extractedProfile: .mockWithRemovedDate)]
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(), .mock(), .mock(lastRunDate: Date(), extractedProfile: .mockWithoutRemovedDate)]
 
         let result = sut.initialScanState(brokerProfileQueryData)
 
-        XCTAssertEqual(result.scanProgress.totalScans, brokerProfileQueryData.count)
-        XCTAssertEqual(result.scanProgress.currentScans, 1)
         XCTAssertEqual(result.resultsFound.count, 1)
     }
 
+    func testWhenAScanRanAndHasAMatchForTheSameBroker_thenMatchesReflectsTheCorrectValue() {
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            .mock(dataBrokerName: "Broker #1"),
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date(), extractedProfile: .mockWithoutRemovedDate),
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date(), extractedProfile: .mockWithoutRemovedDate)
+        ]
+
+        let result = sut.initialScanState(brokerProfileQueryData)
+
+        XCTAssertEqual(result.resultsFound.count, 2)
+    }
+
     func testWhenAllScansRan_thenCurrentScansEqualsTotalScans() {
-        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(lastRunDate: Date()), .mock(lastRunDate: Date()), .mock(lastRunDate: Date())]
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date()),
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date()),
+            .mock(dataBrokerName: "Broker #2", lastRunDate: Date())
+        ]
 
         let result = sut.initialScanState(brokerProfileQueryData)
 
@@ -64,9 +92,10 @@ final class MapperToUITests: XCTestCase {
 
     func testWhenScansHaveDeprecatedProfileQueries_thenThoseAreNotTakenIntoAccount() {
         let brokerProfileQueryData: [BrokerProfileQueryData] = [
-            .mock(lastRunDate: Date(), extractedProfile: .mockWithRemovedDate),
-            .mock(lastRunDate: Date()),
-            .mock(lastRunDate: Date(), extractedProfile: .mockWithRemovedDate, deprecated: true)
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date(), extractedProfile: .mockWithRemovedDate),
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date()),
+            .mock(dataBrokerName: "Broker #2", lastRunDate: Date()),
+            .mock(dataBrokerName: "Broker #3", lastRunDate: Date(), extractedProfile: .mockWithRemovedDate, deprecated: true)
         ]
 
         let result = sut.initialScanState(brokerProfileQueryData)
@@ -136,28 +165,38 @@ final class MapperToUITests: XCTestCase {
     }
 
     func testWhenMirrorSiteIsNotInRemovedPeriod_thenItShouldBeAddedToTotalScans() {
-        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(), .mock(), .mock(mirrorSites: [.init(name: "mirror", addedAt: Date(), removedAt: nil)])]
+        let brokerProfileQueryWithMirrorSite: BrokerProfileQueryData = .mock(dataBrokerName: "Broker #1", mirrorSites: [.init(name: "mirror", addedAt: Date(), removedAt: nil)])
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            brokerProfileQueryWithMirrorSite,
+            brokerProfileQueryWithMirrorSite,
+            brokerProfileQueryWithMirrorSite
+        ]
 
         let result = sut.initialScanState(brokerProfileQueryData)
 
-        XCTAssertEqual(result.scanProgress.totalScans, brokerProfileQueryData.count + 1)
+        XCTAssertEqual(result.scanProgress.totalScans, 2)
     }
 
     func testWhenMirrorSiteIsInRemovedPeriod_thenItShouldNotBeAddedToTotalScans() {
-        let brokerWithMirrorSiteThatWasRemoved = BrokerProfileQueryData.mock(mirrorSites: [.init(name: "mirror", addedAt: Date(), removedAt: Date().yesterday)])
-        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(), .mock(), brokerWithMirrorSiteThatWasRemoved]
+        let brokerWithMirrorSiteThatWasRemoved = BrokerProfileQueryData.mock(dataBrokerName: "Broker #1", mirrorSites: [.init(name: "mirror", addedAt: Date(), removedAt: Date().yesterday)])
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(dataBrokerName: "Broker #1"), brokerWithMirrorSiteThatWasRemoved, .mock(dataBrokerName: "Broker #2")]
 
         let result = sut.initialScanState(brokerProfileQueryData)
 
-        XCTAssertEqual(result.scanProgress.totalScans, brokerProfileQueryData.count)
+        XCTAssertEqual(result.scanProgress.totalScans, 2)
     }
 
     func testWhenMirrorSiteIsNotInRemovedPeriod_thenItShouldBeAddedToCurrentScans() {
         let brokerWithMirrorSiteNotRemovedAndWithScan = BrokerProfileQueryData.mock(
+            dataBrokerName: "Broker #1",
             lastRunDate: Date(),
             mirrorSites: [.init(name: "mirror", addedAt: Date(), removedAt: nil)]
         )
-        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(), .mock(), brokerWithMirrorSiteNotRemovedAndWithScan]
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            brokerWithMirrorSiteNotRemovedAndWithScan,
+            brokerWithMirrorSiteNotRemovedAndWithScan,
+            .mock(dataBrokerName: "Broker #2")
+        ]
 
         let result = sut.initialScanState(brokerProfileQueryData)
 


### PR DESCRIPTION
## Task
https://app.asana.com/0/1204006570077678/1206052775622166/f

## Description
We are currently sending `currentScans` and `totalScans` to the UI with the actual values of what’s happening. The UI shows sites scanned, which is different from total scans. 

For example, if you add two names and one address, let's say we have only Verecor and Veriforia as brokers. We will send `totalScans = 4` (two scans on Verecor, two scans on Veriforia)

Now we send the scans **by broker**.  In the example above, we would show `totalScans = 2` (we only count the brokers Vercor and Veriforia).

One thing is that we will count a broker as ‘scanned’ if one of the profile queries for a particular broker has a scan date. The reason is that if we wait for all profile queries for a particular broker to finish to mark it as scanned, the user could see matches for more than one broker even when the count is one.

Example of the above:
- Broker Profile query 1 (John Doe, broker#1)
- Broker Profile query 2 (John Doe, broker#2)
- Broker Profile query 3 (Sean Doe, broker#1)
- Broker Profile query 4 (Sean Doe, broker#2)

If the first queries return matches, the count will be 1..2, and we will show matches for two brokers which could confuse the user.

**NOTE**: This PR also fixes a bug where if there were multiple matches for the same broker profile query, it would only show one.

## Steps to test

1. Start PIR from scratch (delete all data)
2. Create a profile with different names and addresses
3. The UI should show 1…to the amount of brokers (atm is 17)

**Test matches are correct**
1. Start PIR from scratch (delete all data)
2. Create a profile with different names and addresses, search a profile that has multiple profiles for the same query
3. The UI should show all the matches found

