### PR TITLE
Fix disabled more menu items for waitlist/easter egg users of VPN and PIR.

### DIFF
--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -336,7 +336,7 @@ final class MoreOptionsMenu: NSMenu {
         }
     }
 
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func makeActiveSubscriptionItems() -> [NSMenuItem] {
         var items: [NSMenuItem] = []
 
@@ -361,14 +361,14 @@ final class MoreOptionsMenu: NSMenu {
             if DefaultSubscriptionFeatureAvailability().isFeatureAvailable() && AccountManager().isUserAuthenticated {
                 Task {
                     let isMenuItemEnabled: Bool
-                    
+
                     switch await AccountManager().hasEntitlement(for: .networkProtection) {
                     case let .success(result):
                         isMenuItemEnabled = result
                     case .failure:
                         isMenuItemEnabled = false
                     }
-                    
+
                     networkProtectionItem.isEnabled = isMenuItemEnabled
                 }
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206800986783176/f

**Description**:
Fix disabled more menu items for waitlist/easter egg users of VPN and PIR. Only check user's entitlements when the subscription flow is available and user is authenticated.

**Steps to test this PR**:
1. Ensure the app was not prepared for internal testing of subscription (Debug -> Subscription -> Internal Testing is not enabled)
2. Gain access to VPN or PIR via waitlist or easter egg flow
3. Open more menu
4. The menu items for VPN and PIR should not be disabled.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
