### PR TITLE
fix geolocation propmt when location permission not granted

### DIFF
--- a/DuckDuckGo/Geolocation/GeolocationService.swift
+++ b/DuckDuckGo/Geolocation/GeolocationService.swift
@@ -90,6 +90,9 @@ final class GeolocationService: NSObject, GeolocationServiceProtocol {
             assert(geolocationSubscriptionCounter >= 0)
             switch (oldValue, geolocationSubscriptionCounter) {
             case (0, 1):
+                if case .notDetermined = authorizationStatus {
+                    locationManager.requestWhenInUseAuthorization()
+                }
                 locationManager.startUpdatingLocation()
             case (1, 0):
                 locationManager.stopUpdatingLocation()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206070676223694/f
CC: @samsymons 

**Description**:
- fixes geolocation permission prompt not being shown when geolocation permission not granted

**Steps to test this PR**:
1. reset geolocation permission (clean+build the app, open Location services in System Prefs, ensure checbox is unset for DuckDuckGo)
2. disable system location services; visit https://permission.site, activate geolocation: validate location permission system informs that geo services are disabled and menu item opens system preferences
3. enable system location services; don‘t enable DDG location permission, request location for https://permission.site - validate location permission is first queried in the browser, then system prompt asks for DDG location permissions

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
