### PR TITLE
Fix on demand so that it's not enabled too soon

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -70,6 +70,10 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
     private let networkExtensionBundleID: String
     private let networkExtensionController: NetworkExtensionController
 
+    // MARK: - Notification Center
+
+    private let notificationCenter: NotificationCenter
+
     /// The proxy manager
     ///
     /// We're keeping a reference to this because we don't want to be calling `loadAllFromPreferences` more than
@@ -146,13 +150,41 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
         self.logger = logger
         self.networkExtensionBundleID = networkExtensionBundleID
         self.networkExtensionController = networkExtensionController
+        self.notificationCenter = notificationCenter
         self.settings = settings
         self.tokenStore = tokenStore
 
         subscribeToSettingsChanges()
+        subscribeToStatusChanges()
     }
 
-    // MARK: - Tunnel Settings
+    // MARK: - Observing Status Changes
+
+    private func subscribeToStatusChanges() {
+        notificationCenter.publisher(for: .NEVPNStatusDidChange)
+            .sink(receiveValue: handleStatusChange(_:))
+            .store(in: &cancellables)
+    }
+
+    private func handleStatusChange(_ notification: Notification) {
+        guard let session = (notification.object as? NETunnelProviderSession),
+            let manager = session.manager as? NETunnelProviderManager else {
+
+            return
+        }
+
+        Task { @MainActor in
+            switch session.status {
+            case .connected:
+                try await enableOnDemand(tunnelManager: manager)
+            default:
+                break
+            }
+
+        }
+    }
+
+    // MARK: - Subscriptions
 
     private func subscribeToSettingsChanges() {
         settings.changePublisher
@@ -170,6 +202,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             }
             .store(in: &cancellables)
     }
+
+    // MARK: - Handling Settings Changes
 
     /// This is where the tunnel owner has a chance to handle the settings change locally.
     ///
@@ -483,8 +517,6 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
                 guard let self, error == nil, fired else { return }
                 self.settings.vpnFirstEnabled = PixelKit.pixelLastFireDate(event: NetworkProtectionPixelEvent.networkProtectionNewUser)
             }
-
-        try await enableOnDemand(tunnelManager: tunnelManager)
     }
 
     /// Stops the VPN connection used for Network Protection


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1206543593200557/f

## Description:

Enables on-demand only after the VPN has connected.

## Testing

1. Check out BSK 109.0.0
2. Add it locally to this branch
3. We want to fake a connection issue that makes the connection take longer to establish, and eventually fails.  To do so, replace [these lines](https://github.com/duckduckgo/BrowserServicesKit/blob/5ecf4fe56f334be6eaecb65f6d55632a6d53921c/Sources/NetworkProtection/PacketTunnelProvider.swift#L527-L530) with the following code:

```swift
Task {
    try? await Task.sleep(nanoseconds: 3 * NSEC_PER_SEC)
    completionHandler(NSError(domain: "asd", code: 1))
}
```

5. Run the app and try to connect the VPN.
6. Make sure it fails after ~3 seconds, and that on-demand isn't turned ON for the connection.

If you want to see the issue that was resolved by these changes, add-back [this line that was removed](https://github.com/duckduckgo/macos-browser/pull/2235/files#diff-40a2e611130ab26264d24bf086f16604a1863f3d93b52329a7d8b48f8b2dc183L447) and repeat this test.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
