### PR TITLE
Fix refreshing of subscription preference pane when switching between panes

### DIFF
--- a/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionModel.swift
+++ b/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionModel.swift
@@ -173,14 +173,18 @@ public final class PreferencesSubscriptionModel: ObservableObject {
     func fetchAndUpdateSubscriptionDetails() {
         guard fetchSubscriptionDetailsTask == nil else { return }
 
-        fetchSubscriptionDetailsTask = Task {
-            guard let token = accountManager.accessToken else { return }
+        fetchSubscriptionDetailsTask = Task { [weak self] in
+            defer {
+                self?.fetchSubscriptionDetailsTask = nil
+            }
+
+            guard let token = self?.accountManager.accessToken else { return }
 
             if let cachedDate = SubscriptionService.cachedSubscriptionDetailsResponse?.expiresOrRenewsAt {
-                updateDescription(for: cachedDate)
+                self?.updateDescription(for: cachedDate)
 
-                if cachedDate.timeIntervalSinceNow > 0 {
-                    self.cachedEntitlements = []
+                if cachedDate.timeIntervalSinceNow < 0 {
+                    self?.cachedEntitlements = []
                 }
             }
 
@@ -190,13 +194,13 @@ public final class PreferencesSubscriptionModel: ObservableObject {
                     return
                 }
 
-                updateDescription(for: response.expiresOrRenewsAt)
+                self?.updateDescription(for: response.expiresOrRenewsAt)
 
-                subscriptionPlatform = response.platform
+                self?.subscriptionPlatform = response.platform
             }
 
             if case let .success(entitlements) = await AccountManager().fetchEntitlements() {
-                self.cachedEntitlements = entitlements
+                self?.cachedEntitlements = entitlements
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206654425458681/f
Tech Design URL:
CC:

**Description**:
Fix refreshing of subscription preference pane when switching between panes. 
Also the task var was not nilled so it was only fired once per viewModel instance.
Additionally the check for the expiry date of subscription was wrong and it preemptively cleared cached entitlements resulting in blinking and refresh for every settings pane switch.

**Steps to test this PR**:
Please enable "Subscription" logging in the app to see the requests being fired and make a subscription purchase.
1. Open settings
2. Select "Privacy Pro" pane
3. Ensure that the 2 requests for subscription details and entitlements are fired.
4. Select other settings pane
5. Repeat steps 2. and 3. and ensure that the label with subscription renewal date and 3 feature cells do not blink (by being cleared and repopulated or enabled/disabled for the cells).


<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
