### PR TITLE
Update network path metadata to derive string manually

### DIFF
--- a/DuckDuckGo/VPNFeedbackForm/VPNMetadataCollector.swift
+++ b/DuckDuckGo/VPNFeedbackForm/VPNMetadataCollector.swift
@@ -200,14 +200,14 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
         let monitor = NWPathMonitor()
         monitor.start(queue: DispatchQueue(label: "VPNMetadataCollector.NWPathMonitor.paths"))
 
-        var path: Network.NWPath?
         let startTime = CFAbsoluteTimeGetCurrent()
 
         while true {
             if !monitor.currentPath.availableInterfaces.isEmpty {
-                path = monitor.currentPath
+                let path = monitor.currentPath
                 monitor.cancel()
-                return .init(currentPath: path.debugDescription)
+
+                return .init(currentPath: path.anonymousDescription)
             }
 
             // Wait up to 3 seconds to fetch the path.
@@ -283,6 +283,27 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
         )
     }
 
+}
+
+extension Network.NWPath {
+    /// A description that's safe from a privacy standpoint.
+    ///
+    /// Ref: https://app.asana.com/0/0/1206712493935053/1206712516729780/f
+    ///
+    var anonymousDescription: String {
+        var description = "NWPath("
+
+        description += "status: \(status), "
+
+        if case .unsatisfied = status {
+            description += "unsatisfiedReason: \(unsatisfiedReason), "
+        }
+
+        description += "availableInterfaces: \(availableInterfaces)"
+        description += ")"
+
+        return description
+    }
 }
 
 #endif


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206714043828475/f

iOS PR:  https://github.com/duckduckgo/iOS/pull/2544

## Description

Update network path metadata to derive string manually

For context about why we're doing this, please see: https://app.asana.com/0/0/1206712493935053/1206712516729780/f

## Testing

Note: I don't know if it's possible to make the path unsatisfied while testing - I couldn't do it

1. Place a breakpoint [here](https://github.com/duckduckgo/macos-browser/blob/28fb9e29e6392b730427d1a8c7c55fb706f9c520/DuckDuckGo/VPNFeedbackForm/VPNMetadataCollector.swift#L305).
2. Go to More Menu > Network Description > Send Feedback type something and submit
3. `po description`

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
