### PR TITLE
fix WebView value validation popover crash when WebView not in hierarchy

### DIFF
--- a/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
+++ b/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
@@ -52,14 +52,14 @@ extension WKWebViewConfiguration {
         self.userContentController = userContentController
         self.processPool.geolocationProvider = GeolocationProvider(processPool: self.processPool)
 
-        _=NSPopover.swizzleCurrentFrameOnScreenOnce
+        _=NSPopover.swizzleShowRelativeToRectOnce
      }
 
 }
 
 extension NSPopover {
 
-    fileprivate static let swizzleCurrentFrameOnScreenOnce: () = {
+    fileprivate static let swizzleShowRelativeToRectOnce: () = {
         guard let originalMethod = class_getInstanceMethod(NSPopover.self, #selector(show(relativeTo:of:preferredEdge:))),
               let swizzledMethod = class_getInstanceMethod(NSPopover.self, #selector(swizzled_show(relativeTo:of:preferredEdge:))) else {
             assertionFailure("Methods not available")
@@ -74,7 +74,7 @@ extension NSPopover {
     @objc(swizzled_showRelativeToRect:ofView:preferredEdge:)
     private dynamic func swizzled_show(relativeTo positioningRect: NSRect, of positioningView: NSView, preferredEdge: NSRectEdge) {
         if positioningView.superview == nil {
-            var observer: Cancellable!
+            var observer: Cancellable?
             observer = positioningView.observe(\.window) { positioningView, _ in
                 if positioningView.window != nil {
                     self.swizzled_show(relativeTo: positioningRect, of: positioningView, preferredEdge: preferredEdge)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206407295280737/f

**Description**:
- Fixes a crash when WebView tries to present a Value Validation Popover when the WebView is not in view hierarchy

**Steps to test this PR**:
1. Navigate to https://wpt.live/tools/runner/index.html
2. Uncheck "Manual tests" and set "Timeout multiplier" to "0.1"
3. Click "Start", validate there‘s no crash on a new empty Tab open
4. Switch back to the original tab - validate the Validation Popover is shown
5. Switch to the new tab and back to the original tab, validate the popover is not shown anymore

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
