### PR TITLE
Fix casing in some copy items in Preferences and Main Menu

### DIFF
--- a/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuFactory.swift
+++ b/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuFactory.swift
@@ -37,15 +37,15 @@ struct BookmarksBarMenuFactory {
     private static func makeMenuItem( _ prefs: AppearancePreferences) -> NSMenuItem {
         let item = NSMenuItem(title: UserText.showBookmarksBar, action: nil, keyEquivalent: "B")
         item.submenu = NSMenu(items: [
-            BlockMenuItem(title: UserText.showBookmarksBarAlways, isChecked: prefs.showBookmarksBar && prefs.bookmarksBarAppearance == .alwaysOn) {
+            BlockMenuItem(title: UserText.mainMenuBookmarksShowBookmarksBarAlways, isChecked: prefs.showBookmarksBar && prefs.bookmarksBarAppearance == .alwaysOn) {
                 prefs.bookmarksBarAppearance = .alwaysOn
                 prefs.showBookmarksBar = true
             },
-            BlockMenuItem(title: UserText.showBookmarksBarNewTabOnly, isChecked: prefs.showBookmarksBar && prefs.bookmarksBarAppearance == .newTabOnly) {
+            BlockMenuItem(title: UserText.mainMenuBookmarksShowBookmarksBarNewTabOnly, isChecked: prefs.showBookmarksBar && prefs.bookmarksBarAppearance == .newTabOnly) {
                 prefs.bookmarksBarAppearance = .newTabOnly
                 prefs.showBookmarksBar = true
             },
-            BlockMenuItem(title: UserText.showBookmarksBarNever, isChecked: !prefs.showBookmarksBar) {
+            BlockMenuItem(title: UserText.mainMenuBookmarksShowBookmarksBarNever, isChecked: !prefs.showBookmarksBar) {
                 prefs.showBookmarksBar = false
             }
         ])

--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -135,14 +135,14 @@ struct UserText {
     static let mainMenuViewHome = NSLocalizedString("Home", comment: "Main Menu View item")
     static let mainMenuHomeButton = NSLocalizedString("Home Button", comment: "Main Menu > View > Home Button item")
         
-    static func mainMenuHomeButton(for position: HomeButtonPosition) -> String {
+    static func mainMenuHomeButtonMode(for position: HomeButtonPosition) -> String {
         switch position {
         case .hidden:
             return NSLocalizedString("Hide", comment: "Main Menu > View > Home Button > None item")
         case .left:
-            return NSLocalizedString("Show left of the back button", comment: "Main Menu > View > Home Button > left position item")
+            return NSLocalizedString("Show Left of the Back Button", comment: "Main Menu > View > Home Button > left position item")
         case .right:
-            return NSLocalizedString("Show right of the reload button", comment: "Main Menu > View > Home Button > right position item")
+            return NSLocalizedString("Show Right of the Reload Button", comment: "Main Menu > View > Home Button > right position item")
         }
     }
     
@@ -167,6 +167,12 @@ struct UserText {
     static let mainMenuHistoryClearAllHistory = NSLocalizedString("Clear All History…", comment: "Main Menu History item")
     static let mainMenuHistoryManageBookmarks = NSLocalizedString("Manage Bookmarks", comment: "Main Menu History item")
     static let mainMenuHistoryFavoriteThisPage = NSLocalizedString("Favorite This Page…", comment: "Main Menu History item")
+    static let mainMenuHistoryReopenAllWindowsFromLastSession = NSLocalizedString("Reopen All Windows from Last Session", comment: "Main Menu History item")
+
+    // MARK: - Main Menu -> Bookmarks -> Bookmarks Bar
+    static let mainMenuBookmarksShowBookmarksBarAlways = NSLocalizedString("Always Show", comment: "Preference for always showing the bookmarks bar")
+    static let mainMenuBookmarksShowBookmarksBarNewTabOnly = NSLocalizedString("Only Show on New Tab", comment: "Preference for only showing the bookmarks bar on new tab")
+    static let mainMenuBookmarksShowBookmarksBarNever = NSLocalizedString("Never Show", comment: "Preference for never showing the bookmarks bar on new tab")
 
     // MARK: - Main Menu -> Window
     static let mainMenuWindow = NSLocalizedString("Window", comment: "Main Menu ")
@@ -532,7 +538,7 @@ struct UserText {
     static let isNotDefaultBrowser = NSLocalizedString("preferences.default-browser.inactive", value: "DuckDuckGo is not your default browser.", comment: "Indicate that the browser is not the default")
     static let makeDefaultBrowser = NSLocalizedString("preferences.default-browser.button.make-default", value: "Make DuckDuckGo Default…", comment: "")
     static let onStartup = NSLocalizedString("preferences.on-startup", value: "On Startup", comment: "Name of the preferences section related to app startup")
-    static let reopenAllWindowsFromLastSession = NSLocalizedString("preferences.reopen-windows", value: "Reopen All Windows from Last Session", comment: "Option to control session restoration")
+    static let reopenAllWindowsFromLastSession = NSLocalizedString("preferences.reopen-windows", value: "Reopen all windows from last session", comment: "Option to control session restoration")
     static let showHomePage = NSLocalizedString("preferences.show-home", value: "Open a new window", comment: "Option to control session startup")
     
     static let homePage = NSLocalizedString("preferences-homepage", value: "Homepage", comment: "Title for Homepage section in settings")
@@ -543,7 +549,18 @@ struct UserText {
 
     static let setHomePage = NSLocalizedString("preferences-homepage-set-homePage", value: "Set Homepage", comment: "Set Homepage dialog title")
     static let addressLabel = NSLocalizedString("preferences-homepage-address", value: "Address:", comment: "Homepage address field label")
-    
+
+    static func homeButtonMode(for position: HomeButtonPosition) -> String {
+        switch position {
+        case .hidden:
+            return NSLocalizedString("Hide", comment: "Preferences > Home Button > None item")
+        case .left:
+            return NSLocalizedString("Show left of the back button", comment: "Preferences > Home Button > left position item")
+        case .right:
+            return NSLocalizedString("Show right of the reload button", comment: "Preferences > Home Button > right position item")
+        }
+    }
+
     static let theme = NSLocalizedString("preferences.appearance.theme", value: "Theme", comment: "Theme preferences")
     static let addressBar = NSLocalizedString("preferences.appearance.address-bar", value: "Address Bar", comment: "Theme preferences")
     static let showFullWebsiteAddress = NSLocalizedString("preferences.appearance.show-full-url", value: "Full website address", comment: "Option to show full URL in the address bar")
@@ -764,9 +781,8 @@ struct UserText {
 
     static let showBookmarksBar = NSLocalizedString("bookmarks.bar.show", value: "Bookmarks Bar", comment: "Menu item for showing the bookmarks bar")
     static let showBookmarksBarPreference = NSLocalizedString("bookmarks.bar.show", value: "Show Bookmarks Bar", comment: "Preference item for showing the bookmarks bar")
-    static let showBookmarksBarAlways = NSLocalizedString("bookmarks.bar.show.always", value: "Always Show", comment: "Preference for always showing the bookmarks bar")
-    static let showBookmarksBarNewTabOnly = NSLocalizedString("bookmarks.bar.show.new-tab-only", value: "Only Show on New Tab", comment: "Preference for only showing the bookmarks bar on new tab")
-    static let showBookmarksBarNever = NSLocalizedString("bookmarks.bar.show.never", value: "Never Show", comment: "Preference for never showing the bookmarks bar on new tab")
+    static let showBookmarksBarAlways = NSLocalizedString("bookmarks.bar.show.always", value: "Always show", comment: "Preference for always showing the bookmarks bar")
+    static let showBookmarksBarNewTabOnly = NSLocalizedString("bookmarks.bar.show.new-tab-only", value: "Only show on New Tab", comment: "Preference for only showing the bookmarks bar on new tab")
     static let bookmarksBarFolderEmpty = NSLocalizedString("bookmarks.bar.folder.empty", value: "Empty", comment: "Empty state for a bookmarks bar folder")
     static let bookmarksBarContextMenuCopy = NSLocalizedString("bookmarks.bar.context-menu.copy", value: "Copy", comment: "Copy menu item for the bookmarks bar context menu")
     static let bookmarksBarContextMenuDelete = NSLocalizedString("bookmarks.bar.context-menu.delete", value: "Delete", comment: "Delete menu item for the bookmarks bar context menu")

--- a/DuckDuckGo/Localizable.xcstrings
+++ b/DuckDuckGo/Localizable.xcstrings
@@ -349,6 +349,9 @@
     "also applies here." : {
 
     },
+    "Always Show" : {
+      "comment" : "Preference for always showing the bookmarks bar"
+    },
     "auth.alert.login.button" : {
       "comment" : "Authentication Alert Sign In Button",
       "extractionState" : "extracted_with_value",
@@ -1450,19 +1453,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Always Show"
-          }
-        }
-      }
-    },
-    "bookmarks.bar.show.never" : {
-      "comment" : "Preference for never showing the bookmarks bar on new tab",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Never Show"
+            "value" : "Always show"
           }
         }
       }
@@ -1474,7 +1465,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Only Show on New Tab"
+            "value" : "Only show on New Tab"
           }
         }
       }
@@ -3315,7 +3306,7 @@
       "comment" : "Main Menu Help"
     },
     "Hide" : {
-      "comment" : "Main Menu > View > Home Button > None item"
+      "comment" : "Main Menu > View > Home Button > None item\n   Preferences > Home Button > None item"
     },
     "Hide DuckDuckGo" : {
       "comment" : "Main Menu DuckDuckGo item"
@@ -5211,6 +5202,9 @@
         }
       }
     },
