### PR TITLE
DBP: Changes to weekly scanning pixel parameters

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionEventPixels.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionEventPixels.swift
@@ -120,7 +120,7 @@ final class DataBrokerProtectionEventPixels {
             percentageOfBrokersScanned = (totalBrokersInTheLastWeek * 100) / totalBrokers
         }
 
-        handler.fire(.weeklyReportScanning(hadNewMatch: newMatchesFoundInTheLastWeek > 0, hadReAppereance: reAppereancesInTheLastWeek > 0, scanCoverage: percentageOfBrokersScanned))
+        handler.fire(.weeklyReportScanning(hadNewMatch: newMatchesFoundInTheLastWeek > 0, hadReAppereance: reAppereancesInTheLastWeek > 0, scanCoverage: percentageOfBrokersScanned.toString))
         handler.fire(.weeklyReportRemovals(removals: removalsInTheLastWeek))
     }
 
@@ -137,6 +137,22 @@ final class DataBrokerProtectionEventPixels {
             return differenceInDays >= 7
         } else {
             return false
+        }
+    }
+}
+
+private extension Int {
+    var toString: String {
+        if self < 25 {
+            return "0-25"
+        } else if self < 50 {
+            return "25-50"
+        } else if self < 75 {
+            return "50-75"
+        } else if self <= 100 {
+            return "75-100"
+        } else {
+            return "error"
         }
     }
 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionPixels.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/DataBrokerProtectionPixels.swift
@@ -123,7 +123,7 @@ public enum DataBrokerProtectionPixels {
     case monthlyActiveUser
 
     // KPIs - events
-    case weeklyReportScanning(hadNewMatch: Bool, hadReAppereance: Bool, scanCoverage: Int)
+    case weeklyReportScanning(hadNewMatch: Bool, hadReAppereance: Bool, scanCoverage: String)
     case weeklyReportRemovals(removals: Int)
     case scanningEventNewMatch
     case scanningEventReAppearance
@@ -267,7 +267,7 @@ extension DataBrokerProtectionPixels: PixelKitEvent {
 
             return params
         case .weeklyReportScanning(let hadNewMatch, let hadReAppereance, let scanCoverage):
-            return [Consts.hadNewMatch: hadNewMatch.description, Consts.hadReAppereance: hadReAppereance.description, Consts.scanCoverage: scanCoverage.description]
+            return [Consts.hadNewMatch: hadNewMatch ? "1" : "0", Consts.hadReAppereance: hadReAppereance ? "1" : "0", Consts.scanCoverage: scanCoverage.description]
         case .weeklyReportRemovals(let removals):
             return [Consts.removals: String(removals)]
         case .backgroundAgentStarted,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206897386402583/f
Tech Design URL:
CC:

**Description**:
Change the params for the `dbp.event.weekly-report.scanning ` pixel
 - had_new_match - 1 / 0 (1 when true, 0 when it is false)
- had_re-appearance - 1 / 0 (the same as above)
- scan_coverage - 0-25, 25-50, 50-75 or 75-100 (now this is a range)

**Steps to test this PR**:
1. It could be tested by running PIR and deleting the `macos.browser.data-broker-protection.eventsWeeklyPixelKey` user default in the background agent
2. Then running scans from the debug menu and check the values
3. The cases are covered by unit tests too