### PR TITLE
After Burning, Only Launch a New Window if the App is Active

### DIFF
--- a/DuckDuckGo/Fire/Model/Fire.swift
+++ b/DuckDuckGo/Fire/Model/Fire.swift
@@ -181,7 +181,7 @@ final class Fire {
     }
 
     @MainActor
-    func burnAll(completion:(() -> Void)? = nil) {
+    func burnAll(completion: (() -> Void)? = nil) {
         os_log("Fire started", log: .fire)
 
         let group = DispatchGroup()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205135252111373/f
Tech Design URL:
CC: @ayoy 

**Description**:
From app feedback:

>  When I clear my history and switch to another app, I don't expect the browser to suddenly retake focus because of its clearing history animation.

This PR addresses this feedback by only launching a new window after burning **iff** the app is active.

**Steps to test this PR**:
1. Launch browser
2. Burn all
3. Keep browser app active by not making another app the focus
4. Observe that after burn animation a new browser window is launched
5. Burn all again
3. Make browser app inactive by making another app the focus
4. Observe that after burn animation a new browser window is not launched

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
