### PR TITLE
Disable repeated Bloom Filter errors reporting

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "browserserviceskit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/BrowserServicesKit",
-      "state" : {
-        "revision" : "1d3a891fa58182d10b7bfa3a9b29cec51909c3c7",
-        "version" : "101.1.5"
-      }
-    },
-    {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
@@ -147,7 +138,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
       "state" : {
         "revision" : "a6b7ba151d9dc6684484f3785293875ec01cc1ff",
         "version" : "1.2.2"

--- a/DuckDuckGo/SmarterEncryption/PrivacyFeatures.swift
+++ b/DuckDuckGo/SmarterEncryption/PrivacyFeatures.swift
@@ -41,11 +41,20 @@ final class AppPrivacyFeatures: PrivacyFeaturesProtocol {
     let contentBlocking: AnyContentBlocking
     let httpsUpgrade: HTTPSUpgrade
 
+    private static var lastReportedBloomFilterError: NSError?
     private static let httpsUpgradeDebugEvents = EventMapping<AppHTTPSUpgradeStore.ErrorEvents> { event, error, parameters, onComplete in
         let domainEvent: Pixel.Event.Debug
         switch event {
         case .dbSaveBloomFilterError:
             domainEvent = .dbSaveBloomFilterError
+            if let lastReportedBloomFilterError,
+               lastReportedBloomFilterError.domain == (error as NSError?)?.domain,
+               lastReportedBloomFilterError.code == (error as NSError?)?.code {
+                // don‘t report repeated failures
+                return
+            }
+            lastReportedBloomFilterError = error as NSError?
+
         case .dbSaveExcludedHTTPSDomainsError:
             domainEvent = .dbSaveExcludedHTTPSDomainsError
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1205962557569232/f

**Description**:
- Disable repeated Pixels for Bloom Filter errors

**Steps to test this PR**:
1. Add `throw NSError(domain: NSSQLiteErrorDomain, code: 13)` at AppHTTPSUpgradeStore.swift:166 and disable `assertionFailure` at line 92
2. Run the app, validate Pixel is fired with the error for the first time, wait a few seconds for the next config update cycle, validate the Pixel is not fired for the thrown error
