### PR TITLE
Disable failing DBP tests

### DIFF
--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo Privacy Browser.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo Privacy Browser.xcscheme
@@ -205,7 +205,13 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "DataBrokerProfileQueryOperationManagerTests">
+                  Identifier = "DataBrokerProfileQueryOperationManagerTests/testWhenNewExtractedProfileIsNotInDatabase_thenIsAddedToTheDatabaseAndOptOutOperationIsCreated()">
+               </Test>
+               <Test
+                  Identifier = "DataBrokerProfileQueryOperationManagerTests/testWhenRemovedProfileIsFound_thenOptOutConfirmedIsAddedRemoveDateIsUpdatedAndPreferredRunDateIsSetToNil()">
+               </Test>
+               <Test
+                  Identifier = "DataBrokerProfileQueryOperationManagerTests/testWhenScannedProfileIsAlreadyInTheDatabaseAndWasNotFoundInBroker_thenTheRemovedDateIsSet()">
                </Test>
             </SkippedTests>
          </TestableReference>


### PR DESCRIPTION
- testWhenNewExtractedProfileIsNotInDatabase_thenIsAddedToTheDatabaseAndOptOutOperationIsCreated
- testWhenRemovedProfileIsFound_thenOptOutConfirmedIsAddedRemoveDateIsUpdatedAndPreferredRunDateIsSetToNil
- testWhenScannedProfileIsAlreadyInTheDatabaseAndWasNotFoundInBroker_thenTheRemovedDateIsSet

failing at assertionFailure("If no extracted profiles are saved, removed profiles should always be empty")  at DataBrokerProfileQueryOperationManager.swift:243 

Task/Issue URL: https://app.asana.com/0/0/1206472717181414/f
