### PR TITLE
Fix for empty autofill state displayed on top of existing password items

### DIFF
--- a/DuckDuckGo/SecureVault/Model/PasswordManagementItemListModel.swift
+++ b/DuckDuckGo/SecureVault/Model/PasswordManagementItemListModel.swift
@@ -376,6 +376,8 @@ final class PasswordManagementItemListModel: ObservableObject {
             itemsByCategory = itemsByCategory.filter { $0.item(matches: filter) }
         }
 
+        clearSelection()
+
         if displayedItems.isEmpty && items.isEmpty {
             return
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206123717688571/f
Tech Design URL:
CC:

**Description**:
Empty state for autofill items are displayed on top of an existing password view.

**Steps to test this PR**:
1. Set up the app state so that there are autofill logins / passwords saved but no credit cards saved
2. Go to the autofill popover and change the filter from "All Items" to "Credit Cards"
3. Confirm the "empty state" view for the filter is properly displayed like so: 
<img width="543" alt="image" src="https://github.com/duckduckgo/macos-browser/assets/91189922/f18149bf-2bcd-4f92-8a96-4e09437cf88b">

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
