### PR TITLE
Alex/disable onboarding existing users

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -102,6 +102,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, FileDownloadManagerDel
             fileStore = EncryptedFileStore()
         }
 
+        // keep this on top!
+        // disable onboarding for existing users
+        let isOnboardingFinished = UserDefaultsWrapper<Bool>(key: .onboardingFinished, defaultValue: false)
+        if !isOnboardingFinished.wrappedValue,
+           FileManager.default.fileExists(atPath: URL.sandboxApplicationSupportURL.path) {
+            isOnboardingFinished.wrappedValue = true
+        }
+
         let internalUserDeciderStore = InternalUserDeciderStore(fileStore: fileStore)
         internalUserDecider = DefaultInternalUserDecider(store: internalUserDeciderStore)
 

--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -245,7 +245,7 @@ public struct UserDefaultsWrapper<T> {
 
             return value
         }
-        set {
+        nonmutating set {
             setValue(newValue)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206416810557971/f

**Description**:
- Disables onboarding for users having Data directory

**Steps to test this PR**:
for DEBUG mode:
1. Comment out lines 68-70 and 73 in `MainWindowController.swift`
2. Remove `~/Library/Containers/com.duckduckgo.macos.browser.debug/Data` directory
3. `defaults remove com.duckduckgo.macos.browser.debug`
4. Run the browser, validate the onboarding is shown
5. Quit the browser without finishing the Onboarding
6. Launch again, validate no Onboarding is shown

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
