### PR TITLE
DBP: Set correct duration of submit-success pixel

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionStageDurationCalculator.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionStageDurationCalculator.swift
@@ -128,7 +128,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
     }
 
     func fireOptOutSubmitSuccess() {
-        handler.fire(.optOutSubmitSuccess(dataBroker: dataBroker, attemptId: attemptId, duration: durationSinceLastStage()))
+        handler.fire(.optOutSubmitSuccess(dataBroker: dataBroker, attemptId: attemptId, duration: durationSinceStartTime()))
     }
 
     func fireOptOutFailure() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1206726388374341/f
Tech Design URL:
CC:

**Description**:
There was a bug in the `submit-success` pixel. We were firing it from the last stage when it should have been fired from the beginning.

**Steps to test this PR**:
1. Do an opt-out process. Check that the `submit-success` is fired from the beginning.