### PR TITLE
disable Pixel for Safari Bookmarks.plist read permission request

### DIFF
--- a/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
+++ b/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
@@ -60,7 +60,7 @@ final class SafariDataImporter: DataImporter {
         }
     }
 
-    static private let bookmarksFileName = "Bookmarks.plist"
+    static let bookmarksFileName = "Bookmarks.plist"
 
     private var fileUrl: URL {
         profile.profileURL.appendingPathComponent(Self.bookmarksFileName)

--- a/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -308,7 +308,10 @@ struct DataImportViewModel {
                     break
                 }
                 log("file read no permission for \(url.path)")
-                Pixel.fire(.dataImportFailed(source: importSource, sourceVersion: importSource.installedAppsMajorVersionDescription(selectedProfile: selectedProfile), error: importError))
+
+                if url != selectedProfile?.profileURL.appendingPathComponent(SafariDataImporter.bookmarksFileName) {
+                    Pixel.fire(.dataImportFailed(source: importSource, sourceVersion: importSource.installedAppsMajorVersionDescription(selectedProfile: selectedProfile), error: importError))
+                }
                 screen = .getReadPermission(url)
                 return true
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206403448888681/f

**Description**:
- Disables Data Import Read permission Pixel for Safari Bookmarks.plist file

**Steps to test this PR**:
0. Add `return .failure(ImportError(type: .readPlist, underlyingError: CocoaError(.fileReadNoPermission, userInfo: [NSURLErrorKey: safariBookmarksFileURL])))` in `SafariBookmarksReader.swift:85`
1. Import bookmarks from Safari, validate when Bookmarks.plist read permission is requested no data import failure pixel is fired

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
