### PR TITLE
Fix Add Bookmark buttons size

### DIFF
--- a/DuckDuckGo/Bookmarks/View/AddBookmarkFolderPopoverView.swift
+++ b/DuckDuckGo/Bookmarks/View/AddBookmarkFolderPopoverView.swift
@@ -67,6 +67,8 @@ struct AddBookmarkFolderPopoverView: ModalView {
 
 #Preview("Add Folder - Dark") {
     let bkman = LocalBookmarkManager(bookmarkStore: BookmarkStoreMock(bookmarks: []))
+    bkman.loadBookmarks()
+    customAssertionFailure = { _, _, _ in }
 
     return AddBookmarkFolderPopoverView(model: AddBookmarkFolderPopoverViewModel(bookmarkManager: bkman) {
         print("CompletionHandler:", $0?.title ?? "<nil>")

--- a/DuckDuckGo/Bookmarks/View/AddBookmarkPopoverView.swift
+++ b/DuckDuckGo/Bookmarks/View/AddBookmarkPopoverView.swift
@@ -40,7 +40,7 @@ struct AddBookmarkPopoverView: View {
     private var addBookmarkView: some View {
         AddEditBookmarkView(
             title: UserText.Bookmarks.Dialog.Title.addedBookmark,
-            buttonsState: .compressed,
+            buttonsState: .expanded,
             bookmarkName: $model.bookmarkTitle,
             bookmarkURLPath: nil,
             isBookmarkFavorite: $model.isBookmarkFavorite,

--- a/DuckDuckGo/Bookmarks/View/Dialog/AddEditBookmarkFolderView.swift
+++ b/DuckDuckGo/Bookmarks/View/Dialog/AddEditBookmarkFolderView.swift
@@ -63,7 +63,7 @@ struct AddEditBookmarkFolderView: View {
             },
             bottomSection: {
                 BookmarkDialogButtonsView(
-                    viewState: .compressed,
+                    viewState: .init(buttonsState),
                     otherButtonAction: .init(
                         title: cancelActionTitle,
                         keyboardShortCut: .cancelAction,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206762730363882/f

**Description**:
When adding a bookmark from the bookmark receipt the buttons were showing in the wrong size.

**BEFORE**
<img width="1728" alt="Screenshot 2024-03-08 at 2 14 57 pm" src="https://github.com/duckduckgo/macos-browser/assets/1089358/6b5372f4-5ab2-4bba-b20c-c6c5928eec54">

**AFTER**
<img width="1728" alt="Screenshot 2024-03-08 at 8 39 18 pm" src="https://github.com/duckduckgo/macos-browser/assets/1089358/78d6e651-8e2d-421d-9315-68b9a8499c45">


**Steps to test this PR**:
1. Bookmark a web page from the Address Bar
2. Ensure the buttons size reflect the [Figma Mockup](https://www.figma.com/proto/4JLJGCCMiBEkYrZjEreBqb/%F0%9F%93%99-Bookmark-Management?page-id=4134%3A33166&type=design&node-id=4134-33378&viewport=1276%2C552%2C0.25&t=3XI3HjCy8ARIctgW-1&scaling=min-zoom&starting-point-node-id=4134%3A35142)
3. Click on the “Add Folder” icon
4. Ensure the buttons size reflect the [Figma Mockup](https://www.figma.com/proto/4JLJGCCMiBEkYrZjEreBqb/%F0%9F%93%99-Bookmark-Management?page-id=4134%3A33166&type=design&node-id=4134-33378&viewport=1276%2C552%2C0.25&t=3XI3HjCy8ARIctgW-1&scaling=min-zoom&starting-point-node-id=4134%3A35142)

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
