### PR TITLE
Don't override drop operation if source view is webView

### DIFF
--- a/DuckDuckGo/Tab/View/WebView.swift
+++ b/DuckDuckGo/Tab/View/WebView.swift
@@ -176,6 +176,9 @@ final class WebView: WKWebView {
     // MARK: - NSDraggingDestination
 
     override func draggingUpdated(_ draggingInfo: NSDraggingInfo) -> NSDragOperation {
+        if draggingInfo.draggingSource is WebView {
+            return super.draggingUpdated(draggingInfo)
+        }
         if NSApp.isCommandPressed || NSApp.isOptionPressed {
             return superview?.draggingUpdated(draggingInfo) ?? .none
         }
@@ -190,6 +193,9 @@ final class WebView: WKWebView {
     }
 
     override func performDragOperation(_ draggingInfo: NSDraggingInfo) -> Bool {
+        if draggingInfo.draggingSource is WebView {
+            return super.performDragOperation(draggingInfo)
+        }
         if NSApp.isCommandPressed || NSApp.isOptionPressed || super.draggingUpdated(draggingInfo) == .none {
             return superview?.performDragOperation(draggingInfo) ?? false
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206220522850248/f

**Description**:
For drags from webView to webView, apply default WebKit logic

**Steps to test this PR**:
1. Go to https://duckduckgo.com
2. Try dragging Dax logo elsewhere on the webView, verify that it doesn't replace current page with Dax logo image
3. Verify that file dropping and URL dropping works correctly.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
