### PR TITLE
Fix sync crypto error handling to protect against DoS

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13537,8 +13537,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "tespach/sync/crypto-error-handling";
-				kind = branch;
+				kind = exactVersion;
+				version = 111.0.2;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "tespach/sync/crypto-error-handling",
-        "revision" : "7e4573f05d187e072cadef30073268d8c9ac3fb2"
+        "revision" : "04c35220aa94bd005171086acccadd677400e7d5",
+        "version" : "111.0.2"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper")

--- a/LocalPackages/LoginItems/Package.swift
+++ b/LocalPackages/LoginItems/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../LoginItems")

--- a/LocalPackages/PixelKit/Package.swift
+++ b/LocalPackages/PixelKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [

--- a/LocalPackages/SwiftUIExtensions/Package.swift
+++ b/LocalPackages/SwiftUIExtensions/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "PreferencesViews", targets: ["PreferencesViews"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../SwiftUIExtensions"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SystemExtensionManager/Package.swift
+++ b/LocalPackages/SystemExtensionManager/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/XPCHelper/Package.swift
+++ b/LocalPackages/XPCHelper/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "XPCHelper", targets: ["XPCHelper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "111.0.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206634174761721/f
Tech Design URL:
CC:

**Description**:
During a security audit, it was discovered that a lack of error handling in the ddgSyncCrypto
library can cause unexpected crashes leading to remote DoS on iOS and macOS. This is a rare
occurrence and requires some work to test, but the crux is: an unexpected exception due to
invalid cipher text lengths returned by the Sync API.

**Steps to test this PR**:
1.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
