### PR TITLE
Fix agent startup

### DIFF
--- a/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
@@ -40,9 +40,17 @@ struct DataBrokerProtectionAppEvents {
 
         Task {
             try? await DataBrokerProtectionWaitlist().redeemDataBrokerProtectionInviteCodeIfAvailable()
+
+            // If we don't have profileQueries it means there's no user profile saved in our DB
+            // In this case, let's disable the agent and delete any left-over data because there's nothing for it to do
+            let profileQueries = await DataBrokerProtectionManager.shared.dataManager.fetchBrokerProfileQueryData(ignoresCache: true)
+            if profileQueries.count > 0 {
+                restartBackgroundAgent(loginItemsManager: loginItemsManager)
+            } else {
+                featureVisibility.disableAndDeleteForWaitlistUsers()
+            }
         }
 
-        restartBackgroundAgent(loginItemsManager: loginItemsManager)
     }
 
     func applicationDidBecomeActive() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1206412688037751/f
Tech Design URL:
CC:

**Description**:
* Prevents the background agent from starting on waitlist users that did not start the DBP process
* Disable the agent if the user doesn't have profile data

**Steps to test this PR**:
- As non waitlist user - 
1 - Open app, check if DBP agent is started, it shouldn't 

- As waitlist user,  To make it easier, return true in these [3 methods](https://github.com/duckduckgo/macos-browser/blob/28111c58f25c9aa9b2599548a6aedcdc64c64281/DuckDuckGo/DBP/DataBrokerProtectionFeatureVisibility.swift#L69-L78) to simulate a waitlist user
1 - Open app, check if DBP agent is started, it shouldn't 
2 - Fill the profile for a scan, start the scan
3 - Force close the browser, check if the agent is restarted, it should
4 - Close the app, delete the database, open it again, check if the agent is restarted, it shouldn't
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
