### PR TITLE
Fix clickable area for buttons in 'Sync with Another Device' view

### DIFF
--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/Dialogs/SyncWithAnotherDeviceView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/Dialogs/SyncWithAnotherDeviceView.swift
@@ -63,41 +63,33 @@ struct SyncWithAnotherDeviceView: View {
 
     fileprivate func pickerView() -> some View {
         return HStack(spacing: 0) {
-            HStack {
-                Image("QR-Icon")
-                Text(UserText.syncWithAnotherDeviceShowCodeButton)
-            }
-            .onTapGesture {
-                selectedSegment = 0
-            }
-            .frame(width: 172, height: 28)
-            .background(
-                ZStack {
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(selectedSegment == 0 ? Color("BlackWhite10") : .clear, lineWidth: 1)
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(selectedSegment == 0 ? Color("PickerViewSelected") : Color("BlackWhite1"))
-                }
-            )
-            HStack {
-                Image("Keyboard-16D")
-                Text(UserText.syncWithAnotherDeviceEnterCodeButton)
-            }
-            .onTapGesture {
-                selectedSegment = 1
-            }
-            .frame(width: 172, height: 28)
-            .background(
-                ZStack {
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(selectedSegment == 1 ? Color("BlackWhite10") : .clear, lineWidth: 1)
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(selectedSegment == 1 ? Color("PickerViewSelected")  : Color("BlackWhite1"))
-                }
-            )
+            pickerOptionView(imageName: "QR-Icon", title: UserText.syncWithAnotherDeviceShowCodeButton, tag: 0)
+            pickerOptionView(imageName: "Keyboard-16D", title: UserText.syncWithAnotherDeviceEnterCodeButton, tag: 1)
         }
         .frame(width: 348, height: 32)
         .roundedBorder()
+    }
+
+    @ViewBuilder
+    fileprivate func pickerOptionView(imageName: String, title: String, tag: Int) -> some View {
+        Button {
+            selectedSegment = tag
+        } label: {
+            HStack {
+                Image(imageName)
+                Text(title)
+            }
+            .frame(width: 172, height: 28)
+            .background(
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(selectedSegment == tag ? Color("BlackWhite10") : .clear, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(selectedSegment == tag ? Color("PickerViewSelected") : Color("BlackWhite1"))
+                }
+            )
+        }
+        .buttonStyle(.plain)
     }
 
     fileprivate func scanQRCodeView() -> some View {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201621708115095/1206241303343270

**Description**:
Replace HStacks with tap gesture recognizer with Buttons.

**Steps to test this PR**:
1. Open Settings and go to Sync & Backup
2. Click "Sync with Another Device"
3. Toggle between "Show Code" and "Enter Code", verifying that clickable area spans the entire buttons' area, not only the text and icon.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
