### PR TITLE
Offer to use build number from Xcode when it's higher than the latest release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,7 +108,6 @@ platform :mac do
   #
   # @option [String] version (default: nil) Marketing version string
   # @option [Boolean] resume (default: false) If true, the lane can run from a release/ branch and will run dedicated prechecks.
-  # @option [Boolean] force (default: false) Don't ask for confirmation.
   #
   desc 'Executes the release preparation work in the repository'
   lane :code_freeze do |options|
@@ -120,8 +119,7 @@ platform :mac do
       macos_update_embedded_files
       macos_update_version_and_build_number_config(
         version: new_version,
-        build_number: build_number,
-        force: options[:force]
+        build_number: build_number
       )
       sh('git', 'push')
 
@@ -146,8 +144,6 @@ platform :mac do
   # - Should be called on an existing internal release branch.
   # - Also runs unit tests after updating embedded files.
   #
-  # @option [Boolean] force (default: false) Don't ask for confirmation.
-  #
   desc 'Prepares new internal release on top of an existing one'
   lane :bump_internal_release do |options|
     begin
@@ -155,15 +151,14 @@ platform :mac do
         UI.abort_with_message!("Incorrect branch. Branch name must start with '#{RELEASE_BRANCH}/'.")
       end
 
-      force = options[:force].nil? ? false : options[:force]
       current_version = macos_current_version
       current_build_number = macos_current_build_number
       build_number = increment_current_build_number(options)
 
-      UI.important("Current version is #{current_version} (#{current_build_number}).")
-      UI.important("Will update to #{current_version} (#{build_number}).")
+      UI.important("Current version in project settings is #{current_version} (#{current_build_number}).")
+      UI.important("Will be updated to #{current_version} (#{build_number}).")
 
-      unless force
+      if UI.interactive?
         unless UI.confirm("Do you want to continue?")
           UI.abort_with_message!('Aborted by user.')
         end
@@ -172,8 +167,7 @@ platform :mac do
       macos_update_embedded_files
       macos_update_version_and_build_number_config(
         version: current_version,
-        build_number: build_number,
-        force: true
+        build_number: build_number
       )
       sh('git', 'push')
 
@@ -198,7 +192,6 @@ platform :mac do
   # - Pushes changes to remote
   #
   # @option [String] version Marketing version string to be hotfixed (must be equal to an existing tag)
-  # @option [Boolean] force (default: false) Don't ask for confirmation.
   #
   desc 'Executes the hotfix release preparation work in the repository'
   lane :prepare_hotfix do |options|
@@ -211,8 +204,7 @@ platform :mac do
     macos_create_hotfix_branch(source_version: source_version, new_version: new_version)
     macos_update_version_and_build_number_config(
       version: new_version,
-      build_number: build_number,
-      force: options[:force]
+      build_number: build_number
     )
     sh('git', 'push')
   end
@@ -220,7 +212,6 @@ platform :mac do
   # Updates marketing version to the specified one and increments build number by 1.
   #
   # @option [String] version Marketing version string.
-  # @option [Boolean] force (default: false) Don't ask for confirmation.
   #
   desc 'Executes the release preparation work in the repository'
   lane :set_version do |options|
@@ -335,18 +326,16 @@ platform :mac do
   # and prompts the user to confirm
   #
   # @option [String] version (default: nil) Marketing version string
-  # @option [Boolean] force (default: false) Don't ask for confirmation.
   #
   private_lane :validate_new_version do |options|
     current_version = macos_current_version
     user_version = format_user_version(options[:version])
     new_version = user_version.nil? ? macos_bump_minor_version(current_version) : user_version
 
-    UI.important("Current version is #{current_version}.")
+    UI.important("Current version in project settings is #{current_version}.")
     UI.important("New version is #{new_version}.")
 
-    force = options[:force].nil? ? false : options[:force]
-    unless force
+    if UI.interactive?
       UI.abort_with_message!('Aborted by user.') unless UI.confirm("Do you want to continue?")
     end
     new_version
@@ -367,7 +356,6 @@ platform :mac do
   # Bumps provided version for hotfixing and presents to the user for confirmation.
   #
   # @option [String] source_version Marketing version string of the release that needs to be hotfixed.
-  # @option [Boolean] force (default: false) Don't ask for confirmation.
   #
   private_lane :validate_hotfix_version do |options|
     source_version = options[:source_version]
@@ -375,8 +363,7 @@ platform :mac do
 
     UI.important("Release #{source_version} will be hotfixed as #{new_version}.")
 
-    force = options[:force].nil? ? false : options[:force]
-    unless force
+    if UI.interactive?
       unless UI.confirm("Do you want to continue?")
         UI.abort_with_message!('Aborted by user.')
       end
@@ -385,12 +372,41 @@ platform :mac do
     new_version
   end
 
-  # Checks current build number and increments it by 1.
+  # Checks current build number in Sparkle's appcast.xml and TestFlight
+  # and increments it by 1.
   #
   desc 'Increment build number'
   private_lane :increment_current_build_number do |options|
-    macos_current_build_number = [fetch_testflight_build_number(options), fetch_appcast_build_number].max
-    macos_current_build_number + 1
+    testflight_build_number = fetch_testflight_build_number(options)
+    appcast_build_number = fetch_appcast_build_number
+    xcodeproj_build_number = macos_current_build_number
+    current_release_build_number = [testflight_build_number, appcast_build_number].max
+
+    UI.message("TestFlight build number: #{testflight_build_number}")
+    UI.message("Appcast.xml build number: #{appcast_build_number}")
+    UI.message("Latest release build number (max of TestFlight and appcast): #{current_release_build_number}")
+    UI.message("Xcode project settings build number: #{xcodeproj_build_number}")
+
+    if xcodeproj_build_number <= current_release_build_number
+      new_build_number = current_release_build_number
+    else
+      UI.important "Warning: Build number from Xcode project (#{xcodeproj_build_number}) is higher than the current release (#{current_release_build_number})."
+      UI.message %{This may be an error in the Xcode project settings, or it may mean that there is a hotfix
+release in progress and you're making a follow-up internal release that includes the hotfix.}
+      if UI.interactive?
+        build_numbers = {
+          "Current release (#{current_release_build_number})" => current_release_build_number,
+          "Xcode project (#{xcodeproj_build_number})" => xcodeproj_build_number,
+        }
+        choice = UI.select "Please choose which build number to bump:", build_numbers.keys
+        new_build_number = build_numbers[choice]
+      else
+        UI.important("Shell is non-interactive, so we'll bump the Xcode project build number.")
+        new_build_number = xcodeproj_build_number
+      end
+    end
+
+    new_build_number + 1
   end
 
   private_lane :fetch_testflight_build_number do |options|


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1206133167827450/f

**Description**:
This is to support making internal releases containing an unreleased hotfix.
Additionally, this change removes `force` parameter and replaces it with built-in
fastlane `UI.interactive?` checks.

**Steps to test this PR**:
1. Create a release branch off this branch (make sure its name starts with `release/`). Don't push the branch to remote.
2. Call `bundle exec fastlane mac bump_internal_release`, verify that the AppStore release number is bumped by 1.
3. Update `Config/BuildNumber.xcconfig` to contain build number higher than AppStore release build number.
4. Call `bundle exec fastlane mac bump_internal_release` again, verify that you're being offered to choose whether to bump the local number or AppStore number.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
