### PR TITLE
Update BSK with autofill 10.1.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13290,8 +13290,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 29155f1d3b565a9993bbcb93a7493ddab69f0969;
+				kind = exactVersion;
+				version = 104.1.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "537dc46b8aa45d9a177ab189fbc6705bc14dfd93",
-        "version" : "104.1.0"
+        "revision" : "3b10ff8d5d433a4eb45a1d4d25a348033f5102c1",
+        "version" : "104.1.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
-        "version" : "10.0.3"
+        "revision" : "03d3e3a959dd75afbe8c59b5a203ea676d37555d",
+        "version" : "10.1.0"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/LoginItems/Package.swift
+++ b/LocalPackages/LoginItems/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions")
     ],

--- a/LocalPackages/PixelKit/Package.swift
+++ b/LocalPackages/PixelKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/Subscription/Package.swift
+++ b/LocalPackages/Subscription/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["Subscription"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SwiftUIExtensions/Package.swift
+++ b/LocalPackages/SwiftUIExtensions/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "PreferencesViews", targets: ["PreferencesViews"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../SwiftUIExtensions"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SystemExtensionManager/Package.swift
+++ b/LocalPackages/SystemExtensionManager/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/XPCHelper/Package.swift
+++ b/LocalPackages/XPCHelper/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "XPCHelper", targets: ["XPCHelper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "104.1.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206475855296116/1206475855296116/f
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.1.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/643

## Description
Updates Autofill to version [10.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.1.0). 

### Autofill 10.1.0 release notes
## What's Changed
* Support shadow dom by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/485
* New batch of fixes + integration test improvements by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/489
* Update password-related json files (2024-01-17) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/474
* Bump playwright from 1.38.1 to 1.40.1 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/458
* Update password-related json files (2024-01-26) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/484
* Bump json-schema-to-typescript from 13.1.1 to 13.1.2 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/479


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.3...10.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).