### PR TITLE
Fix nightly internal release build

### DIFF
--- a/.github/actions/asana-find-release-task/action.yml
+++ b/.github/actions/asana-find-release-task/action.yml
@@ -31,4 +31,4 @@ runs:
         ASANA_ACCESS_TOKEN: ${{ inputs.access-token }}
         GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
       run: |
-        ${{ github.action_path }}/find-release-task.sh
+        ${{ github.action_path }}/find_release_task.sh

--- a/.github/workflows/bump_internal_release.yml
+++ b/.github/workflows/bump_internal_release.yml
@@ -43,15 +43,25 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
 
+      # When running on schedule there are no inputs, so the workflow has to find the Asana task
+      - name: Find Asana release task
+        id: find-asana-task
+        if: github.event.inputs.asana-task-url == null
+        uses: ./.github/actions/asana-find-release-task
+        with:
+          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+
       # When running on schedule, only proceed if there are changes to the release branch (i.e. HEAD is not tagged)
       - name: Check if there are changes to the release branch
         id: check-for-changes
+        env:
+          release_branch: ${{ steps.find-asana-task.outputs.release-branch || github.ref_name }}
         run: |
           if [[ "${{ github.event_name }}" != "schedule" ]]; then
             echo "skip-release=false" >> $GITHUB_OUTPUT
           else
             latest_tag="$(git describe --tags --abbrev=0)"
-            changed_files="$(git diff --name-only "$latest_tag" | grep -v -E '.github|scripts')"
+            changed_files="$(git diff --name-only "$latest_tag".."origin/${release_branch}" | grep -v -E '.github|scripts')"
 
             if [[ ${#changed_files} == 0 ]]; then
               echo "::warning::No changes to the release branch (or only scripts and workflows). Skipping automatic release."
@@ -60,14 +70,6 @@ jobs:
               echo "skip-release=false" >> $GITHUB_OUTPUT
             fi
           fi
-
-      # When running on schedule there are no inputs, so the workflow has to find the Asana task
-      - name: Find Asana release task
-        id: find-asana-task
-        if: github.event.inputs.asana-task-url == null
-        uses: ./.github/actions/asana-find-release-task
-        with:
-          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
 
       - name: Extract Asana Task ID
         id: task-id


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206811448026218/f

**Description**:
Fix a typo when calling find_release_task.sh by the asana-find-release-task action.
Also fix calculating diff against the latest tag.

**Steps to test this PR**:
There's no easy way to test the workflow that runs on schedule, so just verify that the updated commands work locally and don't report any error:
1. Fetch all tags: `git fetch --tags origin`
2. Find latest tag: `latest_tag="$(gh api /repos/duckduckgo/macos-browser/releases?per_page=1 --jq .[0].tag_name)"`
3. Compute diff between the latest tag and the release branch HEAD: `git diff --name-only "${latest_tag}".."origin/release/${latest_tag%-*}"`


<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
