### PR TITLE
Disable fetching of favicon.ico for internal sites

### DIFF
--- a/DuckDuckGo/Favicons/Model/FaviconManager.swift
+++ b/DuckDuckGo/Favicons/Model/FaviconManager.swift
@@ -269,7 +269,12 @@ final class FaviconManager: FaviconManagement {
     // MARK: - Private
 
     private nonisolated func createFallbackLinksIfNeeded(_ faviconLinks: [FaviconUserScript.FaviconLink], documentUrl: URL) -> [FaviconUserScript.FaviconLink] {
-        guard faviconLinks.isEmpty, let host = documentUrl.host else { return faviconLinks }
+        let validSchemes: [URL.NavigationalScheme?] = [.http, .https]
+        guard faviconLinks.isEmpty,
+              let host = documentUrl.host,
+              validSchemes.contains(documentUrl.navigationalScheme) else {
+            return faviconLinks
+        }
         return [
             FaviconUserScript.FaviconLink(href: "\(URL.NavigationalScheme.https.separated())\(host)/favicon.ico",
                                           rel: "favicon.ico")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1206794275180512/f
CC:

**Description**:
This PR ensures `favicon.ico` is fetched only for `http` and `https` sites. It resolves the Xcode console error triggered on every navigation to the browser internal site

**Steps to test this PR**:
1. Add breakpoint to `createFallbackLinksIfNeeded` in `FaviconManager`
1. Visit [dsl.sk](dsl.sk)
2. Make sure the method returns `favicon.ico` as favicon link
3. Open Settings or other internal browser page
4. Make sure the method doesn't return `favicon.ico` as favicon link (`return faviconLinks` is called)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
