### PR TITLE
Set Pinned Tab Selected Color to Match Nav Bar Color

### DIFF
--- a/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -71,7 +71,7 @@ struct PinnedTabView: View {
 
     private var foregroundColor: Color {
         if isSelected {
-            return Color("InterfaceBackgroundColor")
+            return Color.navigationBarBackground
         }
         let isHovered = collectionModel.hoveredItem == model
         return showsHover && isHovered ? Color("TabMouseOverColor") : Color.clear
@@ -129,7 +129,7 @@ private struct BorderView: View {
     }
 
     private var bottomLineColor: Color {
-        isSelected ? Color("InterfaceBackgroundColor") : Color(TabShadowConfig.colorName)
+        isSelected ? Color.navigationBarBackground : Color(TabShadowConfig.colorName)
     }
 
     private var cornerPixelsColor: Color {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206594203279024/f

**Description**:
The `PinnedTabView` active/selected color did not match the navigation bar color when the system was using the ‘light mode’ appearance. See screenshots below:

**Before Fix**
![Screenshot 2024-02-15 at 09 42 04](https://github.com/duckduckgo/macos-browser/assets/5278441/328c2fa0-8154-43cc-92ae-d917bd85fafb)

**After Fix**
![Screenshot 2024-02-15 at 09 43 12](https://github.com/duckduckgo/macos-browser/assets/5278441/4aa6eb1f-ea50-464b-9f51-37e3f2f289d9)

_Note: You can use the Mac Digital Color Meter tool to check the RGB values of UI elements_

**Steps to test this PR**:
1. Launch Browser
2. Pin a tab
3. Ensure Mac appearance mode is ‘light mode'
4. Observe that the tab and navigation bar have the same color (should be RGB 250, 250, 250) 
—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
