### PR TITLE
Instantiate a new DBP WebView every time we open the DBP tab

### DIFF
--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -448,6 +448,7 @@ final class BrowserTabViewController: NSViewController {
         bookmarksViewController?.removeCompletely()
 #if DBP
         dataBrokerProtectionHomeViewController?.removeCompletely()
+        dataBrokerProtectionHomeViewController = nil
 #endif
         if includingWebView {
             self.removeWebViewFromHierarchy()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1206111587274630/f

**Description**:
Instantiate a new DBP WebView every time we open the DBP tab

**Steps to test this PR**:
1. Open the DBP tap
2. Add something to check for the tab state, like opening the web inspector
3. Close the tab
4. Open it again
5. The new tab should not have the web inspector visible
6. Additionally, implement the deinit in the `DBPHomeViewController` and check if it's being called once you open it a second time

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
