### PR TITLE
Show history menu on cmd+y shortcut

### DIFF
--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -514,7 +514,7 @@ extension MainViewController {
             NSApp.menu?.performKeyEquivalent(with: event)
             return true
 
-        case kVK_ANSI_Y:
+        case kVK_ANSI_Y where flags == .command:
             (NSApp.mainMenuTyped.historyMenu.accessibilityParent() as? NSMenuItem)?.accessibilityPerformPress()
             return true
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204428516021210/f

**Description**:
Use Accessibility API to click history menu item in Main Menu.

**Steps to test this PR**:
Run the app, click cmd+y, verify that history menu is shown.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
