### PR TITLE
Update NetP launch agent logic to include build number

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionAppEvents.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionAppEvents.swift
@@ -115,7 +115,7 @@ final class NetworkProtectionAppEvents {
     }
 
     private func restartNetworkProtectionIfVersionChanged(using loginItemsManager: LoginItemsManager) {
-        let currentVersion = AppVersion.shared.versionNumber
+        let currentVersion = AppVersion.shared.versionAndBuildNumber
         let versionStore = NetworkProtectionLastVersionRunStore()
         defer {
             versionStore.lastVersionRun = currentVersion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206277530960782/f
Tech Design URL:
CC:

**Description**:

This PR updates the NetP launch logic to include the build number. Previously it only used the version number to detect if the app had been updated and thus needed to re-install the agent, but now we publish builds with the same version number multiple times and only bump the build number.

**Steps to test this PR**:
1. Open `NetworkProtectionAppEvents` and add a breakpoint at line 119
2. Launch the app, and when the breakpoint hits, check that the value of `currentVersion` includes the build; you should see something like `1.69.0.97`

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
