### PR TITLE
Fix PR Checks workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Check out the code
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && github.event_name != 'push'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.ref_name }}
@@ -96,7 +96,7 @@ jobs:
         submodules: recursive
 
     - name: Check out the code
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && github.event_name != 'push'
       uses: actions/checkout@v3
       with:
         submodules: recursive


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206155126726473/f

**Description**:
Only pass `ref` parameter to checkout action in PR Checks when the workflow is called by another workflow.

**Steps to test this PR**:
1. Verify that CI is green.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
