### PR TITLE
Always call Create DMG Variants from main branch

### DIFF
--- a/.github/workflows/create_variants.yml
+++ b/.github/workflows/create_variants.yml
@@ -83,7 +83,6 @@ jobs:
           echo "atb-variants=${atb_variants}" >> $GITHUB_ENV
           variant_matrix="$(sed 's/,/\",\"/g' <<< "${atb_variants}")"
           echo "matrix={\"variant\": [\"${variant_matrix}\"]}" >> $GITHUB_OUTPUT
-          echo "atb-variants=${atb_variants}"
 
   create-atb-variants:
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206746813074878/f

**Description**:
Create DMG Variants pipeline is called by Publish DMG Release after deleting the release branch.
The variants workflow is then unavailable because the branch is gone.
This change fixes it by always calling Create DMG Variants from main branch.

**Steps to test this PR**:
1. See [the failed workflow for the 1.77.0 release](https://github.com/duckduckgo/macos-browser/actions/runs/8136820854/attempts/1) which [used 1.77.0 branch](https://github.com/duckduckgo/macos-browser/actions/runs/8136820854/job/22233968833#step:4:10) and failed on [checking out the action](https://github.com/duckduckgo/macos-browser/actions/runs/8136820854/job/22233968833#step:4:10) inside create_variants.yml
2. See [the fixed workflow](https://github.com/duckduckgo/macos-browser/actions/runs/8137136403/job/22234845512#step:1:35) and verify that it uses create_variants.yml from the main branch

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
