### PR TITLE
Fix DBP first scan notification pixel

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UserNotifications/DataBrokerProtectionUserNotificationService.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UserNotifications/DataBrokerProtectionUserNotificationService.swift
@@ -156,7 +156,7 @@ extension DefaultDataBrokerProtectionUserNotificationService: UNUserNotification
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
         guard let identifier = UNNotificationRequest.Identifier(rawValue: response.notification.request.identifier) else { return }
 
-        let pixelMapper: [UNNotificationRequest.Identifier: DataBrokerProtectionPixels] = [.firstScanComplete: .dataBrokerProtectionNotificationSentFirstScanComplete,
+        let pixelMapper: [UNNotificationRequest.Identifier: DataBrokerProtectionPixels] = [.firstScanComplete: .dataBrokerProtectionNotificationOpenedFirstScanComplete,
                                                                                            .firstProfileRemoved: .dataBrokerProtectionNotificationOpenedFirstRemoval,
                                                                                            .allInfoRemoved: .dataBrokerProtectionNotificationOpenedAllRecordsRemoved,
                                                                                            .twoWeeksCheckIn: .dataBrokerProtectionNotificationOpened2WeeksCheckIn]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1206487658812248/f

**Description**:
Fix pixel being fired when user opens the notification

**Steps to test this PR**:
1. Check if we're sending `dataBrokerProtectionNotificationOpenedFirstScanComplete` on `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) `

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
