### PR TITLE
DBP: Delete profile data and broker data

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
@@ -320,7 +320,8 @@ final class DefaultDataBrokerProtectionDatabaseProvider: GRDBSecureStorageDataba
     }
 
     func deleteProfileData() throws {
-        try db.write { db in
+        try db.writeWithoutTransaction { db in
+            try db.execute(sql: "PRAGMA foreign_keys = OFF;")
             try OptOutDB
                 .deleteAll(db)
             try ScanDB
@@ -331,6 +332,11 @@ final class DefaultDataBrokerProtectionDatabaseProvider: GRDBSecureStorageDataba
                 .deleteAll(db)
             try PhoneDB
                 .deleteAll(db)
+            try ProfileDB
+                .deleteAll(db)
+            try BrokerDB
+                .deleteAll(db)
+            try db.execute(sql: "PRAGMA foreign_keys = ON;")
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1206612938463389/f

**Description**:
The `age` wasn’t correctly deleted after turning off Personal Information Removal.

The problem was with a foreign key constraint in the `ProfileDB`. I tried different things, for example, adding the `ON DELETE CASCADE` in the `profileId` foreign keys in the Name, Address, and Phone tables. That solution didn’t work.

My final solution is to turn off the foreign keys by using the `PRAGMA foreign_keys = OFF;` SQL code. One thing that is important is that `db.write {}` write things in a transaction, so I had to use the `writeWithoutTransaction` because turning off the constraints was not being executed.

I also added deleting the broker's table information, the problem was that after deleting everything and when creating a new profile, we tried to add new brokers without checking if they existed beforehand, so it failed when creating the new profile.


**Steps to test this PR**:
1. Create a profile and start PIR
2. Turn off the profile (data should be deleted, and `age` should not be present)
3. Create a new profile and start PIR
4. Data should be scanned for this new profile
