### PR TITLE
remove QR code from save recovery PDF view

### DIFF
--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/Dialogs/SaveRecoveryPDFView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/Dialogs/SaveRecoveryPDFView.swift
@@ -31,17 +31,14 @@ struct SaveRecoveryPDFView: View {
                 SyncUIViews.TextDetailMultiline(text: UserText.recoveryPDFExplanation)
             }
             VStack(alignment: .leading, spacing: 20) {
-                HStack {
-                    QRCode(string: code, size: CGSize(width: 56, height: 56))
-                    Text(code)
-                        .kerning(2)
-                        .multilineTextAlignment(.leading)
-                        .lineSpacing(5)
-                        .lineLimit(3)
-                        .font(Font.custom("SF Mono", size: 12))
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .frame(width: 340)
+                Text(code)
+                    .kerning(2)
+                    .multilineTextAlignment(.leading)
+                    .lineSpacing(5)
+                    .lineLimit(3)
+                    .font(Font.custom("SF Mono", size: 12))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(width: 340)
                 HStack {
                     Button {
                         viewModel.delegate?.copyCode()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206162433383042/f

**Description**: Remove QR code from save recovery PDF view

**Steps to test this PR**:
1. Create an account and when you get to the recovery PDF screen check the QR code is not there anymore.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
