### PR TITLE
macOS: Fix issue with not being able to add favorites for existing bookmarks in the latest 1.70.0 internal

### DIFF
--- a/DuckDuckGo/Bookmarks/ViewModel/AddBookmarkModalViewModel.swift
+++ b/DuckDuckGo/Bookmarks/ViewModel/AddBookmarkModalViewModel.swift
@@ -54,7 +54,7 @@ struct AddBookmarkModalViewModel {
         }
 
         var result: Bookmark?
-        if var bookmark = originalBookmark {
+        if var bookmark = originalBookmark ?? bookmarkManager.getBookmark(for: url) {
 
             if url.absoluteString != bookmark.url {
                 bookmark = bookmarkManager.updateUrl(of: bookmark, to: url) ?? bookmark


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206339303679760/f

## Description

This is broken only on our internals.

If a bookmark exists, the user cannot add it as a favorite through the "Add favorite" option in the home page.

## Testing:

1. Add a bookmark
2. In the home page tap on the + button to add a favorite
3. Try to favorite the bookmarked URL

It should work

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
