### PR TITLE
Show/dismiss Privacy Dashboard on mouse-down

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -509,6 +509,7 @@ final class AddressBarButtonsViewController: NSViewController {
         }
 
         privacyEntryPointButton.contentTintColor = .privacyEnabledColor
+        privacyEntryPointButton.sendAction(on: .leftMouseDown)
 
         imageButton.applyFaviconStyle()
         (imageButton.cell as? NSButtonCell)?.highlightsBy = NSCell.StyleMask(rawValue: 0)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206230883208824/f

**Description**:
- Show/dismiss Privacy Dashboard on Privacy Dashboard Button mouse-down 
- Fixes the issue of the Privacy Dashboard not disappearing on button click

**Steps to test this PR**:
1. Open Privacy Dashboard
2. Click Privacy Dashboard button - validate the popover disappears

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
