### PR TITLE
DBP: Add initial loading indicator when loading web UI

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/DataBrokerProtectionViewController.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/DataBrokerProtectionViewController.swift
@@ -33,10 +33,6 @@ final public class DataBrokerProtectionViewController: NSViewController {
     private let openURLHandler: (URL?) -> Void
     private var reloadObserver: NSObjectProtocol?
 
-    private enum Consts {
-        static let loaderDimension: CGFloat = 50.0
-    }
-
     public init(scheduler: DataBrokerProtectionScheduler,
                 dataManager: DataBrokerProtectionDataManaging,
                 privacyConfig: PrivacyConfigurationManaging? = nil,
@@ -100,13 +96,12 @@ final public class DataBrokerProtectionViewController: NSViewController {
         loader.controlSize = .regular
         loader.sizeToFit()
         loader.translatesAutoresizingMaskIntoConstraints = false
+        loader.controlSize = .large
         view.addSubview(loader)
 
         NSLayoutConstraint.activate([
             loader.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             loader.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            loader.widthAnchor.constraint(equalToConstant: Consts.loaderDimension),
-            loader.heightAnchor.constraint(equalToConstant: Consts.loaderDimension)
         ])
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206570989671741/f

**Description**:
Adds loading indicator when loading the web UI

https://github.com/duckduckgo/macos-browser/assets/7924732/b4b90687-8f26-4f8f-ae59-85eee8d82b0e

**Steps to test this PR**:
1. Open the browser, bypass the waitlist and open PIR
2. You should see an activity indicator in the middle of the screen while the page is being loaded
