### PR TITLE
Fix BSK reference to tagged version

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "mariusz/fix-rollout-check",
-        "revision" : "b11b744048cf0538ff04ee434772fde0ff81f9d7"
+        "revision" : "2555be729ff019465b4b263d9d68c2d10a88470a",
+        "version" : "104.2.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
-        "version" : "10.0.3"
+        "revision" : "03d3e3a959dd75afbe8c59b5a203ea676d37555d",
+        "version" : "10.1.0"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206535983618950/f

**Description**:
BSK pointed to private branch instead of released version. Caused by https://github.com/duckduckgo/macos-browser/pull/2152

**Steps to test this PR**:
1. Ensure BSK version is correct in all required targets

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
