### PR TITLE
Add the old app group back to NetP

### DIFF
--- a/DuckDuckGoVPN/DuckDuckGoVPN.entitlements
+++ b/DuckDuckGoVPN/DuckDuckGoVPN.entitlements
@@ -16,6 +16,7 @@
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(NETP_APP_GROUP)</string>
+		<string>$(NETP_APP_GROUP)</string>
 		<string>$(SUBSCRIPTION_APP_GROUP)</string>
 	</array>
 </dict>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206825778899560/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue with the access group.

**Steps to test this PR**:

1. Change the `DuckDuckGoVPN` scheme to `Release` for builds
1. Run the `DuckDuckGoVPN` target from Xcode
1. Check that it doesn't fail due to auth token issues

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
