### PR TITLE
Allow arbitrary content loading for DBP

### DIFF
--- a/DuckDuckGoDBPBackgroundAgent/Info.plist
+++ b/DuckDuckGoDBPBackgroundAgent/Info.plist
@@ -6,5 +6,10 @@
 	<string>$(DBP_APP_GROUP)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1206259162884760/f

**Description**:
Allow arbitrary content loading for DBP

**Steps to test this PR**:
1. I recommend remove all broker JSONs, leaving only one left
2. Change the navigate url property to something not using https, like http://shinysublimesplendidspell.neverssl.com/online/
3. Run the DBP scan operation showing the webview. If it loads, it's all good :)
