### PR TITLE
The appcast reference fix for version 0.31.7

### DIFF
--- a/scripts/upload_to_s3/upload_to_s3.sh
+++ b/scripts/upload_to_s3/upload_to_s3.sh
@@ -148,8 +148,13 @@ for FILENAME in $FILES_TO_UPLOAD; do
     fi
 done
 
-# Add appcast2.xml for upload last
-MISSING_FILES+=("appcast2.xml")
+# Create a copy of appcast2.xml called testing-appcast2.xml
+# https://app.asana.com/0/0/1206349575147845/f
+cp "$DIRECTORY/appcast2.xml" "$DIRECTORY/testing-appcast2.xml"
+echo "Created a copy of appcast2.xml as testing-appcast2.xml"
+
+# Add appcast files for upload
+MISSING_FILES+=("appcast2.xml" "testing-appcast2.xml")
 
 # Notify the user about files to be uploaded
 if [[ ${#MISSING_FILES[@]} -gt 0 ]] || [[ -n "$OVERWRITE_DMG_VERSION" ]]; then


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206349575147845/f
CC:

**Description**:
This script ensures the testing-appcast2.xml has the same content as appcast2.xml after each release

_Note: I'll update manual steps in the release template once this is merged_

**Steps to test this PR**:
1. Make sure you have some testing data in `~/Developer/sparkle-updates` (Just the latest appcast2.xml file should be fine)
1. Run `./scripts/upload_to_s3/upload_to_s3.sh --run --debug `
2. Make sure` testing-appcast2.xml` is part of the list of files to upload

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
