### PR TITLE
DBP: Add is_parent param to opt-out success pixel

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/DataBroker.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/DataBroker.swift
@@ -68,6 +68,11 @@ struct MirrorSite: Codable, Sendable {
     }
 }
 
+public enum DataBrokerHierarchy: Int {
+    case parent = 1
+    case child = 0
+}
+
 struct DataBroker: Codable, Sendable {
     let id: Int64?
     let name: String
@@ -186,5 +191,12 @@ extension DataBroker: Hashable {
 
     static func == (lhs: DataBroker, rhs: DataBroker) -> Bool {
         return lhs.name == rhs.name
+    }
+}
+
+extension DataBroker {
+
+    var type: DataBrokerHierarchy {
+        parent == nil ? .parent : .child
     }
 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProfileQueryOperationManager.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProfileQueryOperationManager.swift
@@ -204,7 +204,7 @@ struct DataBrokerProfileQueryOperationManager: OperationsManager {
                             let calculateDurationSinceLastStage = now.timeIntervalSince(attempt.lastStageDate) * 1000
                             let calculateDurationSinceStart = now.timeIntervalSince(attempt.startDate) * 1000
                             pixelHandler.fire(.optOutFinish(dataBroker: attempt.dataBroker, attemptId: attemptUUID, duration: calculateDurationSinceLastStage))
-                            pixelHandler.fire(.optOutSuccess(dataBroker: attempt.dataBroker, attemptId: attemptUUID, duration: calculateDurationSinceStart))
+                            pixelHandler.fire(.optOutSuccess(dataBroker: attempt.dataBroker, attemptId: attemptUUID, duration: calculateDurationSinceStart, brokerType: brokerProfileQueryData.dataBroker.type))
                         }
                     }
                 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionPixels.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionPixels.swift
@@ -52,6 +52,7 @@ public enum DataBrokerProtectionPixels {
         static let errorCategoryKey = "error_category"
         static let errorDetailsKey = "error_details"
         static let pattern = "pattern"
+        static let isParent = "is_parent"
     }
 
     case error(error: DataBrokerProtectionError, dataBroker: String)
@@ -71,7 +72,7 @@ public enum DataBrokerProtectionPixels {
 
     // Process Pixels
     case optOutSubmitSuccess(dataBroker: String, attemptId: UUID, duration: Double, emailPattern: String?)
-    case optOutSuccess(dataBroker: String, attemptId: UUID, duration: Double)
+    case optOutSuccess(dataBroker: String, attemptId: UUID, duration: Double, brokerType: DataBrokerHierarchy)
     case optOutFailure(dataBroker: String, attemptId: UUID, duration: Double, stage: String, emailPattern: String?)
 
     // Backgrond Agent events
@@ -232,8 +233,8 @@ extension DataBrokerProtectionPixels: PixelKitEvent {
                 params[Consts.pattern] = pattern
             }
             return params
-        case .optOutSuccess(let dataBroker, let attemptId, let duration):
-            return [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration)]
+        case .optOutSuccess(let dataBroker, let attemptId, let duration, let type):
+            return [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration), Consts.isParent: String(type.rawValue)]
         case .optOutFailure(let dataBroker, let attemptId, let duration, let stage, let pattern):
             var params = [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration), Consts.stageKey: stage]
             if let pattern = pattern {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -655,6 +655,7 @@ final class MockDatabase: DataBrokerProtectionRepository {
     var lastProfileQueryIdOnScanUpdatePreferredRunDate: Int64?
     var brokerProfileQueryDataToReturn = [BrokerProfileQueryData]()
     var profile: DataBrokerProtectionProfile?
+    var attemptInformation: AttemptInformation?
 
     lazy var callsList: [Bool] = [
         wasSaveProfileCalled,
@@ -765,7 +766,7 @@ final class MockDatabase: DataBrokerProtectionRepository {
     }
 
     func fetchAttemptInformation(for extractedProfileId: Int64) -> AttemptInformation? {
-        return nil
+        return attemptInformation
     }
 
     func addAttempt(extractedProfileId: Int64, attemptUUID: UUID, dataBroker: String, lastStageDate: Date, startTime: Date) {
@@ -800,6 +801,7 @@ final class MockDatabase: DataBrokerProtectionRepository {
         lastProfileQueryIdOnScanUpdatePreferredRunDate = nil
         brokerProfileQueryDataToReturn.removeAll()
         profile = nil
+        attemptInformation = nil
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206775282354176/f
Tech Design URL:
CC:

**Description**: 
Add `is_parent` parameter to the `m_mac_dbp_macos_optout_process_success` Pixel. The value should be `1` when the broker is a parent site, and `0` when is a child site.

**Steps to test this PR**:
1. Run the opt-out flow (or try to mock it)
2. Check that when the opt-out is successful, we fire the `m_mac_dbp_macos_optout_process_success` with the `is_parent=1` when the broker is a parent site (Verecor for example) and `is_parent=0` when it’s a child site (Veriforia for example)