### PR TITLE
change order of items in autofill add new item

### DIFF
--- a/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -777,9 +777,9 @@ final class PasswordManagementViewController: NSViewController {
         }
 
         menu.items = [
-            createMenuItem(title: UserText.pmNewCard, action: #selector(createNewCreditCard), imageName: "CreditCardGlyph"),
             createMenuItem(title: UserText.pmNewLogin, action: #selector(createNewLogin), imageName: "LoginGlyph"),
-            createMenuItem(title: UserText.pmNewIdentity, action: #selector(createNewIdentity), imageName: "IdentityGlyph")
+            createMenuItem(title: UserText.pmNewIdentity, action: #selector(createNewIdentity), imageName: "IdentityGlyph"),
+            createMenuItem(title: UserText.pmNewCard, action: #selector(createNewCreditCard), imageName: "CreditCardGlyph"),
         ]
 
         return menu


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206145724083864/f

**Description**: Change order of autofill item in Passwords manager when adding new items

**Steps to test this PR**:
1. Open the password manager 
2. check then when pressing + the items are in order: logins, identities, credit cards
3. check when pressing on all items that the items appear in the order:  logins, identities, credit cards

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
