### PR TITLE
Always use 'sandbox' Application Support directory for Favicons Fetcher

### DIFF
--- a/DuckDuckGo/Sync/SyncBookmarksAdapter.swift
+++ b/DuckDuckGo/Sync/SyncBookmarksAdapter.swift
@@ -36,19 +36,6 @@ public class BookmarksFaviconsFetcherErrorHandler: EventMapping<BookmarksFavicon
     }
 }
 
-enum SyncBookmarksAdapterError: CustomNSError {
-    case unableToAccessFaviconsFetcherStateStoreDirectory
-
-    static let errorDomain: String = "SyncBookmarksAdapterError"
-
-    var errorCode: Int {
-        switch self {
-        case .unableToAccessFaviconsFetcherStateStoreDirectory:
-            return 1
-        }
-    }
-}
-
 final class SyncBookmarksAdapter {
 
     private(set) var provider: BookmarksProvider?
@@ -157,10 +144,7 @@ final class SyncBookmarksAdapter {
     private func setUpFaviconsFetcher() -> BookmarksFaviconsFetcher? {
         let stateStore: BookmarksFaviconsFetcherStateStore
         do {
-            guard let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-                throw SyncBookmarksAdapterError.unableToAccessFaviconsFetcherStateStoreDirectory
-            }
-            stateStore = try BookmarksFaviconsFetcherStateStore(applicationSupportURL: url)
+            stateStore = try BookmarksFaviconsFetcherStateStore(applicationSupportURL: URL.sandboxApplicationSupportURL)
         } catch {
             Pixel.fire(.debug(event: .bookmarksFaviconsFetcherStateStoreInitializationFailed, error: error))
             os_log(.error, log: OSLog.sync, "Failed to initialize BookmarksFaviconsFetcherStateStore: %{public}s", String(reflecting: error))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201493110486074/1206273801294475/f

**Description**:
Make sure that Favicons Fetcher uses a directory inside app container, also on DMG builds.

**Steps to test this PR**:
1. `rm -r ~/Library/Application\ Support/FaviconsFetcher`
2. Verify that `ls ~/Library/Containers/com.duckduckgo.macos.browser.debug/Data/Library/Application\ Support/FaviconsFetcher` shows that there's no such directory
3. Enable Sync
4. In Sync Settings, enable Favicons Fetching
5. Verify that `~/Library/Application\ Support/FaviconsFetcher` is still not present
6. Verify that `ls ~/Library/Containers/com.duckduckgo.macos.browser.debug/Data/Library/Application\ Support/FaviconsFetcher` lists a directory.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
