### PR TITLE
appcastManager: Retain release notes for all versions

### DIFF
--- a/scripts/appcast_manager/appcastManager.swift
+++ b/scripts/appcast_manager/appcastManager.swift
@@ -341,17 +341,23 @@ final class AppcastDownloader {
         var currentElement: String = ""
         var enclosureURL: String = ""
         var releaseNotesHTML: String?
-        var currentVersion: String?
-        var currentVersionNumber: String?
+        var marketingVersion: String? // e.g. 1.70.0
+        var buildNumber: String? // e.g. 104 (but 1.70.0 for old versions before we switched to using integer build number)
 
+        /**
+         * This represents the version as indicated in the file name.
+         *
+         * For old versions, where build number was equal to the marketing version, it's just the marketing version.
+         * For new versions, where build number is an integer, it's the marketing version and the build number joined by a dot.
+         */
         var currentVersionIdentifier: String? {
-            guard let currentVersion else {
+            guard let marketingVersion else {
                 return nil
             }
-            guard let currentVersionNumber, currentVersionNumber != currentVersion else {
-                return currentVersion
+            guard let buildNumber, buildNumber != marketingVersion else {
+                return marketingVersion
             }
-            return [currentVersion, currentVersionNumber].joined(separator: ".")
+            return [marketingVersion, buildNumber].joined(separator: ".")
         }
 
         private let downloadFile: (URL, URL, @escaping (Error?) -> Void) -> Void
@@ -380,8 +386,8 @@ final class AppcastDownloader {
                     }
                 }
             } else if elementName == "item" {
-                currentVersion = nil
-                currentVersionNumber = nil
+                marketingVersion = nil
+                buildNumber = nil
                 releaseNotesHTML = nil
             }
         }
@@ -390,9 +396,9 @@ final class AppcastDownloader {
             if currentElement == "description" {
                 releaseNotesHTML = (releaseNotesHTML ?? "") + string.trimmingCharacters(in: .whitespacesAndNewlines)
             } else if currentElement == "sparkle:shortVersionString" {
-                currentVersion = ((currentVersion ?? "") + string.trimmingCharacters(in: .whitespacesAndNewlines))
+                marketingVersion = ((marketingVersion ?? "") + string.trimmingCharacters(in: .whitespacesAndNewlines))
             } else if currentElement == "sparkle:version" {
-                currentVersionNumber = ((currentVersionNumber ?? "") + string.trimmingCharacters(in: .whitespacesAndNewlines))
+                buildNumber = ((buildNumber ?? "") + string.trimmingCharacters(in: .whitespacesAndNewlines))
             }
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206448928696961/f
CC: @samsymons 

**Description**:
Fix parsing existing release notes from appcast2.xml so that they're stored in files with names matching
dmg names (including version and build number)

**Steps to test this PR**:
1. Download the latest DMG file from [the latest macOS app internal release](https://app.asana.com/0/1199230911884351/1206404155810886/f).
2. Copy release notes from that release task to `release-notes.txt` file
3. Call appcastManager:
  * `./scripts/appcast_manager/appcastManager.swift --release-to-internal-channel --dmg ~/Downloads/duckduckgo-1.72.0.113.dmg --release-notes release-notes.txt`
4. Open `~/Developer/sparkle-updates/appcast_diff.txt` and verify that no release notes have been deleted from the file and only changes are binary diffs signatures (there should only be 2 lines changed).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
