### PR TITLE
Ensure that root bookmark folder comparison works when one folder has…

### DIFF
--- a/DuckDuckGo/Bookmarks/Model/Bookmark.swift
+++ b/DuckDuckGo/Bookmarks/Model/Bookmark.swift
@@ -154,7 +154,7 @@ final class BookmarkFolder: BaseBookmarkEntity {
         return id == folder.id &&
         title == folder.title &&
         isFolder == folder.isFolder &&
-        parentFolderUUID == folder.parentFolderUUID &&
+        isParentFolderEqual(lhs: parentFolderUUID, rhs: folder.parentFolderUUID) &&
         children == folder.children
     }
 
@@ -164,6 +164,18 @@ final class BookmarkFolder: BaseBookmarkEntity {
         hasher.combine(isFolder)
         hasher.combine(parentFolderUUID)
         hasher.combine(children)
+    }
+
+    // In some cases a bookmark folder that is child of the root folder has its `parentFolderUUID` set to `bookmarks_root`. In some other cases is nil. Making sure that comparing a `nil` and a `bookmarks_root` does not return false. Probably would be good idea to remove the optionality of `parentFolderUUID` in the future and set it to `bookmarks_root` when needed.
+    private func isParentFolderEqual(lhs: String?, rhs: String?) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .none):
+            return true
+        case (.some(let lhsValue), .some(let rhsValue)):
+            return lhsValue == rhsValue
+        case (.some(let value), .none), (.none, .some(let value)):
+            return value == "bookmarks_root"
+        }
     }
 
 }

--- a/UnitTests/Bookmarks/Model/BaseBookmarkEntityTests.swift
+++ b/UnitTests/Bookmarks/Model/BaseBookmarkEntityTests.swift
@@ -206,6 +206,30 @@ final class BaseBookmarkEntityTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    func testTwoBookmarkFoldersAddedToRootFolderReturnTrueWhenLeftParentIsBookmarksRootAndRightIsNil() {
+        // GIVEN
+        let lhs = BookmarkFolder(id: "1", title: "A", parentFolderUUID: "bookmarks_root", children: [])
+        let rhs = BookmarkFolder(id: "1", title: "A", parentFolderUUID: nil, children: [])
+
+        // WHEN
+        let result = lhs == rhs
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testTwoBookmarkFoldersAddedToRootFolderReturnTrueWhenLeftParentIsNilAndRightParentIsRootBookmarks() {
+        // GIVEN
+        let lhs = BookmarkFolder(id: "1", title: "A", parentFolderUUID: nil, children: [])
+        let rhs = BookmarkFolder(id: "1", title: "A", parentFolderUUID: "bookmarks_root", children: [])
+
+        // WHEN
+        let result = lhs == rhs
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
     // MARK: - Base Entity
 
     func testDifferentBookmarkEntitiesReturnFalseWhenIsEqualCalled() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206762730363884/f

**Description**:
In some cases `BookmarkFolder`s that are added to the root folder have `parentFolderUUID` equal to `nil` in some cases they have it equal to the root identifier `bookmarks_root`. Ensure that equality is satisfied when this happens.

This bug started when we changed hashable/equatable. 

**Steps to test this PR**:
1. Open Manage Bookmark
2. Edit a Bookmark.
3. Click on “Add Folder”.
4. Add a folder in the root Bookmark Folder.
Expected Result: The folder picker should have selected the created folder.

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
