### PR TITLE
Update BSK with autofill 10.0.3

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13106,8 +13106,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = f72fcfb0f2570d86ccc4324266b7d423734c1f10;
+				kind = exactVersion;
+				version = 101.0.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "71f65c35de0ae291a1b012ff17c91b9dcd6618fb",
-        "version" : "101.0.0"
+        "revision" : "c5ffbf442caa77d7fe4213748b65cd973c0acdfd",
+        "version" : "101.0.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "5597bc17709c8acf454ecaad4f4082007986242a",
-        "version" : "10.0.2"
+        "revision" : "b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
+        "version" : "10.0.3"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/LoginItems/Package.swift
+++ b/LocalPackages/LoginItems/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],

--- a/LocalPackages/PixelKit/Package.swift
+++ b/LocalPackages/PixelKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/Subscription/Package.swift
+++ b/LocalPackages/Subscription/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Subscription"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SwiftUIExtensions/Package.swift
+++ b/LocalPackages/SwiftUIExtensions/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "PreferencesViews", targets: ["PreferencesViews"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../SwiftUIExtensions"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SystemExtensionManager/Package.swift
+++ b/LocalPackages/SystemExtensionManager/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/XPCHelper/Package.swift
+++ b/LocalPackages/XPCHelper/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "XPCHelper", targets: ["XPCHelper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206327382038432/1206327382038432
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.3
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/623

## Description
Updates Autofill to version [10.0.3](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.3).

### Autofill 10.0.3 release notes
## What's Changed
* Use the default branch when checking out repos by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/444
* Password update flows by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/453
* Bump @types/jest from 29.5.5 to 29.5.11 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/439
* Update password-related json files (2023-12-21) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/454
* Move test forms out of src by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/457
* Move integration tests around by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/455
* Fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/467
* Update password-related json files (2024-01-11) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/466


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.2...10.0.3

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).