### PR TITLE
Fix clean up state when both waitlist and PP flags are on

### DIFF
--- a/DuckDuckGo/DBP/DataBrokerProtectionFeatureVisibility.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionFeatureVisibility.swift
@@ -94,12 +94,10 @@ struct DefaultDataBrokerProtectionFeatureVisibility: DataBrokerProtectionFeature
     }
 
     private var isWaitlistBetaActive: Bool {
-        return false
         return privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(DBPSubfeature.waitlistBetaActive)
     }
 
     private var isWaitlistEnabled: Bool {
-        return false
         return privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(DBPSubfeature.waitlist)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206920947598504/f

**Description**:
Fix clean up state when both waitlist and PP flags are on

**Steps to test this PR**:
1. Turn PP flag ON, Make sure waitlist flags are ON as well
2. Check if disableAndDeleteForWaitlistUsers is being called (it shouldn't)
3. Disable both PP and waitlist
4. Check if disableAndDeleteForWaitlistUsers is being called (it should)
5. Enable PP and leave waitlist off
6. Check if disableAndDeleteForWaitlistUsers is being called (it shouldn't)
7. Enable waitlist and leave PP off
8. Check if disableAndDeleteForWaitlistUsers is being called (it shouldn't)
Note that disableAndDeleteForWaitlistUsers will be called if you don't have profile data, this is expected 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
