### PR TITLE
Update latency & tunnel failure monitor implementation

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13043,8 +13043,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "anh/multiple-timer-fix";
-				kind = branch;
+				kind = exactVersion;
+				version = 99.0.2;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "anh/multiple-timer-fix",
-        "revision" : "256a31cb498449b1aa5ce7e095b80c2bb40e08ab"
+        "revision" : "18043cbc24e5bb79aa1f44e01a367e0bccd2fa6e",
+        "version" : "99.0.2"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/LoginItems/Package.swift
+++ b/LocalPackages/LoginItems/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],

--- a/LocalPackages/PixelKit/Package.swift
+++ b/LocalPackages/PixelKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/Subscription/Package.swift
+++ b/LocalPackages/Subscription/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Subscription"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SwiftUIExtensions/Package.swift
+++ b/LocalPackages/SwiftUIExtensions/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../SwiftUIExtensions"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SystemExtensionManager/Package.swift
+++ b/LocalPackages/SystemExtensionManager/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/XPCHelper/Package.swift
+++ b/LocalPackages/XPCHelper/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "XPCHelper", targets: ["XPCHelper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206209663744590/f and https://app.asana.com/0/0/1206212872939262/f

**Description**:

Updates the monitor implementation to use Task to address situations when timer is launched multiple times.

**Steps to test this PR**:
1. Run the app and turn on the VPN
2. Kill the network extension. It will auto launch back up. 
3. Check Console.log to make sure latency/last handshake are only logged every 5 and 10 seconds respectively. 

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
