### PR TITLE
Include build number in App Store dSYM file name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,7 +54,7 @@ platform :mac do
   lane :release_testflight do |options|
     build_release(options)
 
-    # upload_to_testflight(options.merge({api_key: get_api_key}))
+    upload_to_testflight(options.merge({api_key: get_api_key}))
   end
 
   # Makes App Store release build, uploads it to TestFlight, and prepares App Store listing for submission.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206145260961047/f

**Steps to test this PR**:
Check out the output of [this workflow](https://github.com/duckduckgo/macos-browser/actions/runs/7172818918) and verify that the artifact dSYM contains build number in its file name :)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
