### PR TITLE
Updates the copy for the VPN status bar item context menu

### DIFF
--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Menu/StatusBarMenuModel.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Menu/StatusBarMenuModel.swift
@@ -28,7 +28,7 @@ public final class StatusBarMenuModel {
     }
 
     var hideVPNMenu: NSMenuItem {
-        let item = NSMenuItem(title: "Don't Show VPN in Menu Bar", action: #selector(hideVPNMenuItemAction), keyEquivalent: "")
+        let item = NSMenuItem(title: "Don’t Show VPN in Menu Bar", action: #selector(hideVPNMenuItemAction), keyEquivalent: "")
         item.target = self
         return item
     }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1199230911884351/1206229689016768/f

## Description

Updates the VPN's status-bar-item context menu to the latest copy ("Don't Show VPN in Menu Bar").

Ref: https://app.asana.com/0/38424471409662/1206193217202489/f

## Testing

1. Launch the App, make sure to kill the VPN menu agent app if it's running to make sure the latest one is loaded
2. Right click on the VPN status bar menu
3. Make sure the copy for the only available item reads "Don't Show VPN in Menu Bar"

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
