### PR TITLE
Fix DBP operations holding stale data reference

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
@@ -143,8 +143,7 @@ final class DataBrokerProtectionProcessor {
             guard let dataBrokerID = queryData.dataBroker.id else { continue }
 
             if !visitedDataBrokerIDs.contains(dataBrokerID) {
-                let matchingQueriesData = brokerProfileQueriesData.filter { $0.dataBroker.id == dataBrokerID }
-                let collection = DataBrokerOperationsCollection(brokerProfileQueriesData: matchingQueriesData,
+                let collection = DataBrokerOperationsCollection(dataBrokerID: dataBrokerID,
                                                                 database: database,
                                                                 operationType: operationType,
                                                                 intervalBetweenOperations: config.intervalBetweenSameBrokerOperations,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1206784794470870/f

**Description**:
Fix DBP operations holding stale data reference

**Steps to test this PR**:
1. Clean database and kill the agent
` rm -rf /Users/USER/Library/Group\ Containers/HKE973VLUW.com.duckduckgo.macos.browser.dbp.debug`
` launchctl list | grep duck | awk '{print $3}' | xargs -n 1 launchctl remove`
2. Run the scan after filling your profile data
3. Check if the UI is updated once the operations are done (Make sure to debug the agent to compare) 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
