### PR TITLE
Ensure that LinkPresentation framework is called on main thread

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12751,8 +12751,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "dominik/fix-favicons-fetcher-crash";
-				kind = branch;
+				kind = exactVersion;
+				version = 92.0.3;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "dominik/fix-favicons-fetcher-crash",
-        "revision" : "70c67be570df3ebdcdc1078288db2dcc80f58ce0"
+        "revision" : "5ca0b3d915ab73de43744db40edf41c1d5060034",
+        "version" : "92.0.3"
       }
     },
     {

--- a/LocalPackages/Account/Package.swift
+++ b/LocalPackages/Account/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Account"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "91.0.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "92.0.3"),
         .package(path: "../Purchase")
     ],
     targets: [

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "91.0.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "92.0.3"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "91.0.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "92.0.3"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201493110486074/1206113035171145/f

**Description**:
Ensure that LinkPresentation's metadata lookup API is called on main thread.
Otherwise, it would keep crashing on iOS 15.

**Steps to test this PR**:
See BSK PR for steps to test.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
