### PR TITLE
fix non-Safari DDG iOS bookmarks HTML import

### DIFF
--- a/DuckDuckGo/DataImport/Bookmarks/HTML/BookmarkHTMLReader.swift
+++ b/DuckDuckGo/DataImport/Bookmarks/HTML/BookmarkHTMLReader.swift
@@ -90,7 +90,12 @@ final class BookmarkHTMLReader {
         while cursor != nil {
             let itemType: XMLNode.BookmarkItemType?
             if importSource?.supportsSafariBookmarksHTMLFormat == true {
-                itemType = findNextItemInSafariFormat(&cursor)
+                let initialCursor = cursor
+                itemType = findNextItemInSafariFormat(&cursor) ?? {
+                    // fallback to non-safari format
+                    cursor = initialCursor
+                    return findNextItem(&cursor)
+                }()
             } else {
                 itemType = findNextItem(&cursor)
             }

--- a/UnitTests/DataImport/DataImportResources/TestBookmarksData/bookmarks_duckduckgo_ipad.html
+++ b/UnitTests/DataImport/DataImportResources/TestBookmarksData/bookmarks_duckduckgo_ipad.html
@@ -1,0 +1,93 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+    <HTML xmlns:duckduckgo="https://duckduckgo.com/bookmarks">
+    <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+    <Title>Bookmarks</Title>
+    <H1>Bookmarks</H1>
+    <DL><p>
+		<DT><H3 FOLDED>Mozilla Firefox</H3>
+		<DL><p>
+			<DT><A HREF="https://support.mozilla.org/products/firefox">Firefox help</A>
+			<DT><A HREF="https://support.mozilla.org/kb/customize-firefox-controls-buttons-and-toolbars?utm_source=firefox-browser&utm_medium=default-bookmarks&utm_campaign=customize">Setup Firefox</A>
+			<DT><A HREF="https://www.mozilla.org/contribute/">Contribute</A>
+			<DT><A HREF="https://www.mozilla.org/about/">About</A>
+		</DL><p>
+		<DT><H3 FOLDED>Favorites</H3>
+		<DL><p>
+			<DT><A HREF="https://www.apple.com/">Apple</A>
+			<DT><A HREF="https://www.icloud.com/'%3EiCloud%3C/A%3E%3CD%3E%3CA%20HREF=">Yahoo</A>
+			<DT><A HREF="https://www.bing.com/'%3EBing%3C/A%3E%3CDT%3E%3CA%20HREF=">Google</A>
+			<DT><A HREF="https://www.wikipedia.org/">Wikipedia</A>
+			<DT><A HREF="https://www.facebook.com/">Facebook</A>
+			<DT><A HREF="https://twitter.com/">Twitter</A>
+			<DT><A HREF="https://www.linkedin.com/">LinkedIn</A>
+			<DT><A HREF="https://www.weather.com/">The Weather Channel</A>
+			<DT><A HREF="https://www.yelp.com/">Yelp</A>
+			<DT><A HREF="https://www.google.com/search?q=catz&client=safari&sca_esv=570874343&rls=en&tbm=isch&source=1nms&sa=X&ved=2ahUKEwiQ60DeoN6BAxXJOhAIHbYCD2gQ_AUoAXoECAEQAw&biw=1324&bih=888">catz - Google Search</A>
+			<DT><A HREF="https://www.google.com/search?client=safari&rls=en&q=dogz&ie=UTF-8&oe=UTF-8">dogz - Google Search</A>
+			<DT><A HREF="https://www.google.com/search?client=safari&rls=en&q=abyrvalg&ie=UTF-8&oe=UTF-8">ab yrvalg - Google Search</A>
+		</DL><p>
+		<DT><H3 FOLDED>Bookmarks Menu</H3>
+		<DL><p>
+		</DL><p>
+		<DT><H3 FOLDED>Tab Group Favorites</H3>
+		<DL><p>
+			<DT><H3 FOLDED>Tab Group Favorites</H3>
+			<DL><p>
+				<DT><A HREF="https://www.google.com/search?client=safari&rls=en&q=abyrvalg&ie=UTF-8&oe=UTF-8">abyrvalg - Google Search</A>
+			</DL><p>
+		</DL><p>
+		<DT><A HREF="https://cloud.faceter.cam/public/camera/">Faceter.cam Web Client</A>
+		<DT><A HREF="https://gmail.com/">GMail</A>
+		<DT><A HREF="http://www.thingiverse.com/">Thingiverse - Digital Designs for Physical Objects</A>
+		<DT><A HREF="https://www.youtube.com/">(25) YouTube</A>
+		<DT><A HREF="https://twitter.com/">(161) Twitter</A>
+		<DT><H3 FOLDED>Авто</H3>
+		<DL><p>
+			<DT><A HREF="http://forum.bmw5.co.uk/">BMW 5 Series Owners Board</A>
+		</DL><p>
+		<DT><H3 FOLDED>Bookmarks</H3>
+		<DL><p>
+			<DT><A HREF="http://cafbit.com/">Caffeinated Bitstream</A>
+			<DT><A HREF="https://cloudconvert.com/svg-to-svg">svg to svg - CloudConvert</A>
+			<DT><A HREF="https://www.rapidtables.com/web/tools/svg-viewer-editor.html">SVG viewer &amp; editor online</A>
+		</DL><p>
+		<DT><A HREF="https://asana.com/">Asana</A>
+		<DT><H3 FOLDED>Other Bookmarks</H3>
+		<DL><p>
+			<DT><A HREF="http://www.rw-designer.com/image-to-icon">Online Image to Icon Converter</A>
+		</DL><p>
+		<DT><A HREF="https://mail.google.com/">Gmail</A>
+		<DT><H3 FOLDED>Imported Favorites</H3>
+		<DL><p>
+		</DL><p>
+		<DT><A HREF="https://emby.media/community/index.php">Emby Community</A>
+		<DT><H3 FOLDED>Music</H3>
+		<DL><p>
+			<DT><A HREF="https://music.google.com/">Google Music</A>
+		</DL><p>
+		<DT><H3 FOLDED>Books</H3>
+		<DL><p>
+			<DT><A HREF="https://amazon.com">Amazon</A>
+		</DL><p>
+		<DT><A HREF="https://bignerdranch.com/resources/blog/">Blog - Big Nerd Ranch</A>
+		<DT><A HREF="https://mermaid.live/edit">Online FlowChart &amp; Diagrams Editor - Mermaid Live Editor</A>
+		<DT><H3 FOLDED>Firefox Nightly Resources</H3>
+		<DL><p>
+			<DT><A HREF="https://blog.nightly.mozilla.org/">Firefox Nightly blog</A>
+			<DT><A HREF="https://bugzilla.mozilla.org/">Mozilla Bug Tracker</A>
+			<DT><A HREF="https://developer.mozilla.org/">Mozilla Developer Network</A>
+			<DT><A HREF="https://addons.mozilla.org/firefox/addon/nightly-tester-tools/">Nightly Tester Tools</A>
+			<DT><A HREF="about:crashes">All your crashes</A>
+			<DT><A HREF="https://planet.mozilla.org/">Planet Mozilla</A>
+		</DL><p>
+		<DT><H3 FOLDED>Bookmarks Toolbar</H3>
+		<DL><p>
+			<DT><A HREF="https://www.mozilla0.org/contribute/?utm_medium=firefox-desktop&utm_source=bookmarks-toolbar&utm_campaign=new-users-nightly&utm_content=-global">#0 Added bookmark title with a long bookmark title</A>
+			<DT><A HREF="https://www.mozilla1.org/contribute/?utm_medium=firefox-desktop&utm_source=bookmarks-toolbar&utm_campaign=new-users-nightly&utm_content=-global">#1 Added bookmark title with a long bookmark title</A>
+		</DL><p>
+		<DT><H3 FOLDED>Bookmarks Bar</H3>
+		<DL><p>
+			<DT><A HREF="https://www.mozilla.org/firefox/?utm_medium=firefox-desktop&utm_source=bookmarks-toolbar&utm_campaign=new-users&utm_content=-global">Home</A>
+		</DL><p>
+</DL><p>
+</HTML>

--- a/UnitTests/DataImport/__Snapshots__/BookmarksHTMLReaderTests/snapshot.bookmarks_duckduckgo_ipad.json
+++ b/UnitTests/DataImport/__Snapshots__/BookmarksHTMLReaderTests/snapshot.bookmarks_duckduckgo_ipad.json
@@ -1,0 +1,318 @@
+{
+  "roots" : {
+    "bookmark_bar" : {
+      "children" : [
+
+      ],
+      "name" : "",
+      "type" : "folder"
+    },
+    "other" : {
+      "children" : [
+        {
+          "children" : [
+            {
+              "name" : "Firefox help",
+              "type" : "bookmark",
+              "url" : "https:\/\/support.mozilla.org\/products\/firefox"
+            },
+            {
+              "name" : "Setup Firefox",
+              "type" : "bookmark",
+              "url" : "https:\/\/support.mozilla.org\/kb\/customize-firefox-controls-buttons-and-toolbars?utm_source=firefox-browser&utm_medium=default-bookmarks&utm_campaign=customize"
+            },
+            {
+              "name" : "Contribute",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.mozilla.org\/contribute\/"
+            },
+            {
+              "name" : "About",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.mozilla.org\/about\/"
+            }
+          ],
+          "name" : "Mozilla Firefox",
+          "type" : "folder"
+        },
+        {
+          "children" : [
+            {
+              "name" : "Apple",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.apple.com\/"
+            },
+            {
+              "name" : "Yahoo",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.icloud.com\/'%3EiCloud%3C\/A%3E%3CD%3E%3CA%20HREF="
+            },
+            {
+              "name" : "Google",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.bing.com\/'%3EBing%3C\/A%3E%3CDT%3E%3CA%20HREF="
+            },
+            {
+              "name" : "Wikipedia",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.wikipedia.org\/"
+            },
+            {
+              "name" : "Facebook",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.facebook.com\/"
+            },
+            {
+              "name" : "Twitter",
+              "type" : "bookmark",
+              "url" : "https:\/\/twitter.com\/"
+            },
+            {
+              "name" : "LinkedIn",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.linkedin.com\/"
+            },
+            {
+              "name" : "The Weather Channel",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.weather.com\/"
+            },
+            {
+              "name" : "Yelp",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.yelp.com\/"
+            },
+            {
+              "name" : "catz - Google Search",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.google.com\/search?q=catz&client=safari&sca_esv=570874343&rls=en&tbm=isch&source=1nms&sa=X&ved=2ahUKEwiQ60DeoN6BAxXJOhAIHbYCD2gQ_AUoAXoECAEQAw&biw=1324&bih=888"
+            },
+            {
+              "name" : "dogz - Google Search",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.google.com\/search?client=safari&rls=en&q=dogz&ie=UTF-8&oe=UTF-8"
+            },
+            {
+              "name" : "ab yrvalg - Google Search",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.google.com\/search?client=safari&rls=en&q=abyrvalg&ie=UTF-8&oe=UTF-8"
+            }
+          ],
+          "name" : "Favorites",
+          "type" : "folder"
+        },
+        {
+          "children" : [
+
+          ],
+          "name" : "Bookmarks Menu",
+          "type" : "folder"
+        },
+        {
+          "children" : [
+            {
+              "children" : [
+                {
+                  "name" : "abyrvalg - Google Search",
+                  "type" : "bookmark",
+                  "url" : "https:\/\/www.google.com\/search?client=safari&rls=en&q=abyrvalg&ie=UTF-8&oe=UTF-8"
+                }
+              ],
+              "name" : "Tab Group Favorites",
+              "type" : "folder"
+            }
+          ],
+          "name" : "Tab Group Favorites",
+          "type" : "folder"
+        },
+        {
+          "name" : "Faceter.cam Web Client",
+          "type" : "bookmark",
+          "url" : "https:\/\/cloud.faceter.cam\/public\/camera\/"
+        },
+        {
+          "name" : "GMail",
+          "type" : "bookmark",
+          "url" : "https:\/\/gmail.com\/"
+        },
+        {
+          "name" : "Thingiverse - Digital Designs for Physical Objects",
+          "type" : "bookmark",
+          "url" : "http:\/\/www.thingiverse.com\/"
+        },
+        {
+          "name" : "(25) YouTube",
+          "type" : "bookmark",
+          "url" : "https:\/\/www.youtube.com\/"
+        },
+        {
+          "name" : "(161) Twitter",
+          "type" : "bookmark",
+          "url" : "https:\/\/twitter.com\/"
+        },
+        {
+          "children" : [
+            {
+              "name" : "BMW 5 Series Owners Board",
+              "type" : "bookmark",
+              "url" : "http:\/\/forum.bmw5.co.uk\/"
+            }
+          ],
+          "name" : "Авто",
+          "type" : "folder"
+        },
+        {
+          "children" : [
+            {
+              "name" : "Caffeinated Bitstream",
+              "type" : "bookmark",
+              "url" : "http:\/\/cafbit.com\/"
+            },
+            {
+              "name" : "svg to svg - CloudConvert",
+              "type" : "bookmark",
+              "url" : "https:\/\/cloudconvert.com\/svg-to-svg"
+            },
+            {
+              "name" : "SVG viewer & editor online",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.rapidtables.com\/web\/tools\/svg-viewer-editor.html"
+            }
+          ],
+          "name" : "Bookmarks",
+          "type" : "folder"
+        },
+        {
+          "name" : "Asana",
+          "type" : "bookmark",
+          "url" : "https:\/\/asana.com\/"
+        },
+        {
+          "children" : [
+            {
+              "name" : "Online Image to Icon Converter",
+              "type" : "bookmark",
+              "url" : "http:\/\/www.rw-designer.com\/image-to-icon"
+            }
+          ],
+          "name" : "Other Bookmarks",
+          "type" : "folder"
+        },
+        {
+          "name" : "Gmail",
+          "type" : "bookmark",
+          "url" : "https:\/\/mail.google.com\/"
+        },
+        {
+          "children" : [
+
+          ],
+          "name" : "Imported Favorites",
+          "type" : "folder"
+        },
+        {
+          "name" : "Emby Community",
+          "type" : "bookmark",
+          "url" : "https:\/\/emby.media\/community\/index.php"
+        },
+        {
+          "children" : [
+            {
+              "name" : "Google Music",
+              "type" : "bookmark",
+              "url" : "https:\/\/music.google.com\/"
+            }
+          ],
+          "name" : "Music",
+          "type" : "folder"
+        },
+        {
+          "children" : [
+            {
+              "name" : "Amazon",
+              "type" : "bookmark",
+              "url" : "https:\/\/amazon.com"
+            }
+          ],
+          "name" : "Books",
+          "type" : "folder"
+        },
+        {
+          "name" : "Blog - Big Nerd Ranch",
+          "type" : "bookmark",
+          "url" : "https:\/\/bignerdranch.com\/resources\/blog\/"
+        },
+        {
+          "name" : "Online FlowChart & Diagrams Editor - Mermaid Live Editor",
+          "type" : "bookmark",
+          "url" : "https:\/\/mermaid.live\/edit"
+        },
+        {
+          "children" : [
+            {
+              "name" : "Firefox Nightly blog",
+              "type" : "bookmark",
+              "url" : "https:\/\/blog.nightly.mozilla.org\/"
+            },
+            {
+              "name" : "Mozilla Bug Tracker",
+              "type" : "bookmark",
+              "url" : "https:\/\/bugzilla.mozilla.org\/"
+            },
+            {
+              "name" : "Mozilla Developer Network",
+              "type" : "bookmark",
+              "url" : "https:\/\/developer.mozilla.org\/"
+            },
+            {
+              "name" : "Nightly Tester Tools",
+              "type" : "bookmark",
+              "url" : "https:\/\/addons.mozilla.org\/firefox\/addon\/nightly-tester-tools\/"
+            },
+            {
+              "name" : "All your crashes",
+              "type" : "bookmark",
+              "url" : "about:crashes"
+            },
+            {
+              "name" : "Planet Mozilla",
+              "type" : "bookmark",
+              "url" : "https:\/\/planet.mozilla.org\/"
+            }
+          ],
+          "name" : "Firefox Nightly Resources",
+          "type" : "folder"
+        },
+        {
+          "children" : [
+            {
+              "name" : "#0 Added bookmark title with a long bookmark title",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.mozilla0.org\/contribute\/?utm_medium=firefox-desktop&utm_source=bookmarks-toolbar&utm_campaign=new-users-nightly&utm_content=-global"
+            },
+            {
+              "name" : "#1 Added bookmark title with a long bookmark title",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.mozilla1.org\/contribute\/?utm_medium=firefox-desktop&utm_source=bookmarks-toolbar&utm_campaign=new-users-nightly&utm_content=-global"
+            }
+          ],
+          "name" : "Bookmarks Toolbar",
+          "type" : "folder"
+        },
+        {
+          "children" : [
+            {
+              "name" : "Home",
+              "type" : "bookmark",
+              "url" : "https:\/\/www.mozilla.org\/firefox\/?utm_medium=firefox-desktop&utm_source=bookmarks-toolbar&utm_campaign=new-users&utm_content=-global"
+            }
+          ],
+          "name" : "Bookmarks Bar",
+          "type" : "folder"
+        }
+      ],
+      "name" : "other",
+      "type" : "folder"
+    }
+  }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205774015144862/f

**Description**:
- fix html bookmarks import exported from iOS

**Steps to test this PR**:
1. Open Bookmarks import, choose HTML import source, import `UnitTests/DataImport/DataImportResources/TestBookmarksData/bookmarks_duckduckgo_ipad.html` exported from iOS app - validate all bookmarks from the HTML are imported

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
