### PR TITLE
Suspend sync and refreshing devices list while screen is locked

### DIFF
--- a/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -19,6 +19,7 @@
 import Foundation
 import DDGSync
 import Combine
+import Common
 import SystemConfiguration
 import SyncUI
 import SwiftUI
@@ -85,7 +86,7 @@ final class SyncPreferences: ObservableObject, SyncUI.ManagementViewModel {
     @Published var isSyncCredentialsPaused: Bool
 
     private var shouldRequestSyncOnFavoritesOptionChange: Bool = true
-
+    private var isScreenLocked: Bool = false
     private var recoveryKey: SyncCode.RecoveryKey?
 
     var recoveryCode: String? {
@@ -140,6 +141,18 @@ final class SyncPreferences: ObservableObject, SyncUI.ManagementViewModel {
                 self?.isSyncBookmarksPaused = UserDefaultsWrapper(key: .syncBookmarksPaused, defaultValue: false).wrappedValue
                 self?.isSyncCredentialsPaused = UserDefaultsWrapper(key: .syncCredentialsPaused, defaultValue: false).wrappedValue
             }
+            .store(in: &cancellables)
+
+        let screenIsLockedPublisher = DistributedNotificationCenter.default
+            .publisher(for: .init(rawValue: "com.apple.screenIsLocked"))
+            .map { _ in true }
+        let screenIsUnlockedPublisher = DistributedNotificationCenter.default
+            .publisher(for: .init(rawValue: "com.apple.screenIsUnlocked"))
+            .map { _ in false }
+
+        Publishers.Merge(screenIsLockedPublisher, screenIsUnlockedPublisher)
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.isScreenLocked, onWeaklyHeld: self)
             .store(in: &cancellables)
     }
 
@@ -241,6 +254,10 @@ final class SyncPreferences: ObservableObject, SyncUI.ManagementViewModel {
     }
 
     func refreshDevices() {
+        guard !isScreenLocked else {
+            os_log(.debug, log: .sync, "Screen is locked, skipping devices refresh")
+            return
+        }
         guard syncService.account != nil else {
             devices = []
             return
@@ -250,7 +267,7 @@ final class SyncPreferences: ObservableObject, SyncUI.ManagementViewModel {
                 let registeredDevices = try await syncService.fetchDevices()
                 mapDevices(registeredDevices)
             } catch {
-                print("error", error.localizedDescription)
+                os_log(.error, log: .sync, "Failed to refresh devices: \(error)")
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201493110486074/1204915472675708/f

**Description**:
Listen to screenIsLocked and screenIsUnlocked notifications from Distributed Notification Center
to suspend sync queue while screen is locked. Settings screen also subscribes to these notifications
to skip refreshing devices list.

**Steps to test this PR**:
1. Launch the app, enable Sync and enable Sync logging from Main Menu -> Debug -> Logging -> Sync.
2. Lock the screen: cmd+ctrl+q.
3. Unlock the screen.
4. Check the logs and verify that it suspended Sync queue after locking the screen and resumed it after unlocking.
5. Go to Sync settings. Verify that devices list is refreshed every 3 seconds.
6. Lock the screen (you may also put the computer to sleep by pressing Esc key on the locked screen and then wait some time).
7. Unlock the screen.
8. Check the logs and verify that devices list refreshing was being skipped while the screen was locked.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
