### PR TITLE
Add a placeholder en-US translation to fix Monterey and Big Sur

### DIFF
--- a/LocalPackages/SyncUI/Sources/SyncUI/Resources/Localizable.xcstrings
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Resources/Localizable.xcstrings
@@ -9,6 +9,12 @@
             "value" : "(%@)"
           }
         },
+        "en-US" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%@)"
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206826260134772/f
CC: @SabrinaTardio 

**Description**:
This change adds English (US) to SyncUI's string catalog to fix English language on macOS
Big Sur and Monterey. One string is translated so that the entry for en_US appears in the string catalog,
which makes the OS recognize that English language translation is present in the SyncUI bundle.
Other (non-translated) strings for en_US are taken from the default translation (English) that is compiled
into the bundle

**Steps to test this PR**:
1. Verify that [this Sync UI Tests run](https://github.com/duckduckgo/macos-browser/actions/runs/8256260981) has some passing tests on Big Sur and Monterey. It's run from a branch with the fix cherry-picked on top.
2. If you have Big Sur or Monterey machine:
    * install the review build produced by [this workflow](https://github.com/duckduckgo/macos-browser/actions/runs/8256640864),
    * set your OS language to English,
    * remove other languages from the list,
    * launch the app,
    * verify that Sync Settings appear in English.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
