### PR TITLE
Makes a method thread safe

### DIFF
--- a/LocalPackages/XPCHelper/Sources/XPCHelper/XPCServer.swift
+++ b/LocalPackages/XPCHelper/Sources/XPCHelper/XPCServer.swift
@@ -23,7 +23,7 @@ private class XPCConnectionsManager: NSObject, NSXPCListenerDelegate {
 
     private let clientInterface: NSXPCInterface
     private let serverInterface: NSXPCInterface
-    private let queue: DispatchQueue
+    fileprivate let queue: DispatchQueue
     weak var delegate: AnyObject?
 
     /// The active connections
@@ -135,16 +135,18 @@ extension XPCServer {
     }
 
     public func forEachClient(do callback: @escaping (ClientInterface) -> Void) {
-        for connection in connectionsManager.connections {
-            let client: ClientInterface
+        connectionsManager.queue.async {
+            for connection in self.connectionsManager.connections {
+                let client: ClientInterface
 
-            do {
-                client = try self.client(for: connection)
-            } catch {
-                continue
+                do {
+                    client = try self.client(for: connection)
+                } catch {
+                    continue
+                }
+
+                callback(client)
             }
-
-            callback(client)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206878016688977/f

## Description

Makes a method thread safe

## Testing

1. Make sure you can start and stop the VPN from the main browser app
2. XPC is used for all commands sent by the main app to the menu app, which is mostly through the status view toggle.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
