### PR TITLE
Use static date for PixelKit tests

### DIFF
--- a/LocalPackages/PixelKit/Tests/PixelKitTests/PixelKitTests.swift
+++ b/LocalPackages/PixelKit/Tests/PixelKitTests/PixelKitTests.swift
@@ -267,7 +267,7 @@ final class PixelKitTests: XCTestCase {
         timeMachine.travel(by: 60 * 60 * 10)
         pixelKit.fire(event, frequency: .dailyOnly) // Skipped (10 hours since last fire)
 
-        timeMachine.travel(by: 60 * 60 * 24)
+        timeMachine.travel(by: 60 * 60 * 14)
         pixelKit.fire(event, frequency: .dailyOnly) // Fired (24 hours since last fire)
 
         // Wait for expectations to be fulfilled


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206177144674653/f
Tech Design URL:
CC: @ayoy @quanganhdo 

**Description**:

This PR changes the date used by the PixelKit tests to be static.

**Steps to test this PR**:
1. Make sure tests pass on CI and locally

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
