### PR TITLE
fix Safari favicons import

### DIFF
--- a/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
+++ b/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
@@ -26,7 +26,6 @@ final class SafariDataImporter: DataImporter {
         let openPanel = NSOpenPanel()
         // if file does not exist, grant permission to its parent folder
         openPanel.directoryURL = fileUrl.deletingLastPathComponent()
-        openPanel.directoryURL = fileUrl
         openPanel.message = UserText.bookmarkImportSafariRequestPermissionButtonTitle
         openPanel.allowsOtherFileTypes = false
         openPanel.canChooseFiles = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206402251433589/f

**Description**:
- Restores granting permission to Safari folder instead of only `Bookmarks.plist` fixing Safari favicons import 

**Steps to test this PR**:
1. Import Bookmarks from Safari using the App Store build, make sure Bookmarks.plist permission is requested
2. Validate no error is thrown on lines 100, 102 in `SafariFaviconsReader.swift`

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
