### PR TITLE
Prevent dragging a folder to itself to move items in BookmarkStore

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -2429,6 +2429,8 @@
 		9F56CFB12B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56CFB02B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift */; };
 		9F56CFB22B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56CFB02B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift */; };
 		9F56CFB32B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56CFB02B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift */; };
+		9F7FE7302BA3CAD000E1832C /* DraggingInfoMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7FE72E2BA3CAC700E1832C /* DraggingInfoMock.swift */; };
+		9F7FE7312BA3CAD100E1832C /* DraggingInfoMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7FE72E2BA3CAC700E1832C /* DraggingInfoMock.swift */; };
 		9F872D982B8DA9F800138637 /* Bookmarks+Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F872D972B8DA9F800138637 /* Bookmarks+Tab.swift */; };
 		9F872D992B8DA9F800138637 /* Bookmarks+Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F872D972B8DA9F800138637 /* Bookmarks+Tab.swift */; };
 		9F872D9A2B8DA9F800138637 /* Bookmarks+Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F872D972B8DA9F800138637 /* Bookmarks+Tab.swift */; };
@@ -4047,6 +4049,7 @@
 		9F56CFA82B82DC4300BB7F11 /* AddEditBookmarkFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditBookmarkFolderView.swift; sourceTree = "<group>"; };
 		9F56CFAC2B84326C00BB7F11 /* AddEditBookmarkDialogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditBookmarkDialogViewModel.swift; sourceTree = "<group>"; };
 		9F56CFB02B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksDialogViewFactory.swift; sourceTree = "<group>"; };
+		9F7FE72E2BA3CAC700E1832C /* DraggingInfoMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggingInfoMock.swift; sourceTree = "<group>"; };
 		9F872D972B8DA9F800138637 /* Bookmarks+Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmarks+Tab.swift"; sourceTree = "<group>"; };
 		9F872D9C2B9058D000138637 /* Bookmarks+TabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmarks+TabTests.swift"; sourceTree = "<group>"; };
 		9F872D9F2B90644800138637 /* ContextualMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualMenuTests.swift; sourceTree = "<group>"; };
@@ -6718,6 +6721,14 @@
 			path = DuckDuckGoDBPBackgroundAgent;
 			sourceTree = "<group>";
 		};
+		9F7FE72D2BA3CAB300E1832C /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				9F7FE72E2BA3CAC700E1832C /* DraggingInfoMock.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		9F872D9B2B9058B000138637 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -7108,6 +7119,7 @@
 		AA652CAB25DD820D009059CC /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
+				9F7FE72D2BA3CAB300E1832C /* Mocks */,
 				9F872D9B2B9058B000138637 /* Extensions */,
 				9FA75A3C2BA00DF500DA5FA6 /* Factory */,
 				9F982F102B82264400231028 /* ViewModels */,
@@ -10800,6 +10812,7 @@
 				3706FE78293F661700E42796 /* HistoryCoordinatingMock.swift in Sources */,
 				3706FE79293F661700E42796 /* AppearancePreferencesTests.swift in Sources */,
 				3706FE7A293F661700E42796 /* FirePopoverViewModelTests.swift in Sources */,
+				9F7FE7312BA3CAD100E1832C /* DraggingInfoMock.swift in Sources */,
 				3706FE7B293F661700E42796 /* HistoryStoringMock.swift in Sources */,
 				562984702AC4610100AC20EB /* SyncPreferencesTests.swift in Sources */,
 				3706FE7C293F661700E42796 /* LocalBookmarkStoreTests.swift in Sources */,
@@ -12693,6 +12706,7 @@
 				4B98D27A28D95F1A003C2B6F /* ChromiumFaviconsReaderTests.swift in Sources */,
 				986189E62A7CFB3E001B4519 /* LocalBookmarkStoreSavingTests.swift in Sources */,
 				AA652CD325DDA6E9009059CC /* LocalBookmarkManagerTests.swift in Sources */,
+				9F7FE7302BA3CAD000E1832C /* DraggingInfoMock.swift in Sources */,
 				CBDD5DE329A67F2700832877 /* MockConfigurationStore.swift in Sources */,
 				9F3910692B68D87B00CB5112 /* ProgressExtensionTests.swift in Sources */,
 				B63ED0DC26AE7B1E00A9DAD1 /* WebViewMock.swift in Sources */,

--- a/UnitTests/Bookmarks/Mocks/DraggingInfoMock.swift
+++ b/UnitTests/Bookmarks/Mocks/DraggingInfoMock.swift
@@ -1,0 +1,91 @@
+//
+//  DraggingInfoMock.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import DuckDuckGo_Privacy_Browser
+
+final class DraggingInfoMock: NSObject, NSDraggingInfo {
+    private let pasteboard: NSPasteboard
+
+    var animatesToDestination: Bool = false
+    var numberOfValidItemsForDrop: Int = 0
+    var draggingFormation: NSDraggingFormation = .none
+    var springLoadingHighlight: NSSpringLoadingHighlight = .none
+
+    init(pasteboard: NSPasteboard) {
+        self.pasteboard = pasteboard
+        super.init()
+    }
+
+    var draggingLocation: NSPoint {
+        return NSPoint(x: 50, y: 50)
+    }
+
+    var draggingPasteboard: NSPasteboard {
+        return pasteboard
+    }
+
+    var draggingSequenceNumber: Int {
+        return 0
+    }
+
+    var draggingSource: Any? {
+        return nil
+    }
+
+    var draggingSourceOperationMask: NSDragOperation {
+        return .every
+    }
+
+    var draggingDestinationWindow: NSWindow? {
+        return nil
+    }
+
+    var draggedImage: NSImage? {
+        return nil
+    }
+
+    var draggedImageLocation: NSPoint {
+        return .zero
+    }
+
+    func slideDraggedImage(to aPoint: NSPoint) {}
+
+    func enumerateDraggingItems(options enumOpts: NSDraggingItemEnumerationOptions, for view: NSView?, classes classArray: [AnyClass], searchOptions: [NSPasteboard.ReadingOptionKey: Any], using block: @escaping (NSDraggingItem, Int, UnsafeMutablePointer<ObjCBool>) -> Void) {}
+
+    func resetSpringLoading() {}
+}
+
+extension DraggingInfoMock {
+
+    static func with(bookmarkEntity: BaseBookmarkEntity, pasteboardName: StaticString = #function) -> DraggingInfoMock {
+        DraggingInfoMock(pasteboard: NSPasteboard.with(bookmarkEntity: bookmarkEntity, name: pasteboardName))
+    }
+
+}
+
+extension NSPasteboard {
+
+    static func with(bookmarkEntity: BaseBookmarkEntity, name: StaticString = #function) -> NSPasteboard {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name(String(name)))
+        pasteboard.clearContents()
+        pasteboard.writeObjects([bookmarkEntity.pasteboardWriter])
+        return pasteboard
+    }
+
+}