+    "Never Show" : {
+      "comment" : "Preference for never showing the bookmarks bar on new tab"
+    },
     "never.for.this.site" : {
       "comment" : "Never ask to save login credentials for this site button",
       "extractionState" : "extracted_with_value",
@@ -5804,6 +5798,9 @@
           }
         }
       }
+    },
+    "Only Show on New Tab" : {
+      "comment" : "Preference for only showing the bookmarks bar on new tab"
     },
     "open" : {
       "comment" : "Open button",
@@ -7890,7 +7887,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Reopen All Windows from Last Session"
+            "value" : "Reopen all windows from last session"
           }
         }
       }
@@ -8017,6 +8014,9 @@
           }
         }
       }
+    },
+    "Reopen All Windows from Last Session" : {
+      "comment" : "Main Menu History item"
     },
     "reopen.last.closed.tab" : {
       "extractionState" : "extracted_with_value",
@@ -8232,6 +8232,9 @@
       "comment" : "Main Menu View item"
     },
     "Show left of the back button" : {
+      "comment" : "Preferences > Home Button > left position item"
+    },
+    "Show Left of the Back Button" : {
       "comment" : "Main Menu > View > Home Button > left position item"
     },
     "Show Next Tab" : {
@@ -8247,6 +8250,9 @@
       "comment" : "Main Menu View-Developer item"
     },
     "Show right of the reload button" : {
+      "comment" : "Preferences > Home Button > right position item"
+    },
+    "Show Right of the Reload Button" : {
       "comment" : "Main Menu > View > Home Button > right position item"
     },
     "Show Spelling and Grammar" : {

--- a/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/DuckDuckGo/Menus/HistoryMenu.swift
@@ -28,7 +28,7 @@ final class HistoryMenu: NSMenu {
 
     private let recentlyClosedMenuItem = NSMenuItem(title: UserText.mainMenuHistoryRecentlyClosed)
     private let reopenLastClosedMenuItem = NSMenuItem(title: UserText.reopenLastClosedTab, action: #selector(AppDelegate.reopenLastClosedTab))
-    private let reopenAllWindowsFromLastSessionMenuItem = NSMenuItem(title: UserText.reopenAllWindowsFromLastSession,
+    private let reopenAllWindowsFromLastSessionMenuItem = NSMenuItem(title: UserText.mainMenuHistoryReopenAllWindowsFromLastSession,
                                                                      action: #selector(AppDelegate.reopenAllWindowsFromLastSession))
     private let clearAllHistoryMenuItem = NSMenuItem(title: UserText.mainMenuHistoryClearAllHistory,
                                                      action: #selector(MainViewController.clearAllHistory),

--- a/DuckDuckGo/NavigationBar/View/HomeButtonMenuFactory.swift
+++ b/DuckDuckGo/NavigationBar/View/HomeButtonMenuFactory.swift
@@ -41,16 +41,16 @@ struct HomeButtonMenuFactory {
         let isButtonVisible = LocalPinningManager.shared.isPinned(.homeButton)
         let buttonPosition = AppearancePreferences.shared.homeButtonPosition
 
-        let hiddenItem: NSMenuItem = BlockMenuItem(title: UserText.mainMenuHomeButton(for: .hidden), isChecked: !isButtonVisible, block: {
+        let hiddenItem: NSMenuItem = BlockMenuItem(title: UserText.mainMenuHomeButtonMode(for: .hidden), isChecked: !isButtonVisible, block: {
             AppearancePreferences.shared.homeButtonPosition = .hidden
             LocalPinningManager.shared.unpin(.homeButton)
         })
-        let leftItem: NSMenuItem = BlockMenuItem(title: UserText.mainMenuHomeButton(for: .left), isChecked: isButtonVisible && buttonPosition == .left, block: {
+        let leftItem: NSMenuItem = BlockMenuItem(title: UserText.mainMenuHomeButtonMode(for: .left), isChecked: isButtonVisible && buttonPosition == .left, block: {
             AppearancePreferences.shared.homeButtonPosition = .left
             LocalPinningManager.shared.unpin(.homeButton)
             LocalPinningManager.shared.pin(.homeButton)
         })
-        let rightItem: NSMenuItem = BlockMenuItem(title: UserText.mainMenuHomeButton(for: .right), isChecked: isButtonVisible && buttonPosition == .right, block: {
+        let rightItem: NSMenuItem = BlockMenuItem(title: UserText.mainMenuHomeButtonMode(for: .right), isChecked: isButtonVisible && buttonPosition == .right, block: {
             AppearancePreferences.shared.homeButtonPosition = .right
             LocalPinningManager.shared.unpin(.homeButton)
             LocalPinningManager.shared.pin(.homeButton)

--- a/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
@@ -89,7 +89,7 @@ extension Preferences {
                     HStack {
                         Picker(UserText.mainMenuHomeButton, selection: $startupModel.homeButtonPosition) {
                             ForEach(HomeButtonPosition.allCases, id: \.self) { position in
-                                Text(UserText.mainMenuHomeButton(for: position)).tag(position)
+                                Text(UserText.homeButtonMode(for: position)).tag(position)
                             }
                         }.scaledToFit()
                         .onChange(of: startupModel.homeButtonPosition) { _ in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206074055876149/f

**Description**:
Update copy casing for Home Button mode, Bookmarks Bar appearance and session restoration settings.

**Steps to test this PR**:
(Consult Asana task for copy details)
1. Check Main Menu -> View -> Home Button options and verify that the copy uses `Title Case`.
2. Check Main Menu -> Bookmarks -> Bookmarks Bar options and verify that the copy uses `Title Case`.
3. Check Main Menu -> History -> Reopen All Windows from Last Session and verify that the copy uses `Title Case`.
4. Check Settings -> General -> Home Button options and verify that the copy uses `Sentence case`.
5. Check Settings -> Appearance -> Bookmarks Bar options and verify that the copy uses `Sentence case`.
6. Check Settings -> General -> On Startup and verify that the copy uses `Sentence case`.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
