### PR TITLE
Fix of the crash related to tab previews on macOS Big Sur

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/TabSnapshotExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/TabSnapshotExtension.swift
@@ -67,6 +67,12 @@ final class TabSnapshotExtension {
     }
 
     deinit {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+
+        webView?.interactionEventsDelegate = nil
+        webView = nil
+
         store.clearSnapshot(tabID: identifier)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206764504716341/f

**Description**:
This PR fixes a crash on macOS Big Sur by refactoring TabSnapshotExtension to ensure the instance exists when accessing and modifying instance properties.

**Steps to test this PR**:
_Unfortunately, I haven't found a way to reproduce the issue. It is pretty rare considering amount of users and method calls_

1. Make sure tab previews work as expected:

- Load various websites and see tab previews
- Modify content on tabs and make sure previews are refreshed
- Close tabs and verify there are no memory leaks (TabSnapshotExtension is deallocated too)

3. Optionally, verify the same on macOS 11 Big Sur (except memory leaks since you can't run in Xcode on macOS Big Sur)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
