### PR TITLE
Suspend Sync when updating device name

### DIFF
--- a/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -367,14 +367,16 @@ extension SyncPreferences: ManagementDialogModelDelegate {
 
     func updateDeviceName(_ name: String) {
         Task { @MainActor in
+            self.devices = []
+            syncService.scheduler.cancelSyncAndSuspendSyncQueue()
             do {
-                self.devices = []
                 let devices = try await syncService.updateDeviceName(name)
                 managementDialogModel.endFlow()
                 mapDevices(devices)
             } catch {
                 managementDialogModel.syncErrorMessage = SyncErrorMessage(type: .unableToUpdateDeviceName, description: error.localizedDescription)
             }
+            syncService.scheduler.resumeSyncQueue()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201493110486074/1206304176229205/f

**Description**:
This is to prevent data sync requests being sent with an outdated authorization token.

**Steps to test this PR**:
1. Enable Sync (best to test on production).
2. Change device name a few times.
3. Verify that you're not logged out while updating device name.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
