### PR TITLE
Fix permission request

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UserNotifications/DataBrokerProtectionUserNotificationService.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UserNotifications/DataBrokerProtectionUserNotificationService.swift
@@ -57,11 +57,12 @@ public class DefaultDataBrokerProtectionUserNotificationService: NSObject, DataB
 
     public func requestNotificationPermission() {
         guard areNotificationsEnabled else { return }
-
-        userNotificationCenter.requestAuthorization(options: [.alert]) { _, _ in }
+        requestNotificationPermissionIfNecessary()
     }
 
     private func sendNotification(_ notification: UserNotification, afterDays days: Int? = nil) {
+        requestNotificationPermissionIfNecessary()
+
         let notificationContent = UNMutableNotificationContent()
         notificationContent.title = notification.title
         notificationContent.body = notification.message
@@ -92,6 +93,14 @@ public class DefaultDataBrokerProtectionUserNotificationService: NSObject, DataB
                 } else {
                     os_log("Notification sent", log: .dataBrokerProtection)
                 }
+            }
+        }
+    }
+
+    private func requestNotificationPermissionIfNecessary() {
+        userNotificationCenter.getNotificationSettings { [weak self] settings in
+            if settings.authorizationStatus == .notDetermined {
+                self?.userNotificationCenter.requestAuthorization(options: [.alert]) { _, _ in }
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206319918056750/f
Tech Design URL:
CC:

**Description**:
Ask for notification permission before sending notifications. This is to fix a bug where the notification permission would only be requested after the first scan step. 

The notification being sent right after the permission is requested might not be sent, which is fine.

**Steps to test this PR**:
1. add self.userNotificationService.sendFirstScanCompletedNotification() to the init of `DefaultDataBrokerProtectionScheduler` to force notifications being sent
2. then reset your notifications settings
3. see if we're correctly asking for permission, allow it, run the app again, you should see a notification

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
