### PR TITLE
DBP: Make webview non-persistent and delete any old cache data

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/CCF/WebViewHandler.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/CCF/WebViewHandler.swift
@@ -48,6 +48,7 @@ final class DataBrokerProtectionWebViewHandler: NSObject, WebViewHandler {
         let configuration = WKWebViewConfiguration()
         configuration.applyDataBrokerConfiguration(privacyConfig: privacyConfig, prefs: prefs, delegate: delegate)
         configuration.preferences.setValue(true, forKey: "developerExtrasEnabled")
+        configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
 
         self.webViewConfiguration = configuration
         self.isFakeBroker = isFakeBroker
@@ -85,6 +86,9 @@ final class DataBrokerProtectionWebViewHandler: NSObject, WebViewHandler {
 
         webView?.stopLoading()
         userContentController?.cleanUpBeforeClosing()
+        WKWebsiteDataStore.default().removeData(ofTypes: [WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache], modifiedSince: Date(timeIntervalSince1970: 0)) {
+            os_log("WKWebView data store deleted correctly", log: .action)
+        }
 
         userContentController = nil
         webView?.navigationDelegate = nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206866129873259/f
Tech Design URL:
CC:

**Description**:
Make WebView store non-persistent so we do not store any information about which sites we are accesing.

**Steps to test this PR**:
1. Go to `~/Library/Caches/com.duckduckgo.macos.DBP.backgroundAgent.debug/WebKit/NetworkCache/Version\ 16` and remove all data there.
2. Go to PIR, and start scans from the **background agent**
3. The `Blob` and `Records` folders should be empty all the time when the request to the brokers finishes.