### PR TITLE
Fix Bump Internal Release to run Validate Input Conditions job on a macOS runner

### DIFF
--- a/.github/workflows/bump_internal_release.yml
+++ b/.github/workflows/bump_internal_release.yml
@@ -2,7 +2,7 @@ name: Bump Internal Release
 
 on:
   schedule:
-    - cron: '0 5 * * 2,3,4,5' # Run at 05:00 UTC on Tuesday through Friday
+    - cron: '0 7 * * 2-5' # Run at 07:00 UTC, Tuesday through Friday
   workflow_dispatch:
     inputs:
       asana-task-url:
@@ -20,7 +20,9 @@ jobs:
 
     name: Validate Input Conditions
 
-    runs-on: ubuntu-latest
+    # This doesn't need Xcode, so could technically run on Ubuntu, but find_asana_release_task.sh
+    # uses BSD-specific `date` syntax, that doesn't work with GNU `date` (available on Linux).
+    runs-on: macos-13
     timeout-minutes: 10
 
     outputs:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1206827461323982/f

**Description**:
macOS runner is needed because date tool used by find_asana_task.sh uses BSD (macOS-specific) syntax.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
