### PR TITLE
DBP: Respect foreign constraints when deleting all user's data

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
@@ -321,27 +321,15 @@ final class DefaultDataBrokerProtectionDatabaseProvider: GRDBSecureStorageDataba
 
     func deleteProfileData() throws {
         try db.write { db in
-            try OptOutHistoryEventDB
-                .deleteAll(db)
             try OptOutDB
                 .deleteAll(db)
-            try ScanHistoryEventDB
-                .deleteAll(db)
             try ScanDB
-                .deleteAll(db)
-            try ExtractedProfileDB
-                .deleteAll(db)
-            try ProfileQueryDB
-                .deleteAll(db)
-            try BrokerDB
                 .deleteAll(db)
             try NameDB
                 .deleteAll(db)
             try AddressDB
                 .deleteAll(db)
             try PhoneDB
-                .deleteAll(db)
-            try ProfileDB
                 .deleteAll(db)
         }
     }


### PR DESCRIPTION
## Task
https://app.asana.com/0/1204006570077678/1206098291891775/f

## Description
Fixed a bug where removing all data was throwing an exception caused by a foreign key constraint

## Steps to test

1. Create a PIR and start a scan (it has to have matches)
2. Go to `DataBrokerProfileQueryOperationManager` and change the scan operation to return an empty array of extracted profiles (to simulate that those profiles were removed)
3. Force scans using the Debug menu
4. Go to Edit Profile and tap on the ’turn off my data' option at the bottom
5. Check the database using the Debug menu. It should be empty
6. Run a new scan with a new profile, no old data should appear.