### PR TITLE
Prevent text selection from superseding the VPN easter egg

### DIFF
--- a/DuckDuckGo/Preferences/View/PreferencesAboutView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesAboutView.swift
@@ -53,7 +53,6 @@ extension Preferences {
                             Text(UserText.privacySimplified).font(.privacySimplified)
 
                             Text(UserText.versionLabel(version: model.appVersion.versionNumber, build: model.appVersion.buildNumber))
-                                .makeSelectable()
                                 .onTapGesture(count: 12) {
 #if NETWORK_PROTECTION && !SUBSCRIPTION
                                     model.displayNetPInvite()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206547948478798/f
Tech Design URL:
CC: @mallexxx 

**Description**:

This PR makes it so that the VPN easter egg flow can work again.

**Steps to test this PR**:

1. Check that clicking the version number label 12 times in a row shows the VPN invite code modal

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
