### PR TITLE
Remove alphabetic sorting in Bookmarks Sidebar

### DIFF
--- a/DuckDuckGo/Bookmarks/Model/BookmarkNode.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkNode.swift
@@ -31,17 +31,6 @@ final class BookmarkNode: Hashable {
         return node
     }
 
-    class func bookmarkNodesSortedAlphabetically(_ nodes: [BookmarkNode]) -> [BookmarkNode] {
-        return nodes.sorted { (firstNode, secondNode) -> Bool in
-            guard let firstBookmark = firstNode.representedObject as? BaseBookmarkEntity,
-                  let secondBookmark = secondNode.representedObject as? BaseBookmarkEntity else {
-                return false
-            }
-
-            return firstBookmark.title.localizedStandardCompare(secondBookmark.title) == .orderedAscending
-        }
-    }
-
     weak var parent: BookmarkNode?
 
     let uniqueID: Int
@@ -230,10 +219,6 @@ extension Array where Element == BookmarkNode {
 
     func representedObjects() -> [AnyObject] {
         return self.map { $0.representedObject }
-    }
-
-    func bookmarksSortedAlphabetically() -> [BookmarkNode] {
-        return BookmarkNode.bookmarkNodesSortedAlphabetically(self)
     }
 
 }

--- a/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
@@ -161,11 +161,16 @@ final class BookmarkOutlineViewDataSource: NSObject, NSOutlineViewDataSource, NS
                      validateDrop info: NSDraggingInfo,
                      proposedItem item: Any?,
                      proposedChildIndex index: Int) -> NSDragOperation {
-        if contentMode == .foldersOnly, index != -1 {
+        let destinationNode = nodeForItem(item)
+
+        if contentMode == .foldersOnly {
+            // when in folders sidebar mode only allow moving a folder to another folder (or root)
+            if destinationNode.representedObject is BookmarkFolder
+                || (destinationNode.representedObject as? PseudoFolder == .bookmarks) {
+                return .move
+            }
             return .none
         }
-
-        let destinationNode = nodeForItem(item)
 
         let bookmarks = PasteboardBookmark.pasteboardBookmarks(with: info.draggingPasteboard)
         let folders = PasteboardFolder.pasteboardFolders(with: info.draggingPasteboard)
@@ -255,7 +260,8 @@ final class BookmarkOutlineViewDataSource: NSObject, NSOutlineViewDataSource, NS
 
         // Handle the nil destination case:
 
-        if let pseudoFolder = representedObject as? PseudoFolder {
+        if contentMode == .bookmarksAndFolders,
+           let pseudoFolder = representedObject as? PseudoFolder {
             if pseudoFolder == .favorites {
                 bookmarkManager.update(objectsWithUUIDs: draggedObjectIdentifiers, update: { entity in
                     let bookmark = entity as? Bookmark
@@ -278,25 +284,30 @@ final class BookmarkOutlineViewDataSource: NSObject, NSOutlineViewDataSource, NS
 
         // Handle the existing destination case:
 
-        if let parent = representedObject as? BookmarkFolder {
-            bookmarkManager.move(objectUUIDs: draggedObjectIdentifiers, toIndex: index, withinParentFolder: .parent(uuid: parent.id)) { error in
-                if let error = error {
-                    os_log("Failed to accept existing parent drop via outline view: %s", error.localizedDescription)
-                }
-            }
+        var index = index
+        // for folders-only calculate new real index based on the nearest folder index
+        if contentMode == .foldersOnly,
+           index > -1,
+           // get folder before the insertion point (or the first one)
+           let nearestObject = (outlineView.child(max(0, index - 1), ofItem: item) as? BookmarkNode)?.representedObject as? BookmarkFolder,
+           // get all the children of a new parent folder
+           let siblings = (representedObject as? BookmarkFolder)?.children ?? bookmarkManager.list?.topLevelEntities {
 
-            return true
-        } else if representedObject == nil {
-            bookmarkManager.move(objectUUIDs: draggedObjectIdentifiers, toIndex: index, withinParentFolder: .root) { error in
-                if let error = error {
-                    os_log("Failed to accept existing parent drop via outline view: %s", error.localizedDescription)
-                }
-            }
-
-            return true
-        } else {
-            return false
+            // insert after the nearest item (or in place of the nearest item for index == 0)
+            index = (siblings.firstIndex(of: nearestObject) ?? 0) + (index == 0 ? 0 : 1)
+        } else if index == -1 {
+            // drop onto folder
+            index = 0
         }
+
+        let parent: ParentFolderType = (representedObject as? BookmarkFolder).map { .parent(uuid: $0.id) } ?? .root
+        bookmarkManager.move(objectUUIDs: draggedObjectIdentifiers, toIndex: index, withinParentFolder: parent) { error in
+            if let error = error {
+                os_log("Failed to accept existing parent drop via outline view: %s", error.localizedDescription)
+            }
+        }
+
+        return true
     }
 
     func outlineView(_ outlineView: NSOutlineView, rowViewForItem item: Any) -> NSTableRowView? {

--- a/DuckDuckGo/Bookmarks/Model/BookmarkSidebarTreeController.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkSidebarTreeController.swift
@@ -77,7 +77,7 @@ final class BookmarkSidebarTreeController: BookmarkTreeControllerDataSource {
             return folderNode
         } ?? []
 
-        return nodes.bookmarksSortedAlphabetically()
+        return nodes
     }
 
     private func childNodes(for folder: BookmarkFolder, parentNode: BookmarkNode) -> [BookmarkNode] {
@@ -100,7 +100,7 @@ final class BookmarkSidebarTreeController: BookmarkTreeControllerDataSource {
             updatedChildNodes += [newNode]
         }
 
-        return updatedChildNodes.bookmarksSortedAlphabetically()
+        return updatedChildNodes
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199178362774117/1202793152060312/f

**Description**:
- Removes alphabetic folders sorting from Bookmarks Sidebar
- Allows reordering bookmarks in the sidebar

**Steps to test this PR**:
1. Ensure there are folders and bookmarks in the Bookmarks Root
2. Open Bookmark Manager, ensure folders in the Sidebar are sorted with the same order as in the Manager
3. Reorder bookmarks folder in the Sidebar; move folders into other folders/back to the root - ensure reordering is done both in the Sidebar and in the Manager and order matches
4. Open Bookmarks list from the "..." menu, reorder folder and bookmarks, ensure it works correctly

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
