### PR TITLE
Fix sparkle strings for thank you message

### DIFF
--- a/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
+++ b/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
@@ -392,10 +392,16 @@ extension UserText {
     static let dbpThankYouTitle = "Personal Information Removal early access is over"
     static let dbpThankYouSubtitle = "Thank you for being a tester!"
     static let dbpThankYouBody1 = "To continue using Personal Information Removal, subscribe to DuckDuckGo Privacy Pro and get 40% off with promo code THANKYOU"
-    static let dbpThankYouBody2 = "Offer redeemable for a limited time only in the desktop version of the DuckDuckGo browser by U.S. testers when you download from duckduckgo.com/app"
 
     static let vpnThankYouTitle = "DuckDuckGo VPN early access is over"
     static let vpnThankYouSubtitle = "Thank you for being a tester!"
     static let vpnThankYouBody1 = "To continue using the VPN, subscribe to DuckDuckGo Privacy Pro and get 40% off with promo code THANKYOU"
+
+#if APPSTORE
+    static let dbpThankYouBody2 = "Offer redeemable for a limited time only in the desktop version of the DuckDuckGo browser by U.S. testers when you download from duckduckgo.com/app"
     static let vpnThankYouBody2 = "Offer redeemable for a limited time only in the desktop version of the DuckDuckGo browser by U.S. testers when you download from duckduckgo.com/app"
+#else
+    static let dbpThankYouBody2 = "Offer redeemable for a limited time in the desktop version of the DuckDuckGo browser by U.S. beta testers only."
+    static let vpnThankYouBody2 = "Offer redeemable for a limited time in the desktop version of the DuckDuckGo browser by U.S. beta testers only."
+#endif
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1206888588805890/f
Tech Design URL:
CC:

**Description**:
Fix sparkle strings for thank you message

**Steps to test this PR**:
1. Check the thank you message for Developer ID build
2. Check the thank you message for App Store build 

How to force the message to appear: https://github.com/duckduckgo/macos-browser/pull/2437
