### PR TITLE
Allow individual variant builds to fail without cancelling others

### DIFF
--- a/.github/workflows/create_variants.yml
+++ b/.github/workflows/create_variants.yml
@@ -34,6 +34,7 @@ jobs:
     needs: set-up-variants
 
     strategy:
+      fail-fast: false
       matrix: ${{ fromJSON(needs.set-up-variants.outputs.atb-variants) }}
 
     runs-on: macos-12


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206145260961053/f

**Description**:
Disable `fail-fast` flag for the variants matrix so that a single failed job won't cause others to get cancelled.

**Steps to test this PR**:
1. Check out [this workflow run](https://github.com/duckduckgo/macos-browser/actions/runs/7173190470/attempts/1) and verify that 1 of 10 jobs has failed, but others have successfully completed.
2. Check out [the re-run](https://github.com/duckduckgo/macos-browser/actions/runs/7173190470) and verify that all jobs are successful.
3. Check out [the usage](https://github.com/duckduckgo/macos-browser/actions/runs/7173190470/usage) for that workflow and verify that only the `lc` job was billed (run) twice.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
