### PR TITLE
Entitlements cache fixes

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14108,8 +14108,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "michal/cache-fixes";
-				kind = branch;
+				kind = exactVersion;
+				version = 127.1.1;
 			};
 		};
 		AA06B6B52672AF8100F541C5 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "michal/cache-fixes",
-        "revision" : "04e9b7aaa887b0a639cfd23c92b6949cc20da4f8"
+        "revision" : "1ba3e3682b9231a1d8685f1d16f950e7910b8593",
+        "version" : "127.1.1"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "127.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "127.1.1"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "127.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "127.1.1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../LoginItems"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "127.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "127.1.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206892721639727/f


**Description**:
Update the default cache validity time from 1 day to 1 hour.
Change the entitlements cache behaviour to not to store the empty entitlement array but instead clear the cache as this will force refetching updated ones via API.

**Steps to test this PR**:
Steps to test this PR:
Complete the purchase check the confirmation response it should contain the full entitlement set which should be then reflected in the UI in more menu and settings.


---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
