### PR TITLE
Fix vertical alignment of privacy feed shield icon

### DIFF
--- a/DuckDuckGo/HomePage/View/RecentlyVisitedView.swift
+++ b/DuckDuckGo/HomePage/View/RecentlyVisitedView.swift
@@ -317,6 +317,7 @@ struct RecentlyVisitedTitle: View {
                     model.showPagesOnHover.toggle()
                 }
                 .padding(.leading, isExpanded ? 5 : 0)
+                .padding(.top, 4)
 
             VStack(alignment: isExpanded ? .leading : .center, spacing: 6) {
                 Text(UserText.homePageProtectionSummaryMessage(numberOfTrackersBlocked: model.numberOfTrackersBlocked))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203888749824536/f

**Steps to test this PR**:
1. Run the app and open new tab page
2. Verify that the shield icon in privacy feed is vertically aligned with the top privacy summary label.
3. Collapse and expand the privacy feed and confirm that the shield icon is still correctly aligned vertically.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
