### PR TITLE
Correctly present the DBP waitlist

### DIFF
--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -164,15 +164,11 @@ final class MoreOptionsMenu: NSMenu {
 
 #if DBP
     @objc func openDataBrokerProtection(_ sender: NSMenuItem) {
-        #if SUBSCRIPTION
-        actionDelegate?.optionsButtonMenuRequestedDataBrokerProtection(self)
-        #else
         if !DefaultDataBrokerProtectionFeatureVisibility.bypassWaitlist && DataBrokerProtectionWaitlistViewControllerPresenter.shouldPresentWaitlist() {
             DataBrokerProtectionWaitlistViewControllerPresenter.show()
         } else {
             actionDelegate?.optionsButtonMenuRequestedDataBrokerProtection(self)
         }
-        #endif
     }
 #endif // DBP
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1206836168416480/f

**Description**:
Correctly present the DBP waitlist with SUBSCRIPTION flag is on

**Steps to test this PR**:
1. Force the waitlist flag to be on [here](https://github.com/duckduckgo/macos-browser/blob/4000ffe15e313c92abe233522fdc82888fca5590/DuckDuckGo/DBP/DataBrokerProtectionFeatureVisibility.swift#L75-L81)
2. Test the sandbox build, check if when opening Personal Information Removal menu item it displays the waitlist modal
3. Test the app store build, check if when opening Personal Information Removal menu item it displays the waitlist modal
