### PR TITLE
Fix giving focus to webView when it's loaded in BrowserTabViewController

### DIFF
--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -407,7 +407,11 @@ final class BrowserTabViewController: NSViewController {
     private var setFirstResponderAfterAdding = false
 
     private func setFirstResponderIfNeeded() {
-        guard webView?.url != nil else {
+        guard let webView else {
+            setFirstResponderAfterAdding = true
+            return
+        }
+        guard webView.url != nil else {
             return
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204283962145424/f

**Description**:
When BrowserTabViewController's webView is nil upon tabDidStartNavigation, postpone
setting first responder until webView is added to view hierarchy.

**Steps to test this PR**:
1. Launch the app.
2. From new tab page enter search query.
3. When SERP is loaded, press space. Verify that SERP is scrolled down.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
