### PR TITLE
Add PixelKit source parameter

### DIFF
--- a/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -379,8 +379,17 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
         dryRun = false
 #endif
 
+        let source: String
+
+#if NETP_SYSTEM_EXTENSION
+        source = "vpnSystemExtension"
+#else
+        source = "vpnAppExtension"
+#endif
+
         PixelKit.setUp(dryRun: dryRun,
                        appVersion: AppVersion.shared.versionNumber,
+                       source: source,
                        defaultHeaders: defaultHeaders,
                        log: .networkProtectionPixel,
                        defaults: .netP) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in

--- a/DuckDuckGoDBPBackgroundAgent/DuckDuckGoDBPBackgroundAgentAppDelegate.swift
+++ b/DuckDuckGoDBPBackgroundAgent/DuckDuckGoDBPBackgroundAgentAppDelegate.swift
@@ -41,6 +41,7 @@ final class DuckDuckGoDBPBackgroundAgentApplication: NSApplication {
 
         PixelKit.setUp(dryRun: dryRun,
                        appVersion: AppVersion.shared.versionNumber,
+                       source: nil,
                        defaultHeaders: [:],
                        log: .dbpBackgroundAgentPixel,
                        defaults: .standard) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping (Bool, Error?) -> Void) in

--- a/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -173,7 +173,12 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
         dryRun = false
 #endif
 
-        PixelKit.setUp(dryRun: dryRun, appVersion: AppVersion.shared.versionNumber, defaultHeaders: [:], log: .networkProtectionPixel, defaults: .netP) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in
+        PixelKit.setUp(dryRun: dryRun,
+                       appVersion: AppVersion.shared.versionNumber,
+                       source: "vpnAgent",
+                       defaultHeaders: [:],
+                       log: .networkProtectionPixel,
+                       defaults: .netP) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in
 
             let url = URL.pixelUrl(forPixelNamed: pixelName)
             let apiHeaders = APIRequest.Headers(additionalHeaders: headers) // workaround - Pixel class should really handle APIRequest.Headers by itself

--- a/LocalPackages/PixelKit/Sources/PixelKit/PixelKit+Parameters.swift
+++ b/LocalPackages/PixelKit/Sources/PixelKit/PixelKit+Parameters.swift
@@ -24,6 +24,7 @@ public extension PixelKit {
         public static let duration = "duration"
         public static let test = "test"
         public static let appVersion = "appVersion"
+        public static let pixelSource = "pixelSource"
         public static let osMajorVersion = "osMajorVersion"
 
         public static let errorCode = "e"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206203334750907/f
Tech Design URL:
CC:

**Description**:

This PR adds a `source` parameter to the PixelKit `setUp` function, to allow us to include which target is sending the pixel.

**Steps to test this PR**:
1. Run the app and check that pixels are sending with the correct parameters - Console.app can be used for this, or for the VPN agent you can attach the debugger directly. Alternatively, make a release build and check the real pixel calls in Kibana.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
