### PR TITLE
Fix of the Fire Button icon 

### DIFF
--- a/DuckDuckGo/Common/View/AppKit/MouseOverAnimationButton.swift
+++ b/DuckDuckGo/Common/View/AppKit/MouseOverAnimationButton.swift
@@ -135,9 +135,10 @@ final class MouseOverAnimationButton: AddressBarButton {
         }
 
         set {
-            if isAnimationViewVisible {
+            if imageCache !== newValue {
                 imageCache = newValue
-            } else {
+            }
+            if !isAnimationViewVisible {
                 super.image = newValue
             }
         }
@@ -146,7 +147,6 @@ final class MouseOverAnimationButton: AddressBarButton {
     var imageCache: NSImage?
 
     private func hideImage() {
-        imageCache = image
         super.image = nil
     }
 

--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -158,6 +158,7 @@ final class TabBarViewController: NSViewController {
     }
 
     private func setupFireButton() {
+        fireButton.image = .burn
         fireButton.toolTip = UserText.clearBrowsingHistoryTooltip
         fireButton.animationNames = MouseOverAnimationButton.AnimationNames(aqua: "flame-mouse-over", dark: "dark-flame-mouse-over")
         fireButton.sendAction(on: .leftMouseDown)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206052997725503/f

**Description**:
This PR fixies the issue with Fire Button icon not being present. We can't reproduce the issue, but my guess is that `imageCache` overwrites `image` with nil value. In order to fix this issue, we have to ensure `imageCache` contains the reference to appropriate image all the time.

**Steps to test this PR**:
1. Verify Fire Button and Privacy Dashboard button (in the address bar) work properly. 
It means:
- They contain a placeholder image (grey shield or grey fire button)
- When the cursor is above, they animate and stay at the last animation frame
- When the cursor leaves, they default back to the placeholder image

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
