### PR TITLE
Add lite PIR version debug option

### DIFF
--- a/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
@@ -133,7 +133,10 @@ final class DataBrokerProtectionDebugMenu: NSMenu {
             NSMenuItem(title: "Show DB Browser", action: #selector(DataBrokerProtectionDebugMenu.showDatabaseBrowser))
                 .targetting(self)
             NSMenuItem(title: "Force Profile Removal", action: #selector(DataBrokerProtectionDebugMenu.showForceOptOutWindow))
+                .targetting(self)
             NSMenuItem(title: "Force broker JSON files update", action: #selector(DataBrokerProtectionDebugMenu.forceBrokerJSONFilesUpdate))
+                .targetting(self)
+            NSMenuItem(title: "Run Personal Information Removal Debug Mode", action: #selector(DataBrokerProtectionDebugMenu.runCustomJSON))
                 .targetting(self)
         }
     }
@@ -252,6 +255,21 @@ final class DataBrokerProtectionDebugMenu: NSMenu {
         window.center()
         dataBrokerForceOptOutWindowController = NSWindowController(window: window)
         dataBrokerForceOptOutWindowController?.showWindow(nil)
+        window.delegate = self
+    }
+
+    @objc private func runCustomJSON() {
+        let viewController = DataBrokerRunCustomJSONViewController()
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 400),
+                              styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                              backing: .buffered,
+                              defer: false)
+
+        window.contentViewController = viewController
+        window.minSize = NSSize(width: 500, height: 400)
+        window.center()
+        databaseBrowserWindowController = NSWindowController(window: window)
+        databaseBrowserWindowController?.showWindow(nil)
         window.delegate = self
     }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONView.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONView.swift
@@ -1,0 +1,122 @@
+//
+//  DataBrokerRunCustomJSONView.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import BrowserServicesKit
+
+struct DataBrokerRunCustomJSONView: View {
+    @ObservedObject var viewModel: DataBrokerRunCustomJSONViewModel
+
+    @State private var jsonText: String = ""
+
+    var body: some View {
+        if viewModel.results.isEmpty {
+            VStack(alignment: .leading) {
+                Text("macOS App version: \(viewModel.appVersion())")
+                Text("C-S-S version: \(viewModel.contentScopeScriptsVersion())")
+
+                Divider()
+
+                HStack {
+                    TextField("First name", text: $viewModel.firstName)
+                        .padding()
+                    TextField("Last name", text: $viewModel.lastName)
+                        .padding()
+                    TextField("Middle", text: $viewModel.middle)
+                        .padding()
+                }
+
+                Divider()
+
+                HStack {
+                    TextField("City", text: $viewModel.city)
+                        .padding()
+                    TextField("State", text: $viewModel.state)
+                        .padding()
+                }
+
+                Divider()
+
+                HStack {
+                    TextField("Birth year (YYYY)", text: $viewModel.birthYear)
+                        .padding()
+                }
+
+                Divider()
+
+                List(viewModel.brokers, id: \.name) { broker in
+                    Text(broker.name)
+                        .onTapGesture {
+                            jsonText = broker.toJSONString()
+                        }
+                }.navigationTitle("Current brokers")
+
+                Divider()
+
+                TextEditor(text: $jsonText)
+                    .border(Color.gray, width: 1)
+                    .padding()
+
+                Divider()
+                Button("Run") {
+                    viewModel.runJSON(jsonString: jsonText)
+                }
+            }
+            .padding()
+            .frame(minWidth: 600, minHeight: 800)
+            .alert(isPresented: $viewModel.showAlert) {
+                            Alert(title: Text(viewModel.alert?.title ?? "-"),
+                                  message: Text(viewModel.alert?.description ?? "-"),
+                                  dismissButton: .default(Text("OK"), action: { viewModel.showAlert = false })
+                            )
+                        }
+        } else {
+            VStack {
+                VStack {
+                    List(viewModel.results, id: \.name) { extractedProfile in
+                        HStack {
+                            Text(extractedProfile.name ?? "No name")
+                                .padding(.horizontal, 10)
+                            Divider()
+                            Text(extractedProfile.addresses?.first?.fullAddress ?? "No address")
+                                .padding(.horizontal, 10)
+                            Divider()
+                            Text(extractedProfile.relatives?.joined(separator: ",") ?? "No relatives")
+                                .padding(.horizontal, 10)
+                            Divider()
+                            Button("Opt-out") {
+                                viewModel.runOptOut(extractedProfile: extractedProfile)
+                            }
+                        }
+                    }.navigationTitle("Results")
+                }.frame(minWidth: 600, minHeight: 800)
+
+                Divider()
+
+                Button("Clear and go back") {
+                    viewModel.results.removeAll()
+                }.padding()
+            }.alert(isPresented: $viewModel.showAlert) {
+                Alert(title: Text(viewModel.alert?.title ?? "-"),
+                      message: Text(viewModel.alert?.description ?? "-"),
+                      dismissButton: .default(Text("OK"), action: { viewModel.showAlert = false })
+                )
+            }
+        }
+    }
+}

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONViewController.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONViewController.swift
@@ -1,0 +1,29 @@
+//
+//  DataBrokerRunCustomJSONViewController.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftUI
+
+public final class DataBrokerRunCustomJSONViewController: NSViewController {
+    public override func loadView() {
+        let contentView = DataBrokerRunCustomJSONView(viewModel: DataBrokerRunCustomJSONViewModel())
+        let hostingController = NSHostingController(rootView: contentView)
+        hostingController.view.autoresizingMask = [.width, .height]
+        self.view = hostingController.view
+    }
+}

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONViewModel.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONViewModel.swift
@@ -1,0 +1,353 @@
+//
+//  DataBrokerRunCustomJSONViewModel.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import BrowserServicesKit
+import Common
+import ContentScopeScripts
+import Combine
+
+struct AlertUI {
+    var title: String = ""
+    var description: String = ""
+
+    static func noResults() -> AlertUI {
+        AlertUI(title: "No results", description: "No results were found.")
+    }
+
+    static func from(error: DataBrokerProtectionError) -> AlertUI {
+        AlertUI(title: error.title, description: error.description)
+    }
+}
+
+final class DataBrokerRunCustomJSONViewModel: ObservableObject {
+
+    @Published var firstName: String = ""
+    @Published var lastName: String = ""
+    @Published var middle: String = ""
+    @Published var city: String = ""
+    @Published var state: String = ""
+    @Published var birthYear: String = ""
+    @Published var results = [ExtractedProfile]()
+    @Published var showAlert = false
+    @Published var showNoResults = false
+    var alert: AlertUI?
+    var selectedDataBroker: DataBroker?
+
+    let brokers: [DataBroker]
+
+    private let runnerProvider: OperationRunnerProvider
+
+    init() {
+        let privacyConfigurationManager = PrivacyConfigurationManagingMock()
+        let features = ContentScopeFeatureToggles(emailProtection: false,
+                                                  emailProtectionIncontextSignup: false,
+                                                  credentialsAutofill: false,
+                                                  identitiesAutofill: false,
+                                                  creditCardsAutofill: false,
+                                                  credentialsSaving: false,
+                                                  passwordGeneration: false,
+                                                  inlineIconCredentials: false,
+                                                  thirdPartyCredentialsProvider: false)
+
+        let sessionKey = UUID().uuidString
+        let contentScopeProperties = ContentScopeProperties(gpcEnabled: false,
+                                                            sessionKey: sessionKey,
+                                                            featureToggles: features)
+        self.runnerProvider = DataBrokerOperationRunnerProvider(
+            privacyConfigManager: privacyConfigurationManager,
+            contentScopeProperties: contentScopeProperties,
+            emailService: EmailService(),
+            captchaService: CaptchaService())
+
+        let fileResources = FileResources()
+        self.brokers = fileResources.fetchBrokerFromResourceFiles() ?? [DataBroker]()
+    }
+
+    func runJSON(jsonString: String) {
+        if firstName.isEmpty || lastName.isEmpty || city.isEmpty || state.isEmpty || birthYear.isEmpty {
+            self.showAlert = true
+            self.alert = AlertUI(title: "Error", description: "Some required fields were not entered.")
+            return
+        }
+
+        if let data = jsonString.data(using: .utf8) {
+            do {
+                let decoder = JSONDecoder()
+                let dataBroker = try decoder.decode(DataBroker.self, from: data)
+                self.selectedDataBroker = dataBroker
+                let brokerProfileQueryData = createBrokerProfileQueryData(for: dataBroker)
+
+                let runner = runnerProvider.getOperationRunner()
+
+                Task {
+                    do {
+                        let extractedProfiles = try await runner.scan(brokerProfileQueryData, stageCalculator: FakeStageDurationCalculator(), showWebView: true) { true }
+
+                        DispatchQueue.main.async {
+                            if extractedProfiles.isEmpty {
+                                self.showNoResultsAlert()
+                            } else {
+                                self.results = extractedProfiles
+                            }
+                        }
+                    } catch {
+                        showAlert(for: error)
+                    }
+                }
+            } catch {
+                showAlert(for: error)
+            }
+        }
+    }
+
+    func runOptOut(extractedProfile: ExtractedProfile) {
+        let runner = runnerProvider.getOperationRunner()
+        guard let dataBroker = self.selectedDataBroker else {
+            print("No broker selected")
+            return
+        }
+
+        let brokerProfileQueryData = createBrokerProfileQueryData(for: dataBroker)
+
+        Task {
+            do {
+                try await runner.optOut(profileQuery: brokerProfileQueryData, extractedProfile: extractedProfile, stageCalculator: FakeStageDurationCalculator(), showWebView: true) {
+                    true
+                }
+
+                DispatchQueue.main.async {
+                    self.showAlert = true
+                    self.alert = AlertUI(title: "Success!", description: "We finished the opt out process for the selected profile.")
+                }
+
+            } catch {
+                showAlert(for: error)
+            }
+        }
+    }
+
+    private func createBrokerProfileQueryData(for dataBroker: DataBroker) -> BrokerProfileQueryData {
+        let profile = createProfile()
+        let fakeScanOperationData = ScanOperationData(brokerId: 0, profileQueryId: 0, historyEvents: [HistoryEvent]())
+        return BrokerProfileQueryData(dataBroker: dataBroker, profileQuery: profile.profileQueries.first!, scanOperationData: fakeScanOperationData)
+    }
+
+    private func showNoResultsAlert() {
+        DispatchQueue.main.async {
+            self.showAlert = true
+            self.alert = AlertUI.noResults()
+        }
+    }
+
+    private func showAlert(for error: Error) {
+        DispatchQueue.main.async {
+            self.showAlert = true
+            if let dbpError = error as? DataBrokerProtectionError {
+                self.alert = AlertUI.from(error: dbpError)
+            }
+
+            print("Error when scanning: \(error)")
+        }
+    }
+
+    private func createProfile() -> DataBrokerProtectionProfile {
+        let names = DataBrokerProtectionProfile.Name(firstName: firstName, lastName: lastName, middleName: middle)
+        let addresses = DataBrokerProtectionProfile.Address(city: city, state: state)
+
+        return DataBrokerProtectionProfile(names: [names], addresses: [addresses], phones: [String](), birthYear: Int(birthYear) ?? 1990)
+    }
+
+    func appVersion() -> String {
+        AppVersion.shared.versionNumber
+    }
+
+    func contentScopeScriptsVersion() -> String {
+        // How can I return this?
+        return "4.59.2"
+    }
+}
+
+final class FakeStageDurationCalculator: StageDurationCalculator {
+    func durationSinceLastStage() -> Double {
+        0.0
+    }
+
+    func durationSinceStartTime() -> Double {
+        0.0
+    }
+
+    func fireOptOutStart() {
+    }
+
+    func fireOptOutEmailGenerate() {
+    }
+
+    func fireOptOutCaptchaParse() {
+    }
+
+    func fireOptOutCaptchaSend() {
+    }
+
+    func fireOptOutCaptchaSolve() {
+    }
+
+    func fireOptOutSubmit() {
+    }
+
+    func fireOptOutEmailReceive() {
+    }
+
+    func fireOptOutEmailConfirm() {
+    }
+
+    func fireOptOutValidate() {
+    }
+
+    func fireOptOutSubmitSuccess() {
+    }
+
+    func fireOptOutFailure() {
+    }
+
+    func fireScanSuccess(matchesFound: Int) {
+    }
+
+    func fireScanFailed() {
+    }
+
+    func fireScanError(error: Error) {
+    }
+
+    func setStage(_ stage: Stage) {
+    }
+}
+
+/*
+ I wasn't able to import this mock from the background agent project, so I had to re-use it here.
+ */
+fileprivate final class PrivacyConfigurationManagingMock: PrivacyConfigurationManaging {
+
+    var data: Data {
+        let configString = """
+    {
+            "readme": "https://github.com/duckduckgo/privacy-configuration",
+            "version": 1693838894358,
+            "features": {
+                "brokerProtection": {
+                    "state": "enabled",
+                    "exceptions": [],
+                    "settings": {}
+                }
+            },
+            "unprotectedTemporary": []
+        }
+    """
+        let data = configString.data(using: .utf8)
+        return data!
+    }
+
+    var currentConfig: Data {
+        data
+    }
+
+    var updatesPublisher: AnyPublisher<Void, Never> = .init(Just(()))
+
+    var privacyConfig: BrowserServicesKit.PrivacyConfiguration {
+        guard let privacyConfigurationData = try? PrivacyConfigurationData(data: data) else {
+            fatalError("Could not retrieve privacy configuration data")
+        }
+        let privacyConfig = privacyConfiguration(withData: privacyConfigurationData, internalUserDecider: internalUserDecider)
+        return privacyConfig
+    }
+
+    var internalUserDecider: InternalUserDecider = DefaultInternalUserDecider(store: InternalUserDeciderStoreMock())
+
+    func reload(etag: String?, data: Data?) -> PrivacyConfigurationManager.ReloadResult {
+        .downloaded
+    }
+}
+
+func privacyConfiguration(withData data: PrivacyConfigurationData, internalUserDecider: InternalUserDecider) -> PrivacyConfiguration {
+    let domain = MockDomainsProtectionStore()
+    return AppPrivacyConfiguration(data: data,
+                                   identifier: UUID().uuidString,
+                                   localProtection: domain,
+                                   internalUserDecider: internalUserDecider)
+}
+
+final class MockDomainsProtectionStore: DomainsProtectionStore {
+    var unprotectedDomains = Set<String>()
+
+    func disableProtection(forDomain domain: String) {
+        unprotectedDomains.insert(domain)
+    }
+
+    func enableProtection(forDomain domain: String) {
+        unprotectedDomains.remove(domain)
+    }
+}
+
+final class InternalUserDeciderStoreMock: InternalUserStoring {
+    var isInternalUser: Bool = false
+}
+
+extension DataBroker {
+    func toJSONString() -> String {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted // Optional: for pretty-printed JSON
+            let jsonData = try encoder.encode(self)
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                return jsonString
+            }
+
+            return ""
+        } catch {
+            print("Error encoding object to JSON: \(error)")
+            return ""
+        }
+
+    }
+}
+
+extension DataBrokerProtectionError {
+    var title: String {
+        switch self {
+        case .httpError(let code):
+            if code == 404 {
+                return "No results."
+            } else {
+                return "Error."
+            }
+        default: return "Error"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .httpError(let code):
+            if code == 404 {
+                return "No results were found."
+            } else {
+                return "Failed with HTTP error code: \(code)"
+            }
+        default: return name
+        }
+    }
+}

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperation.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperation.swift
@@ -34,7 +34,7 @@ protocol DataBrokerOperation: CCFCommunicationDelegate {
 
     var webViewHandler: WebViewHandler? { get set }
     var actionsHandler: ActionsHandler? { get }
-    var stageCalculator: DataBrokerProtectionStageDurationCalculator? { get }
+    var stageCalculator: StageDurationCalculator? { get }
     var continuation: CheckedContinuation<ReturnValue, Error>? { get set }
     var extractedProfile: ExtractedProfile? { get set }
     var shouldRunNextStep: () -> Bool { get }
@@ -43,7 +43,7 @@ protocol DataBrokerOperation: CCFCommunicationDelegate {
     func run(inputValue: InputValue,
              webViewHandler: WebViewHandler?,
              actionsHandler: ActionsHandler?,
-             stageCalculator: DataBrokerProtectionStageDurationCalculator,
+             stageCalculator: StageDurationCalculator,
              showWebView: Bool) async throws -> ReturnValue
 
     func executeNextStep() async
@@ -54,7 +54,7 @@ extension DataBrokerOperation {
     func run(inputValue: InputValue,
              webViewHandler: WebViewHandler?,
              actionsHandler: ActionsHandler?,
-             stageCalculator: DataBrokerProtectionStageDurationCalculator,
+             stageCalculator: StageDurationCalculator,
              shouldRunNextStep: @escaping () -> Bool) async throws -> ReturnValue {
 
         try await run(inputValue: inputValue,

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationRunner.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationRunner.swift
@@ -23,13 +23,13 @@ import Common
 protocol WebOperationRunner {
 
     func scan(_ profileQuery: BrokerProfileQueryData,
-              stageCalculator: DataBrokerProtectionStageDurationCalculator,
+              stageCalculator: StageDurationCalculator,
               showWebView: Bool,
               shouldRunNextStep: @escaping () -> Bool) async throws -> [ExtractedProfile]
 
     func optOut(profileQuery: BrokerProfileQueryData,
                 extractedProfile: ExtractedProfile,
-                stageCalculator: DataBrokerProtectionStageDurationCalculator,
+                stageCalculator: StageDurationCalculator,
                 showWebView: Bool,
                 shouldRunNextStep: @escaping () -> Bool) async throws
 }
@@ -37,7 +37,7 @@ protocol WebOperationRunner {
 extension WebOperationRunner {
 
     func scan(_ profileQuery: BrokerProfileQueryData,
-              stageCalculator: DataBrokerProtectionStageDurationCalculator,
+              stageCalculator: StageDurationCalculator,
               shouldRunNextStep: @escaping () -> Bool) async throws -> [ExtractedProfile] {
 
         try await scan(profileQuery,
@@ -48,7 +48,7 @@ extension WebOperationRunner {
 
     func optOut(profileQuery: BrokerProfileQueryData,
                 extractedProfile: ExtractedProfile,
-                stageCalculator: DataBrokerProtectionStageDurationCalculator,
+                stageCalculator: StageDurationCalculator,
                 shouldRunNextStep: @escaping () -> Bool) async throws {
 
         try await optOut(profileQuery: profileQuery,
@@ -77,7 +77,7 @@ final class DataBrokerOperationRunner: WebOperationRunner {
     }
 
     func scan(_ profileQuery: BrokerProfileQueryData,
-              stageCalculator: DataBrokerProtectionStageDurationCalculator,
+              stageCalculator: StageDurationCalculator,
               showWebView: Bool,
               shouldRunNextStep: @escaping () -> Bool) async throws -> [ExtractedProfile] {
         let scan = ScanOperation(
@@ -93,7 +93,7 @@ final class DataBrokerOperationRunner: WebOperationRunner {
 
     func optOut(profileQuery: BrokerProfileQueryData,
                 extractedProfile: ExtractedProfile,
-                stageCalculator: DataBrokerProtectionStageDurationCalculator,
+                stageCalculator: StageDurationCalculator,
                 showWebView: Bool,
                 shouldRunNextStep: @escaping () -> Bool) async throws {
         let optOut = OptOutOperation(

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OptOutOperation.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OptOutOperation.swift
@@ -35,7 +35,7 @@ final class OptOutOperation: DataBrokerOperation {
     var actionsHandler: ActionsHandler?
     var continuation: CheckedContinuation<Void, Error>?
     var extractedProfile: ExtractedProfile?
-    var stageCalculator: DataBrokerProtectionStageDurationCalculator?
+    var stageCalculator: StageDurationCalculator?
     private let operationAwaitTime: TimeInterval
     let shouldRunNextStep: () -> Bool
 
@@ -66,7 +66,7 @@ final class OptOutOperation: DataBrokerOperation {
     func run(inputValue: ExtractedProfile,
              webViewHandler: WebViewHandler? = nil,
              actionsHandler: ActionsHandler? = nil,
-             stageCalculator: DataBrokerProtectionStageDurationCalculator,
+             stageCalculator: StageDurationCalculator,
              showWebView: Bool = false) async throws {
         try await withCheckedThrowingContinuation { continuation in
             self.extractedProfile = inputValue.merge(with: query.profileQuery)

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/ScanOperation.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/ScanOperation.swift
@@ -35,7 +35,7 @@ final class ScanOperation: DataBrokerOperation {
     var actionsHandler: ActionsHandler?
     var continuation: CheckedContinuation<[ExtractedProfile], Error>?
     var extractedProfile: ExtractedProfile?
-    var stageCalculator: DataBrokerProtectionStageDurationCalculator?
+    var stageCalculator: StageDurationCalculator?
     private let operationAwaitTime: TimeInterval
     let shouldRunNextStep: () -> Bool
     var retriesCountOnError: Int = 0
@@ -60,7 +60,7 @@ final class ScanOperation: DataBrokerOperation {
     func run(inputValue: Void,
              webViewHandler: WebViewHandler? = nil,
              actionsHandler: ActionsHandler? = nil,
-             stageCalculator: DataBrokerProtectionStageDurationCalculator, // We do not need it for scans - for now.
+             stageCalculator: StageDurationCalculator, // We do not need it for scans - for now.
              showWebView: Bool) async throws -> [ExtractedProfile] {
         try await withCheckedThrowingContinuation { continuation in
             self.stageCalculator = stageCalculator

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionPixels.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionPixels.swift
@@ -39,21 +39,40 @@ enum ErrorCategory: Equatable {
     }
 }
 
-final class DataBrokerProtectionStageDurationCalculator {
+enum Stage: String {
+    case start
+    case emailGenerate = "email-generate"
+    case captchaParse = "captcha-parse"
+    case captchaSend = "captcha-send"
+    case captchaSolve = "captcha-solve"
+    case submit
+    case emailReceive = "email-receive"
+    case emailConfirm = "email-confirm"
+    case validate
+    case other
+}
 
-    enum Stage: String {
-        case start
-        case emailGenerate = "email-generate"
-        case captchaParse = "captcha-parse"
-        case captchaSend = "captcha-send"
-        case captchaSolve = "captcha-solve"
-        case submit
-        case emailReceive = "email-receive"
-        case emailConfirm = "email-confirm"
-        case validate
-        case other
-    }
+protocol StageDurationCalculator {
+    func durationSinceLastStage() -> Double
+    func durationSinceStartTime() -> Double
+    func fireOptOutStart()
+    func fireOptOutEmailGenerate()
+    func fireOptOutCaptchaParse()
+    func fireOptOutCaptchaSend()
+    func fireOptOutCaptchaSolve()
+    func fireOptOutSubmit()
+    func fireOptOutEmailReceive()
+    func fireOptOutEmailConfirm()
+    func fireOptOutValidate()
+    func fireOptOutSubmitSuccess()
+    func fireOptOutFailure()
+    func fireScanSuccess(matchesFound: Int)
+    func fireScanFailed()
+    func fireScanError(error: Error)
+    func setStage(_ stage: Stage)
+}
 
+final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator {
     let handler: EventMapping<DataBrokerProtectionPixels>
     let attemptId: UUID
     let dataBroker: String

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProfileQueryOperationManagerTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProfileQueryOperationManagerTests.swift
@@ -795,7 +795,7 @@ final class MockWebOperationRunner: WebOperationRunner {
     var wasScanCalled = false
     var wasOptOutCalled = false
 
-    func scan(_ profileQuery: BrokerProfileQueryData, stageCalculator: DataBrokerProtectionStageDurationCalculator, showWebView: Bool, shouldRunNextStep: @escaping () -> Bool) async throws -> [ExtractedProfile] {
+    func scan(_ profileQuery: BrokerProfileQueryData, stageCalculator: StageDurationCalculator, showWebView: Bool, shouldRunNextStep: @escaping () -> Bool) async throws -> [ExtractedProfile] {
         wasScanCalled = true
 
         if shouldScanThrow {
@@ -805,7 +805,7 @@ final class MockWebOperationRunner: WebOperationRunner {
         }
     }
 
-    func optOut(profileQuery: BrokerProfileQueryData, extractedProfile: ExtractedProfile, stageCalculator: DataBrokerProtectionStageDurationCalculator, showWebView: Bool, shouldRunNextStep: @escaping () -> Bool) async throws {
+    func optOut(profileQuery: BrokerProfileQueryData, extractedProfile: ExtractedProfile, stageCalculator: StageDurationCalculator, showWebView: Bool, shouldRunNextStep: @escaping () -> Bool) async throws {
         wasOptOutCalled = true
 
         if shouldOptOutThrow {


### PR DESCRIPTION
## Task
https://app.asana.com/0/42792087274227/1206546637547291/f

## Description
**Background**
On DBP/PIR, we currently have a debug menu that allows developers or testers to run all the scans, opt-outs, or queued operations.

We do not have the option to run a particular scan on a broker, a particular selected opt-out, or a JSON test file for a non-existing broker that we would like to test.

**Objective**
The objective is to add an option to the PIR debug menu that will allow us run operations on particular brokers and also add custom broker JSON files for us to test.

## Steps to test

1. Go to Debug -> Personal Information Removal -> Run Personal Information Removal Debug Mode
2. Test that scans, opt-outs and errors are correct, also, try to add custom JSON strings to test. 
