### PR TITLE
Always use black and white colors for the QR code

### DIFF
--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/internal/QRCodeView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/internal/QRCodeView.swift
@@ -20,8 +20,6 @@ import SwiftUI
 import CoreImage
 
 struct QRCode: View {
-    @Environment(\.colorScheme) var colorScheme
-
     let string: String
     let size: CGSize
 
@@ -58,8 +56,8 @@ struct QRCode: View {
         }
 
         let colorParameters: [String: Any] = [
-            "inputColor0": CIColor(color: colorScheme == .light ? NSColor.black : NSColor.white)!,
-            "inputColor1": CIColor(color: NSColor.clear)!
+            "inputColor0": CIColor(color: NSColor.black)!,
+            "inputColor1": CIColor(color: NSColor.white)!
         ]
         let coloredImage = outputImage.applyingFilter("CIFalseColor", parameters: colorParameters)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201493110486074/1205142491450702/f

**Description**:
This is to increase compatibility with Android devices.


**Steps to test this PR**:
Verify that the Sync QR codes are displayed properly in both dark and light modes.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
