### PR TITLE
Only download tag artifact when tag wasn't provided as input to Publish DMG Release workflow

### DIFF
--- a/.github/workflows/publish_dmg_release.yml
+++ b/.github/workflows/publish_dmg_release.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Download tag artifact
         id: download-tag
+        # Only look for the tag artifact when the tag input is empty
+        if: github.event.inputs.tag == null || github.event.inputs.tag == ''
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206808542771112/f

**Description**:
publish_dmg_release.yml contains a mechanism to download a tag from artifacts.
This is to support publishing internal builds right after building, where a tag gets
created in the same workflow and can't be passed as argument.
When calling the workflow manually to make a public release, tag_release.yml was
called first and uploaded the tag artifact, which would later be retrieved by Publish
Release job and caused overriding the tag passed as argument.

This change fixes it so that the tag artifact is only check when tag has not been provided
in the inputs (which is true for when the worfklow is called by bump_internal_release.yml).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
