### PR TITLE
Fix `site:` queries escaping with iOS 17 SDK (#640)

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13120,8 +13120,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "mariusz/url-escaping-ios17";
-				kind = branch;
+				kind = exactVersion;
+				version = 103.0.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "mariusz/url-escaping-ios17",
-        "revision" : "0ac84b2582f96209495916c80715333387311cb0"
+        "revision" : "055cc2d86c0ac085d032fc28665c3115ea3f325a",
+        "version" : "103.0.1"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/LoginItems/Package.swift
+++ b/LocalPackages/LoginItems/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],

--- a/LocalPackages/PixelKit/Package.swift
+++ b/LocalPackages/PixelKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/Subscription/Package.swift
+++ b/LocalPackages/Subscription/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Subscription"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SwiftUIExtensions/Package.swift
+++ b/LocalPackages/SwiftUIExtensions/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "PreferencesViews", targets: ["PreferencesViews"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../SwiftUIExtensions"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SystemExtensionManager/Package.swift
+++ b/LocalPackages/SystemExtensionManager/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/XPCHelper/Package.swift
+++ b/LocalPackages/XPCHelper/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "XPCHelper", targets: ["XPCHelper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206343150540010/f

**Description**:
Linking to iOS 17 SDK modifies how URLs are being parsed and escaped (see [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes)). This change re-uses the solution done for macOS.

**Steps to test this PR**:
See [PR in BSK](https://github.com/duckduckgo/BrowserServicesKit/pull/640)

Internal references:

[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)