### PR TITLE
Cropped tab previews fixed

### DIFF
--- a/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
+++ b/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
@@ -127,14 +127,11 @@ final class TabPreviewWindowController: NSWindowController {
         }
         var topLeftPoint = topLeftPoint
 
-        let defaultFrame = NSRect(x: 0, y: 0, width: 250, height: 58)
-        window.setFrame(defaultFrame, display: true)
-
         // Make sure preview is presented within screen
         if let screenVisibleFrame = window.screen?.visibleFrame {
             topLeftPoint.x = min(topLeftPoint.x, screenVisibleFrame.width - window.frame.width)
 
-            let windowHeight = defaultFrame.size.height + tabPreviewViewController.snapshotImageViewHeightConstraint.constant
+            let windowHeight = window.frame.size.height
             if topLeftPoint.y <= windowHeight + screenVisibleFrame.origin.y {
                 topLeftPoint.y = topLeftPoint.y + windowHeight + Self.bottomPadding
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206569585467178/f
CC: @mallexxx 

**Description**:
This PR fixes an issue with tab previews being presented outside of the screen bounds.

**Steps to test this PR**:
1. Open many tabs with a regular website (for example [Wikipegia](https://www.wikipedia.org))
3. Position the window in a way that tabs are located in the top right corner.
<img width="374" alt="Screenshot 2024-02-12 at 10 40 53 AM" src="https://github.com/duckduckgo/macos-browser/assets/57389842/bf8eb97e-9a5c-484e-858c-79701a9327fe">


4. Hover mouse cursor over the tab to show preview and make sure it is fully placed within the screen
5. Repeat the test while having tabs located very close to the bottom of the screen
6. Repeat the test while having standard position of the window (covers most of the screen)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
