### PR TITLE
Update Enter Code view in Sync Account Recovery

### DIFF
--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/Dialogs/EnterRecoveryCodeView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/Dialogs/EnterRecoveryCodeView.swift
@@ -40,7 +40,7 @@ public struct EnterRecoveryCodeView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 Button {
                     recoveryCodeModel.paste()
-                    model.delegate?.recoveryCodePasted(recoveryCodeModel.recoveryCode, fromRecoveryScreen: false)
+                    model.delegate?.recoveryCodePasted(recoveryCodeModel.recoveryCode, fromRecoveryScreen: true)
                 } label: {
                     HStack {
                         Image("Paste")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206308874424023/f

**Description**:
Removing the fake text field and replacing it with a simple label.
This change also adds support for cmd+v keyboard shortcut to trigger paste button.

**Steps to test this PR**:
1. Disable Sync
2. In Sync Settings, click Recover Account
3. Verify that changes match the designs (see [here](https://www.figma.com/file/5wIXwQLKJ0dZVsP5XWcgbT/Sync?node-id=8748%3A302882&mode=dev))
4. Try pasting the code using cmd+v and verify that it worked.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
