### PR TITLE
Avoid waitlist invite code redemption after waitlist end

### DIFF
--- a/DuckDuckGo/Waitlist/Waitlist.swift
+++ b/DuckDuckGo/Waitlist/Waitlist.swift
@@ -210,7 +210,12 @@ struct NetworkProtectionWaitlist: Waitlist {
             if let error {
                 // Check for users who have waitlist state but have no auth token, for example if the redeem call fails.
                 let networkProtectionKeyStore = NetworkProtectionKeychainTokenStore()
-                if let inviteCode = waitlistStorage.getWaitlistInviteCode(), !networkProtectionKeyStore.isFeatureActivated {
+                let configManager = ContentBlocking.shared.privacyConfigurationManager
+                let waitlistBetaActive = configManager.privacyConfig.isSubfeatureEnabled(NetworkProtectionSubfeature.waitlistBetaActive)
+
+                if let inviteCode = waitlistStorage.getWaitlistInviteCode(),
+                   !networkProtectionKeyStore.isFeatureActivated,
+                   waitlistBetaActive {
                     Task { @MainActor in
                         do {
                             try await networkProtectionCodeRedemption.redeem(inviteCode)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206789264380517/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue where the waitlist invite code was being re-redeemed after the waitlist ends.

The fix is to check the privacy config when re-redeeming.

**Steps to test this PR**:
1. Search for the line `quackdev` and change it to `quack` so that you join the prod waitlist
2. Reset your debug build state and join the waitlist, then ask Sam to advance it
3. After you get let in, check that you have an auth token in the keychain
4. Delete the auth token
5. Re-focus the app and wait a second, then check the keychain and you should see the auth token has come back again
6. Now change the `let waitlistBetaActive = configManager...` line in this diff to **always** be false
7. Delete the auth token in the keychain again, and refocus the app
8. Check that no new auth token appears

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
