### PR TITLE
Fix Gatekeeper dialog for binaries downloaded by the browser

### DIFF
--- a/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -423,11 +423,9 @@ extension URL {
             quarantineProperties[kLSQuarantineDataURLKey as String] = sourceURL
             quarantineProperties[kLSQuarantineOriginURLKey as String] = referrerURL
 
-            if quarantineProperties[kLSQuarantineTypeKey as String] == nil {
-                quarantineProperties[kLSQuarantineTypeKey as String] = ["http", "https"].contains(sourceURL?.scheme)
-                    ? kLSQuarantineTypeWebDownload
-                    : kLSQuarantineTypeOtherDownload
-            }
+            quarantineProperties[kLSQuarantineTypeKey as String] = ["http", "https"].contains(sourceURL?.scheme)
+                ? kLSQuarantineTypeWebDownload
+                : kLSQuarantineTypeOtherDownload
 
             try (self as NSURL).setResourceValue(quarantineProperties, forKey: .quarantinePropertiesKey)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203568220589424/f

**Description**:
Always overwrite quarantine type to web download or other download to show "DuckDuckGo downloaded this file"
instead of "DuckDuckGo created this file" Gatekeeper dialogs for downloaded binaries.

**Steps to test this PR**:
1. Go to https://duckduckgo.com/mac and download the browser DMG file.
2. Open DMG and move the app to Desktop.
3. Open the app
4. Verify that you see a Gatekeeper dialog warning before opening the app, explaining that DuckDuckGo downloaded (and not created) this app.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
