### PR TITLE
Fix navigating to native pages

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -543,7 +543,7 @@ protocol NewWindowPolicyDecisionMaker {
     @MainActor(unsafe)
     private func cleanUpBeforeClosing(onDeinit: Bool) {
         let job = { [webView, userContentController] in
-            webView.stopAllMediaAndLoading()
+            webView.stopAllMedia(shouldStopLoading: true)
 
             userContentController?.cleanUpBeforeClosing()
             webView.assertObjectDeallocated(after: 4.0)
@@ -560,7 +560,7 @@ protocol NewWindowPolicyDecisionMaker {
     }
 
     func stopAllMediaAndLoading() {
-        webView.stopAllMediaAndLoading()
+        webView.stopAllMedia(shouldStopLoading: true)
     }
 
 #if DEBUG
@@ -595,7 +595,7 @@ protocol NewWindowPolicyDecisionMaker {
     @Published private(set) var content: TabContent {
         didSet {
             if !content.displaysContentInWebView && oldValue.displaysContentInWebView {
-                webView.stopAllMediaAndLoading()
+                webView.stopAllMedia(shouldStopLoading: false)
             }
             handleFavicon(oldValue: oldValue)
             invalidateInteractionStateData()
@@ -814,12 +814,12 @@ protocol NewWindowPolicyDecisionMaker {
            let customURL = URL(string: startupPreferences.formattedCustomHomePageURL) {
             webView.load(URLRequest(url: customURL))
         } else {
-            content = .newtab
+            webView.load(URLRequest(url: .newtab))
         }
     }
 
     func startOnboarding() {
-        content = .onboarding
+        webView.load(URLRequest(url: .welcome))
     }
 
     func reload() {

--- a/DuckDuckGo/Tab/View/WebView.swift
+++ b/DuckDuckGo/Tab/View/WebView.swift
@@ -36,8 +36,10 @@ final class WebView: WKWebView {
         }
     }
 
-    func stopAllMediaAndLoading() {
-        stopLoading()
+    func stopAllMedia(shouldStopLoading: Bool) {
+        if shouldStopLoading {
+            stopLoading()
+        }
         stopMediaCapture()
         stopAllMediaPlayback()
         if isInFullScreenMode {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205967509404626/f

**Description**:
Update stopAllMediaAndLoading to call stopLoading optionally (controlled by a boolean argument).
Don't stop loading when setting new content on a tab, which fixes navigating to duck:// URLs.

**Steps to test this PR**:
1. Navigate to a website
2. Navigate back, verify that home page is presented and you can go forward in the back-forward list
3. Navigate forward, verify that you're navigated back to the website from 1.
4. Show home button on the address bar
5. Navigate to a website and then click home button
6. Navigate back and verify that you're navigated to the website from 5.
7. Navigate forward and verify that you're back to the new tab page.
8. Repeat similar steps with other native page like bookmarks or settings.


<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
