### PR TITLE
Adds option + click support for our VPN menu to show some useful debu…

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarPopoverManager.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarPopoverManager.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import Foundation
 import NetworkProtection
 import NetworkProtectionIPC
@@ -61,7 +62,9 @@ final class NetworkProtectionNavBarPopoverManager {
             let onboardingStatusPublisher = UserDefaults.netP.networkProtectionOnboardingStatusPublisher
             _ = VPNSettings(defaults: .netP)
 
-            let popover = NetworkProtectionPopover(controller: controller, onboardingStatusPublisher: onboardingStatusPublisher, statusReporter: statusReporter) {
+            let popover = NetworkProtectionPopover(controller: controller,
+                                                   onboardingStatusPublisher: onboardingStatusPublisher,
+                                                   statusReporter: statusReporter) {
                 let menuItems = [
                     NetworkProtectionStatusView.Model.MenuItem(
                         name: UserText.networkProtectionNavBarStatusMenuVPNSettings, action: {

--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Menu/StatusBarMenu.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Menu/StatusBarMenu.swift
@@ -59,7 +59,10 @@ public final class StatusBarMenu: NSObject {
         self.statusItem = statusItem
         self.iconPublisher = NetworkProtectionIconPublisher(statusReporter: statusReporter, iconProvider: iconProvider)
 
-        popover = NetworkProtectionPopover(controller: controller, onboardingStatusPublisher: onboardingStatusPublisher, statusReporter: statusReporter, menuItems: menuItems)
+        popover = NetworkProtectionPopover(controller: controller,
+                                           onboardingStatusPublisher: onboardingStatusPublisher,
+                                           statusReporter: statusReporter,
+                                           menuItems: menuItems)
         popover.behavior = .transient
 
         super.init()
@@ -74,6 +77,7 @@ public final class StatusBarMenu: NSObject {
 
     @objc
     private func statusBarButtonTapped() {
+        let isOptionKeyPressed = NSApp.currentEvent?.modifierFlags.contains(.option) ?? false
         let isRightClick = NSApp.currentEvent?.type == .rightMouseUp
 
         guard !isRightClick else {
@@ -81,7 +85,7 @@ public final class StatusBarMenu: NSObject {
             return
         }
 
-        togglePopover()
+        togglePopover(isOptionKeyPressed: isOptionKeyPressed)
     }
 
     private func subscribeToIconUpdates() {
@@ -95,7 +99,7 @@ public final class StatusBarMenu: NSObject {
 
     // MARK: - Popover
 
-    private func togglePopover() {
+    private func togglePopover(isOptionKeyPressed: Bool) {
         if popover.isShown {
             popover.close()
         } else {
@@ -103,6 +107,7 @@ public final class StatusBarMenu: NSObject {
                 return
             }
 
+            popover.setShowsDebugInformation(isOptionKeyPressed)
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
     }

--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/DebugInformationView/DebugInformationView.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/DebugInformationView/DebugInformationView.swift
@@ -1,0 +1,90 @@
+//
+//  DebugInformationView.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import SwiftUIExtensions
+import Combine
+import NetworkProtection
+
+public struct DebugInformationView: View {
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Model
+
+    /// The view model that this instance will use.
+    ///
+    @ObservedObject var model: DebugInformationViewModel
+
+    // MARK: - Initializers
+
+    public init(model: DebugInformationViewModel) {
+        self.model = model
+    }
+
+    // MARK: - View Contents
+
+    public var body: some View {
+        Group {
+            VStack(alignment: .leading, spacing: 0) {
+                informationRow(title: "Bundle Path", details: model.bundlePath)
+                informationRow(title: "Version", details: model.version)
+            }
+
+            Divider()
+                .padding(EdgeInsets(top: 5, leading: 9, bottom: 5, trailing: 9))
+        }
+    }
+
+    // MARK: - Composite Views
+
+    private func informationRow(title: String, details: String) -> some View {
+        VStack(spacing: 2) {
+            HStack {
+                Text(title)
+                    .padding(.leading, 24)
+                    .opacity(0.6)
+                    .font(.system(size: 12, weight: .bold, design: .default))
+                    .fixedSize()
+
+                Spacer()
+            }
+
+            HStack {
+                Text(details)
+                    .makeSelectable()
+                    .multilineText()
+                    .padding(.leading, 24)
+                    .opacity(0.6)
+                    .font(.system(size: 12, weight: .regular, design: .default))
+
+                Spacer()
+            }
+        }
+        .padding(EdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 9))
+    }
+
+    // MARK: - Rows
+
+    private func dividerRow() -> some View {
+        Divider()
+            .padding(EdgeInsets(top: 5, leading: 9, bottom: 5, trailing: 9))
+    }
+}

--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/DebugInformationView/DebugInformationViewModel.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/DebugInformationView/DebugInformationViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  DebugInformationViewModel.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+import NetworkProtection
+import SwiftUI
+
+@MainActor
+public final class DebugInformationViewModel: ObservableObject {
+
+    var bundlePath: String
+    var version: String
+
+    // MARK: - Initialization & Deinitialization
+
+    public init(bundle: Bundle = .main) {
+        bundlePath = bundle.bundlePath
+
+        // swiftlint:disable:next force_cast
+        let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+
+        // swiftlint:disable:next force_cast
+        let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as! String
+
+        version = shortVersion + " (build: " + buildNumber + ")"
+    }
+}

--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/StatusView/NetworkProtectionStatusView.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/StatusView/NetworkProtectionStatusView.swift
@@ -65,6 +65,10 @@ public struct NetworkProtectionStatusView: View {
             TunnelControllerView(model: model.tunnelControllerViewModel)
                 .disabled(model.tunnelControllerViewDisabled)
 
+            if model.showDebugInformation {
+                DebugInformationView(model: DebugInformationViewModel())
+            }
+
             bottomMenuView()
         }
         .padding(5)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206230773829767/f

## Description

Adds debug information to the VPN menu.

<img width="422" alt="Screenshot 2023-12-22 at 11 08 55 PM" src="https://github.com/duckduckgo/macos-browser/assets/1836005/7bf96a1a-3d4e-40a2-90ab-ca63105d425e">


## Testing

1. Launch the App
2. Enable NetP
3. Make sure our VPN menu app is launched.
4. Click on the VPN menu normally, no debug info should be shown.
5. Option + click on the VPN menu, you should see debug information.
6. Make sure you can select the debug values and right click to copy it (CMD + C doesn't work).

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
