### PR TITLE
fix DBP UI at duck://dbp url

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -119,6 +119,8 @@ protocol NewWindowPolicyDecisionMaker {
                 return .anySettingsPane
             case URL.bookmarks, URL.Invalid.aboutBookmarks:
                 return .bookmarks
+            case URL.dataBrokerProtection:
+                return .dataBrokerProtection
             case URL.Invalid.aboutHome:
                 guard let customURL = URL(string: StartupPreferences.shared.formattedCustomHomePageURL) else {
                     return .newtab


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206389286378952/f

**Description**:
- fixes opening DBP UI at duck://dbp url

**Steps to test this PR**:
1. Return false from this line 
[macos-browser/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/RedeemCodeServices.swift](https://github.com/duckduckgo/macos-browser/blob/2bd8ca8663b388d62126822c8c26be7e39fdd547/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Services/RedeemCodeServices.swift#L72)
Line 72 in [2bd8ca8](https://github.com/duckduckgo/macos-browser/commit/2bd8ca8663b388d62126822c8c26be7e39fdd547)
authenticationRepository.getAccessToken() == nil
2. Return true from this line if you're not already logged as in internal user 
[macos-browser/DuckDuckGo/DBP/DataBrokerProtectionFeatureVisibility.swift](https://github.com/duckduckgo/macos-browser/blob/2bd8ca8663b388d62126822c8c26be7e39fdd547/DuckDuckGo/DBP/DataBrokerProtectionFeatureVisibility.swift#L62)
Line 62 in [2bd8ca8](https://github.com/duckduckgo/macos-browser/commit/2bd8ca8663b388d62126822c8c26be7e39fdd547)
NSApp.delegateTyped.internalUserDecider.isInternalUser
3. return true in DefaultDataBrokerProtectionFeatureVisibility.isFeatureVisible()
4. Activate Debug->DBP->Bypass waitlist
5. Go to the Browser Menu, select Personal information removal, validate DBP UI is open


<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
