### PR TITLE
Remove unnecessary pixel

### DIFF
--- a/DuckDuckGo/PasswordManager/Bitwarden/Model/BWManager.swift
+++ b/DuckDuckGo/PasswordManager/Bitwarden/Model/BWManager.swift
@@ -232,7 +232,6 @@ final class BWManager: BWManagement, ObservableObject {
         switch error {
         case "cannot-decrypt":
             logOrAssertionFailure("BWManagement: Bitwarden error - cannot decrypt")
-            Pixel.fire(.debug(event: .bitwardenRespondedCannotDecrypt))
 
             if Pixel.Event.Repetition(key: "bitwardenRespondedCannotDecryptUnique", update: false) != .repetitive {
                 Pixel.fire(.debug(event: .bitwardenRespondedCannotDecryptUnique()))

--- a/DuckDuckGo/Statistics/PixelEvent.swift
+++ b/DuckDuckGo/Statistics/PixelEvent.swift
@@ -288,7 +288,6 @@ extension Pixel {
             case removedInvalidBookmarkManagedObjects
 
             case bitwardenNotResponding
-            case bitwardenRespondedCannotDecrypt
             case bitwardenRespondedCannotDecryptUnique(repetition: Repetition = .init(key: "bitwardenRespondedCannotDecryptUnique"))
             case bitwardenHandshakeFailed
             case bitwardenDecryptionOfSharedKeyFailed
@@ -734,8 +733,6 @@ extension Pixel.Event.Debug {
 
         case .bitwardenNotResponding:
             return "bitwarden_not_responding"
-        case .bitwardenRespondedCannotDecrypt:
-            return "bitwarden_responded_cannot_decrypt"
         case .bitwardenRespondedCannotDecryptUnique:
             return "bitwarden_responded_cannot_decrypt_unique"
         case .bitwardenHandshakeFailed:

--- a/DuckDuckGo/Statistics/PixelParameters.swift
+++ b/DuckDuckGo/Statistics/PixelParameters.swift
@@ -224,7 +224,6 @@ extension Pixel.Event.Debug {
                 .webKitDidTerminate,
                 .removedInvalidBookmarkManagedObjects,
                 .bitwardenNotResponding,
-                .bitwardenRespondedCannotDecrypt,
                 .bitwardenRespondedCannotDecryptUnique,
                 .bitwardenHandshakeFailed,
                 .bitwardenDecryptionOfSharedKeyFailed,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206612719423754/f

**Description**:
Remove unnecessary pixel for bitwarden 

**Steps to test this PR**:
1. Validate that we're not sending mac_debug_bitwarden_responded_cannot_decrypt  anymore
2. Validate that bitwarden_responded_cannot_decrypt_unique is still being sent

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
