### PR TITLE
DBP: Treat 404 as failure instead of error

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionStageDurationCalculator.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionStageDurationCalculator.swift
@@ -170,7 +170,12 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
             switch dataBrokerProtectionError {
             case .httpError(let httpCode):
                 if httpCode < 500 {
-                    errorCategory = .clientError(httpCode: httpCode)
+                    if httpCode == 404 {
+                        fireScanFailed()
+                        return
+                    } else {
+                        errorCategory = .clientError(httpCode: httpCode)
+                    }
                 } else {
                     errorCategory = .serverError(httpCode: httpCode)
                 }

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionStageDurationCalculatorTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionStageDurationCalculatorTests.swift
@@ -1,0 +1,141 @@
+//
+//  DataBrokerProtectionStageDurationCalculatorTests.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Foundation
+import XCTest
+
+@testable import DataBrokerProtection
+
+final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
+    let handler = MockDataBrokerProtectionPixelsHandler()
+
+    override func tearDown() {
+        handler.clear()
+    }
+
+    func testWhenErrorIs404_thenWeFireScanFailedPixel() {
+        let sut = DataBrokerProtectionStageDurationCalculator(dataBroker: "broker", handler: handler)
+
+        sut.fireScanError(error: DataBrokerProtectionError.httpError(code: 404))
+
+        XCTAssertTrue(MockDataBrokerProtectionPixelsHandler.lastPixelsFired.count == 1)
+
+        if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last{
+            switch failurePixel {
+            case .scanFailed(let broker, _, _):
+                XCTAssertEqual(broker, "broker")
+            default: XCTFail("The scan failed pixel should be fired")
+            }
+        } else {
+            XCTFail("A pixel should be fired")
+        }
+    }
+
+    func testWhenErrorIs403_thenWeFireScanErrorPixelWithClientErrorCategory() {
+        let sut = DataBrokerProtectionStageDurationCalculator(dataBroker: "broker", handler: handler)
+
+        sut.fireScanError(error: DataBrokerProtectionError.httpError(code: 403))
+
+        XCTAssertTrue(MockDataBrokerProtectionPixelsHandler.lastPixelsFired.count == 1)
+
+        if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last{
+            switch failurePixel {
+            case .scanError(_, _, let category, _):
+                XCTAssertEqual(category, ErrorCategory.clientError(httpCode: 403).toString)
+            default: XCTFail("The scan error pixel should be fired")
+            }
+        } else {
+            XCTFail("A pixel should be fired")
+        }
+    }
+
+    func testWhenErrorIs500_thenWeFireScanErrorPixelWithServerErrorCategory() {
+        let sut = DataBrokerProtectionStageDurationCalculator(dataBroker: "broker", handler: handler)
+
+        sut.fireScanError(error: DataBrokerProtectionError.httpError(code: 500))
+
+        XCTAssertTrue(MockDataBrokerProtectionPixelsHandler.lastPixelsFired.count == 1)
+
+        if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last{
+            switch failurePixel {
+            case .scanError(_, _, let category, _):
+                XCTAssertEqual(category, ErrorCategory.serverError(httpCode: 500).toString)
+            default: XCTFail("The scan error pixel should be fired")
+            }
+        } else {
+            XCTFail("A pixel should be fired")
+        }
+    }
+
+    func testWhenErrorIsNotHttp_thenWeFireScanErrorPixelWithValidationErrorCategory() {
+        let sut = DataBrokerProtectionStageDurationCalculator(dataBroker: "broker", handler: handler)
+
+        sut.fireScanError(error: DataBrokerProtectionError.actionFailed(actionID: "Action-ID", message: "Some message"))
+
+        XCTAssertTrue(MockDataBrokerProtectionPixelsHandler.lastPixelsFired.count == 1)
+
+        if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last{
+            switch failurePixel {
+            case .scanError(_, _, let category, _):
+                XCTAssertEqual(category, ErrorCategory.validationError.toString)
+            default: XCTFail("The scan error pixel should be fired")
+            }
+        } else {
+            XCTFail("A pixel should be fired")
+        }
+    }
+
+    func testWhenErrorIsNotDBPErrorButItIsNSURL_thenWeFireScanErrorPixelWithNetworkErrorErrorCategory() {
+        let sut = DataBrokerProtectionStageDurationCalculator(dataBroker: "broker", handler: handler)
+        let nsURLError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+
+        sut.fireScanError(error: nsURLError)
+
+        XCTAssertTrue(MockDataBrokerProtectionPixelsHandler.lastPixelsFired.count == 1)
+
+        if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last{
+            switch failurePixel {
+            case .scanError(_, _, let category, _):
+                XCTAssertEqual(category, ErrorCategory.networkError.toString)
+            default: XCTFail("The scan error pixel should be fired")
+            }
+        } else {
+            XCTFail("A pixel should be fired")
+        }
+    }
+
+    func testWhenErrorIsNotDBPErrorAndNotURL_thenWeFireScanErrorPixelWithUnclassifiedErrorCategory() {
+        let sut = DataBrokerProtectionStageDurationCalculator(dataBroker: "broker", handler: handler)
+        let error = NSError(domain: NSCocoaErrorDomain, code: -1)
+
+        sut.fireScanError(error: error)
+
+        XCTAssertTrue(MockDataBrokerProtectionPixelsHandler.lastPixelsFired.count == 1)
+
+        if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last{
+            switch failurePixel {
+            case .scanError(_, _, let category, _):
+                XCTAssertEqual(category, ErrorCategory.unclassified.toString)
+            default: XCTFail("The scan error pixel should be fired")
+            }
+        } else {
+            XCTFail("A pixel should be fired")
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206289941388102/f
Tech Design URL:
CC:

**Description**:
Stop treating 404s as `error` pixels and treat them as `failure` pixels.

**Steps to test this PR**:
1. Run PIR with a profile where some broker sites return 404
2. Check that the `failure` Pixel is fired instead of the error