--- a/UnitTests/Bookmarks/Model/BookmarkOutlineViewDataSourceTests.swift
+++ b/UnitTests/Bookmarks/Model/BookmarkOutlineViewDataSourceTests.swift
@@ -77,6 +77,7 @@ class BookmarkOutlineViewDataSourceTests: XCTestCase {
     }
 
     func testWhenValidatingBookmarkDrop_AndDestinationIsFolder_ThenMoveDragOperationIsReturned() {
+        // GIVEN
         let mockDestinationFolder = BookmarkFolder.mock
         let bookmarkStoreMock = BookmarkStoreMock()
         let faviconManagerMock = FaviconManagerMock()
@@ -90,13 +91,18 @@ class BookmarkOutlineViewDataSourceTests: XCTestCase {
         let mockDestinationNode = treeController.node(representing: mockDestinationFolder)!
         let dataSource = BookmarkOutlineViewDataSource(contentMode: .foldersOnly, bookmarkManager: bookmarkManager, treeController: treeController)
 
-        let pasteboardBookmark = PasteboardBookmark(id: UUID().uuidString, url: "https://example.com", title: "Pasteboard Bookmark")
-        let result = dataSource.validateDrop(for: [pasteboardBookmark], destination: mockDestinationNode)
+        let bookmark = Bookmark(id: UUID().uuidString, url: "https://example.com", title: "Pasteboard Bookmark", isFavorite: false)
+        let draggingInfoMock = DraggingInfoMock.with(bookmarkEntity: bookmark)
 
+        // WHEN
+        let result = dataSource.outlineView(BookmarksOutlineView(), validateDrop: draggingInfoMock, proposedItem: mockDestinationNode, proposedChildIndex: -1)
+
+        // THEN
         XCTAssertEqual(result, .move)
     }
 
     func testWhenValidatingFolderDrop_AndDestinationIsFolder_ThenMoveDragOperationIsReturned() {
+        // GIVEN
         let mockDestinationFolder = BookmarkFolder.mock
         let bookmarkStoreMock = BookmarkStoreMock()
         let faviconManagerMock = FaviconManagerMock()
@@ -110,9 +116,13 @@ class BookmarkOutlineViewDataSourceTests: XCTestCase {
         let mockDestinationNode = treeController.node(representing: mockDestinationFolder)!
         let dataSource = BookmarkOutlineViewDataSource(contentMode: .foldersOnly, bookmarkManager: bookmarkManager, treeController: treeController)
 
-        let pasteboardFolder = PasteboardFolder(folder: .init(id: UUID().uuidString, title: "Pasteboard Folder"))
-        let result = dataSource.validateDrop(for: [pasteboardFolder], destination: mockDestinationNode)
+        let folder = BookmarkFolder(id: UUID().uuidString, title: "Pasteboard Folder")
+        let draggingInfoMock = DraggingInfoMock.with(bookmarkEntity: folder)
 
+        // WHEN
+        let result = dataSource.outlineView(BookmarksOutlineView(), validateDrop: draggingInfoMock, proposedItem: mockDestinationNode, proposedChildIndex: -1)
+
+        // THEN
         XCTAssertEqual(result, .move)
     }
 
@@ -130,9 +140,12 @@ class BookmarkOutlineViewDataSourceTests: XCTestCase {
         let dataSource = BookmarkOutlineViewDataSource(contentMode: .foldersOnly, bookmarkManager: bookmarkManager, treeController: treeController)
         let mockDestinationNode = treeController.node(representing: mockDestinationFolder)!
 
-        let pasteboardFolder = PasteboardFolder(folder: mockDestinationFolder)
-        let result = dataSource.validateDrop(for: [pasteboardFolder], destination: mockDestinationNode)
+        let draggingInfoMock = DraggingInfoMock.with(bookmarkEntity: mockDestinationFolder)
 
+        // WHEN
+        let result = dataSource.outlineView(BookmarksOutlineView(), validateDrop: draggingInfoMock, proposedItem: mockDestinationNode, proposedChildIndex: -1)
+
+        // THEN
         XCTAssertEqual(result, .none)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206837985963146/f

**Description**:
Prevent assertion failure to fire when dragging a folder to itself


**Steps to test this PR**:
1. Open Manage Bookmarks
2. Drag a folder from the left hand side view and drop in the same location
Expected Result: No assertion failure should be thrown and content should not be moved

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
