### PR TITLE
Update URL.isDuckPlayer to return true also for duck scheme URLs

### DIFF
--- a/DuckDuckGo/YoutubePlayer/DuckPlayer.swift
+++ b/DuckDuckGo/YoutubePlayer/DuckPlayer.swift
@@ -70,13 +70,7 @@ final class DuckPlayer {
         }
     }()
 
-    static let duckPlayerHost: String = {
-        if usesSimulatedRequests {
-            return "www.youtube-nocookie.com"
-        } else {
-            return "player"
-        }
-    }()
+    static let duckPlayerHost: String = "player"
     static let commonName = UserText.duckPlayer
 
     static let shared = DuckPlayer()

--- a/DuckDuckGo/YoutubePlayer/DuckPlayerURLExtension.swift
+++ b/DuckDuckGo/YoutubePlayer/DuckPlayerURLExtension.swift
@@ -54,14 +54,16 @@ extension URL {
     /**
      * Returns true if a URL represents a Private Player URL.
      *
-     * When simulated requests are in use (macOS 12 and above), the Private Player Scheme URL is replaced by
-     * `www.youtube-nocookie.com/embed/VIDEOID` URL. Otherwise, checks for `duck://player/` URL.
+     * It primarily checks for `duck://player/` URL, but on macOS 12 and above (when using simulated requests),
+     * the Duck Scheme URL is eventually replaced by `www.youtube-nocookie.com/embed/VIDEOID` URL so this
+     * is checked too and this function returns `true` if any of the two is true on macOS 12.
      */
     var isDuckPlayer: Bool {
+        let isPrivatePlayer = isDuckURLScheme && host == DuckPlayer.duckPlayerHost
         if DuckPlayer.usesSimulatedRequests {
-            return host == DuckPlayer.duckPlayerHost && pathComponents.count == 3 && pathComponents[safe: 1] == "embed"
+            return isPrivatePlayer || isYoutubeNoCookie
         } else {
-            return isDuckURLScheme && host == DuckPlayer.duckPlayerHost
+            return isPrivatePlayer
         }
     }
 
@@ -134,6 +136,10 @@ extension URL {
     }
 
     // MARK: - Private
+
+    private var isYoutubeNoCookie: Bool {
+        host == "www.youtube-nocookie.com" && pathComponents.count == 3 && pathComponents[safe: 1] == "embed"
+    }
 
     private var isYoutubeWatch: Bool {
         guard let host else { return false }

--- a/UnitTests/YoutubePlayer/DuckPlayerURLExtensionTests.swift
+++ b/UnitTests/YoutubePlayer/DuckPlayerURLExtensionTests.swift
@@ -39,7 +39,7 @@ final class DuckPlayerURLExtensionTests: XCTestCase {
         XCTAssertFalse("https://www.youtube-nocookie.com/embed".url!.isDuckPlayer)
         XCTAssertFalse("https://www.youtube-nocookie.com/embed?t=23s".url!.isDuckPlayer)
 
-        XCTAssertFalse("duck://player/abcdef12345".url!.isDuckPlayer)
+        XCTAssertTrue("duck://player/abcdef12345".url!.isDuckPlayer)
         XCTAssertFalse("https://www.youtube.com/watch?v=abcdef12345".url!.isDuckPlayer)
         XCTAssertFalse("https://duckduckgo.com".url!.isDuckPlayer)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206392088291140/f

**Description**:
Return true from URL.isDuckPlayer when the URL is youtube-nocookie.com (simulated request)
or duck://player (for scheme handler).

**Steps to test this PR**:
1. Verify that you can open Duck Player in "Show overlays" and "Always open" mode.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
