### PR TITLE
Make a broker as scanned when all profile queries have a lastRunDate

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/UIMapper.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/UIMapper.swift
@@ -249,9 +249,9 @@ fileprivate extension Array where Element == BrokerProfileQueryData {
         guard let broker = self.first?.dataBroker else { return 0 }
 
         let areAllQueriesDeprecated = allSatisfy { $0.profileQuery.deprecated }
-        let areAllQueriesNotStartedScanning = allSatisfy { $0.scanOperationData.lastRunDate == nil }
+        let didAllQueriesFinished = allSatisfy { $0.scanOperationData.lastRunDate != nil }
 
-        if areAllQueriesDeprecated || areAllQueriesNotStartedScanning {
+        if areAllQueriesDeprecated || !didAllQueriesFinished {
             return 0
         } else {
             return 1 + broker.mirrorSites.filter { $0.shouldWeIncludeMirrorSite() }.count

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/MapperToUITests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/MapperToUITests.swift
@@ -45,9 +45,9 @@ final class MapperToUITests: XCTestCase {
         XCTAssertEqual(result.scanProgress.totalScans, 2)
     }
 
-    func testWhenAScanRanOnOneBroker_thenCurrentScansReflectsThatScansWereDoneOnThatBroker() {
+    func testWhenAScanRanOnAllProfileQueriesOnTheSameBroker_thenCurrentScansReflectsThatScansWereDoneOnThatBroker() {
         let brokerProfileQueryData: [BrokerProfileQueryData] = [
-            .mock(dataBrokerName: "Broker #1"),
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date()),
             .mock(dataBrokerName: "Broker #1", lastRunDate: Date()),
             .mock(dataBrokerName: "Broker #2")
         ]
@@ -205,10 +205,15 @@ final class MapperToUITests: XCTestCase {
 
     func testWhenMirrorSiteIsInRemovedPeriod_thenItShouldNotBeAddedToCurrentScans() {
         let brokerWithMirrorSiteRemovedAndWithScan = BrokerProfileQueryData.mock(
+            dataBrokerName: "Broker #2",
             lastRunDate: Date(),
             mirrorSites: [.init(name: "mirror", addedAt: Date(), removedAt: Date().yesterday)]
         )
-        let brokerProfileQueryData: [BrokerProfileQueryData] = [.mock(), .mock(), brokerWithMirrorSiteRemovedAndWithScan]
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            .mock(dataBrokerName: "Broker #1"),
+            .mock(dataBrokerName: "Broker #1"),
+            brokerWithMirrorSiteRemovedAndWithScan
+        ]
 
         let result = sut.initialScanState(brokerProfileQueryData)
 


### PR DESCRIPTION
## Task
https://app.asana.com/0/1204006570077678/1206113158438785/f

## Description
In the past, we were marking a broker as scanned when at least one of the profile queries had a `lastRunDate` different from nil.

The problem is that if the user runs a scan and then reruns it after the initial one, all the previous scans ran, so it returns 17/17 to the UI, so the UI thinks it has completed.

I’ve changed the logic; a broker is marked as scanned when all the profile queries run at least once.

## Steps to test
1. Create a profile
2. After the initial is scan is done
3. Add a name or address
4. Check the scan screen is being shown

