### PR TITLE
DBP: Update veripages JSON to 0.1.2

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Resources/JSON/veripages.com.json
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Resources/JSON/veripages.com.json
@@ -1,8 +1,8 @@
 {
   "name": "veripages.com",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "parent": "verecor.com",
-  "addedDatetime": 1691985600000,
+  "addedDatetime": 1691982000000,
   "steps": [
     {
       "stepType": "scan",
@@ -10,8 +10,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "e1adef78-997c-42f5-8c33-501566fc705b",
-          "url": "https://veripages.com/inner/profile/search?fname=${firstName}&lname=${lastName}&fage=${ageRange}&state=${state}&city=${city}",
+          "id": "5bf98772-1804-4939-a06b-dbf9cd31f198",
+          "url": "https://veripages.com/inner/profile/search?fname=${firstName}&lname=${lastName}&fage=${age|ageRange}&state=${state}&city=${city}",
           "ageRange": [
             "18-30",
             "31-40",
@@ -24,7 +24,7 @@
         },
         {
           "actionType": "extract",
-          "id": "1a06491a-e2b6-4d04-9ac2-d14b0776415a",
+          "id": "f3d53642-9a58-4275-b97f-5547e3ef8e55",
           "selector": ".search-item",
           "profile": {
             "name": {
@@ -40,7 +40,7 @@
               "afterText": ", "
             },
             "addressCityStateList": {
-              "selector": ".//span[@itemprop='address']",
+              "selector": ".//div[contains(@class, 'search-item')]//dt[text() = 'Has lived in']/following-sibling::dd/ul/li",
               "findElements": true
             },
             "relativesList": {


### PR DESCRIPTION
## Task
https://app.asana.com/0/1204006570077678/1206113162462629/f

## Description
Update Veripages with new selector fix

## Steps to test

1. Do a clean DBP install (remove the DB or edit your current profile)
2. In the new/edited profile add a name that is on the veripages search
3. check that veripages appears as a match in the scanning results
