### PR TITLE
Fix expiry prompt uninstall button selection state

### DIFF
--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/SubscriptionExpiredView/SubscriptionExpiredView.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/SubscriptionExpiredView/SubscriptionExpiredView.swift
@@ -49,7 +49,7 @@ struct SubscriptionExpiredView: View {
                 .padding(.bottom, 3)
 
             Button(UserText.networkProtectionSubscriptionExpiredUninstallButton, action: uninstallButtonHandler)
-                .buttonStyle(.borderless)
+                .buttonStyle(TransparentActionButtonStyle(enabled: true))
                 .foregroundColor(.accentColor)
                 .padding(.top, 3)
         }

--- a/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/ButtonStyles.swift
+++ b/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/ButtonStyles.swift
@@ -69,6 +69,34 @@ public struct DefaultActionButtonStyle: ButtonStyle {
     }
 }
 
+public struct TransparentActionButtonStyle: ButtonStyle {
+
+    public let enabled: Bool
+
+    public init(enabled: Bool) {
+        self.enabled = enabled
+    }
+
+    public func makeBody(configuration: Self.Configuration) -> some View {
+
+        let enabledForegroundColor = configuration.isPressed ? Color(NSColor.controlAccentColor).opacity(0.5) : Color(NSColor.controlAccentColor)
+        let disabledForegroundColor = Color.gray.opacity(0.1)
+
+        configuration.label
+            .font(.system(size: 13))
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(minWidth: 44) // OK buttons will match the width of "Cancel" at least in English
+            .padding(.top, 2.5)
+            .padding(.bottom, 3)
+            .padding(.horizontal, 0)
+            .background(Color.clear)
+            .foregroundColor(enabled ? enabledForegroundColor : disabledForegroundColor)
+            .cornerRadius(5)
+
+    }
+}
+
 public struct DismissActionButtonStyle: ButtonStyle {
     @Environment(\.colorScheme) var colorScheme
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206887263279894/f

**Description**:

The uninstall button on the VPN entitlements expiry view has no selection state. Update it so the colour changes to match the background selection state of the normal default button style. See video in task for context.

**Steps to test this PR**:
1. Hardcode NetworkProtectionStatusViewModel.shouldShowSubscriptionExpired to true
2. Comment out L: 161 (which observes the entitlements validity
3. Authenticate (either invite code or subs) the VPN so you can see the controls
4. Observe the Uninstall button and select it to see it’s selection state
5. It should change colour to be slightly more transparent

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
