### PR TITLE
Main thread issue for NetworkProtection nav bar icon update

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
@@ -100,9 +100,11 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
     }
 
     private func setupIconSubscription() {
-        iconPublisherCancellable = iconPublisher.$icon.sink { [weak self] icon in
-            self?.buttonImage = self?.buttonImageFromWaitlistState(icon: icon)
-        }
+        iconPublisherCancellable = iconPublisher.$icon
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] icon in
+                self?.buttonImage = self?.buttonImageFromWaitlistState(icon: icon)
+            }
     }
 
     /// Temporary override used for the NetP waitlist beta, as a different asset is used for users who are invited to join the beta but haven't yet accepted.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1206894457777736/f

**Description**:

It seems that when the icon publisher fires for the network protection nav bar the app is not running on the main thread. This leads to accessing AppKit down the track and it will probably crash the App in release mode.

<img width="1728" alt="Screenshot 2024-03-21 at 4 44 19 PM" src="https://github.com/duckduckgo/macos-browser/assets/1089358/28a17a28-dd2a-4ac8-bf21-c3b2dff27eb9">

**Steps to test this PR**:
1. It happened to me when I launched the App. Follow the stack trace :)

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)