### PR TITLE
Make notarized build no longer updates DSYMs to Asana.

### DIFF
--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -190,14 +190,6 @@ jobs:
       with:
         task-url: ${{ env.asana-task-url }}
 
-    - name: Upload dSYMs to Asana
-      if: ${{ env.upload-to == 'asana' }}
-      uses: ./.github/actions/asana-upload
-      with:
-        access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-        file-name: ${{ github.workspace }}/release/DuckDuckGo-${{ env.app-version }}-dSYM.zip
-        task-id: ${{ steps.task-id.outputs.task-id }}
-
     - name: Upload dSYMs to S3
       id: upload-dsyms-to-s3
       if: ${{ env.upload-to == 's3' }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206794044219435/f

## Description

As discussed privately with @ayoy , "Make Notarized DMG Build" should no longer upload DSYMs to Asana.

## Testing

Make a notarized build in this branch and ensure the DSYM isn't uploaded to Asana.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
