### PR TITLE
Fix parsing commit log

### DIFF
--- a/scripts/update_asana_for_release.sh
+++ b/scripts/update_asana_for_release.sh
@@ -41,6 +41,7 @@ find_task_urls_in_git_log() {
 		| grep -A 1 'Task.*URL' \
 		| awk '{ print $NF; }' \
 		| grep app\.asana\.com \
+		| sed -E 's/.*(https:.*)/\1/' \
 		| uniq
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206746746471737/f

**Description**:
When there's no space between "Task/Issue URL:" and the URL, use sed to filter out the URL itself.

**Steps to test this PR**:
Run `git log 1.77.0..HEAD | grep -A 1 'Task.*URL' | awk '{ print $NF; }' | grep app\.asana\.com | sed -E 's/.*(https:.*)/\1/'` in the console and verify that all URLs look sane.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
