### PR TITLE
Hiding tab preview in case the window is minimized or going full screen

### DIFF
--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -209,6 +209,14 @@ final class MainViewController: NSViewController {
         tabBarViewController.hideTabPreview()
     }
 
+    func windowWillMiniaturize() {
+        tabBarViewController.hideTabPreview()
+    }
+
+    func windowWillEnterFullScreen() {
+        tabBarViewController.hideTabPreview()
+    }
+
     func toggleBookmarksBarVisibility() {
         updateBookmarksBarViewVisibility(visible: !(mainView.bookmarksBarHeightConstraint.constant > 0))
     }

--- a/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -203,6 +203,11 @@ extension MainWindowController: NSWindowDelegate {
 
     func windowWillEnterFullScreen(_ notification: Notification) {
         mainViewController.tabBarViewController.draggingSpace.isHidden = true
+        mainViewController.windowWillEnterFullScreen()
+    }
+
+    func windowWillMiniaturize(_ notification: Notification) {
+        mainViewController.windowWillMiniaturize()
     }
 
     func windowDidEnterFullScreen(_ notification: Notification) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206635109534553/f

**Description**:
This PR fixes a bug with tab preview positioning when a window is maximized.

**Steps to test this PR**:
1. Hover your mouse over the first tab, wait for the tab preview to appear, and then minimize the window using the yellow circle 
1. Observe the tab preview being hidden.
1. After maximizing the window, ensure no tab preview is presented.
1. Hover over the first tab again to show the preview.
1. Using the green circle button, enter full screen.
1. Confirm that the tab preview is hidden.


<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
