### PR TITLE
Avoid unnecessary work during bulk drag and drop bookmarks bar operations

### DIFF
--- a/DuckDuckGo/BookmarksBar/View/BookmarksBarViewModel.swift
+++ b/DuckDuckGo/BookmarksBar/View/BookmarksBarViewModel.swift
@@ -398,17 +398,26 @@ extension BookmarksBarViewModel: NSCollectionViewDelegate, NSCollectionViewDataS
 
             return true
         } else if let pasteboardItems = draggingInfo.draggingPasteboard.pasteboardItems {
-            // First, check if the user is dragging a bulk set of bookmarks to the bar, and move them all at once.
-            // Otherwise, read whatever entities were dragged to the bar and create a bookmarks out of them.
+            var bookmarksBarUUIDs: [String] = []
+            var otherItems: [NSPasteboardItem] = []
 
-            let mappedBookmarkEntityUUIDs = pasteboardItems.compactMap(\.bookmarkEntityUUID)
-            if mappedBookmarkEntityUUIDs.count == pasteboardItems.count {
-                bookmarkManager.move(objectUUIDs: mappedBookmarkEntityUUIDs, toIndex: newIndexPath.item, withinParentFolder: .root) { error in
+            pasteboardItems.forEach { item in
+                if let bookmarkEntityUUID = item.bookmarkEntityUUID {
+                    bookmarksBarUUIDs.append(bookmarkEntityUUID)
+                } else {
+                    otherItems.append(item)
+                }
+            }
+
+            if !bookmarksBarUUIDs.isEmpty {
+                bookmarkManager.move(objectUUIDs: bookmarksBarUUIDs, toIndex: newIndexPath.item, withinParentFolder: .root) { error in
                     if error != nil {
                         self.delegate?.bookmarksBarViewModelReloadedData()
                     }
                 }
-            } else {
+            }
+
+            if !otherItems.isEmpty {
                 createBookmarks(from: pasteboardItems, at: newIndexPath.item)
             }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206386927179767/f
Tech Design URL:
CC: @bwaresiak 

**Description**:

This PR fixes issues with bulk drag and drop operations to the bookmarks bar. Previously, the implementation was iterating over and moving each dragged item individually - which could be potentially very large. I was personally able to break this after dragging even half a dozen items.

The new implementation pulls all of the bookmarks bar UUIDs out into an array first, and does a single batch move. After this change, I can no longer hit an assertion failure and Core Data error when moving any number of items.

⚠️ During testing I noticed two other issues:

1. There appears to be a cell reuse issue with the bookmarks bar, where every now and then some of the items will appear highlighted after bulk drag-and-dropping. This occurs in production and was not introduced here, so let's keep it out of scope.
2. When dragging an item from outside the browser to the bookmarks bar, the index is not respected, so the item is always appended to the end (see the `index` parameter [here](https://github.com/duckduckgo/macos-browser/blob/5352e94a9fdaf7bc6c62541fcaeac818ec70f181/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift#L300) and observe that it's not actually used within its function). Again, this occurs in production, let's just focus on the core problem in this PR.

**Steps to test this PR**:
1. Make sure you have at least 10 bookmarks or so, so we can do some bulk drag-and-drop operations
2. Go into the bookmarks manager, select a bunch of them, and drag them to an index in the bookmarks bar - take note of which bookmarks you dragged, and where you dragged them to
3. Make sure the bookmarks were dragged to the right index and maintained their order
4. Open a third party app like Mail.app and drag a link from an email to the bookmarks bar, then check that a bookmark for this item was created in the bookmarks manager. Note that it will not respect the index due to the issue mentioned in point number 2 in the description. This issue has apparently been happening in production for a long time, so I won't address it here, especially as it may require BSK changes

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
