### PR TITLE
Positioning of the preview fixed for external display

### DIFF
--- a/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
+++ b/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
@@ -129,7 +129,8 @@ final class TabPreviewWindowController: NSWindowController {
 
         // Make sure preview is presented within screen
         if let screenVisibleFrame = window.screen?.visibleFrame {
-            topLeftPoint.x = min(topLeftPoint.x, screenVisibleFrame.width - window.frame.width)
+            topLeftPoint.x = min(topLeftPoint.x, screenVisibleFrame.origin.x + screenVisibleFrame.width - window.frame.width)
+            topLeftPoint.x = max(topLeftPoint.x, screenVisibleFrame.origin.x)
 
             let windowHeight = window.frame.size.height
             if topLeftPoint.y <= windowHeight + screenVisibleFrame.origin.y {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206591283698064/f

**Description**:
This PR fixes an issue with previews being at the wrong position on external display when the main MacBook display is set as main
<img width="1064" alt="Screenshot 2024-02-13 at 2 14 47 PM" src="https://github.com/duckduckgo/macos-browser/assets/57389842/bbce1940-7040-4380-bb8d-f9432a1e93cd">

**Steps to test this PR**:
1. Use external display together with the internal MacBook display
2. Set the internal display as main
3. Open a new window with bunch of tabs and move it into your external display
4. Make sure previews are positioned correctly -> right below the tab (or above in case the tab bar is too low)
5. Move the tab bar around in both displays to validate positioning of previews works in all cases
6. Change the external display to main and repeat the test

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
