### PR TITLE
Only set the last VPN version run from the agent

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionAppEvents.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionAppEvents.swift
@@ -115,7 +115,6 @@ final class NetworkProtectionAppEvents {
     }
 
     private func restartNetworkProtectionIfVersionChanged(using loginItemsManager: LoginItemsManager) {
-        let currentVersion = AppVersion.shared.versionAndBuildNumber
         let versionStore = NetworkProtectionLastVersionRunStore()
 
         // should‘ve been run at least once with NetP enabled


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206400808247141/f
Tech Design URL:
CC:

**Description**:

This PR changes our "last version run" logic to only update the version if the agent starts.

The current implementation checks this from the main app, and only restarts the tunnel if the version changes AND as long as an existing last version run value is present, but it mistakenly sets the last version after checking.

**Steps to test this PR**:
1. Run the app and check that the `restartNetworkProtectionIfVersionChanged` function doesn't actually update the version number itself - the version number should only change if the VPN agent's version changes

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
