### PR TITLE
Add subscriptionChangeObserver in settings

### DIFF
--- a/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionModel.swift
+++ b/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionModel.swift
@@ -45,6 +45,7 @@ public final class PreferencesSubscriptionModel: ObservableObject {
 
     private var signInObserver: Any?
     private var signOutObserver: Any?
+    private var subscriptionChangeObserver: Any?
 
     public enum UserEvent {
         case openVPN,
@@ -111,6 +112,12 @@ public final class PreferencesSubscriptionModel: ObservableObject {
         signOutObserver = NotificationCenter.default.addObserver(forName: .accountDidSignOut, object: nil, queue: .main) { [weak self] _ in
             self?.updateUserAuthenticatedState(false)
         }
+
+        subscriptionChangeObserver = NotificationCenter.default.addObserver(forName: .subscriptionDidChange, object: nil, queue: .main) { _ in
+            Task { [weak self] in
+                await self?.updateSubscription(with: .returnCacheDataDontLoad)
+            }
+        }
     }
 
     deinit {
@@ -120,6 +127,10 @@ public final class PreferencesSubscriptionModel: ObservableObject {
 
         if let signOutObserver {
             NotificationCenter.default.removeObserver(signOutObserver)
+        }
+
+        if let subscriptionChangeObserver {
+            NotificationCenter.default.removeObserver(subscriptionChangeObserver)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206930692767234/f

**Description**:
Detect subscription changes and reload subscription tab if needed.

**Steps to test this PR**:
1. Open subscription settings
2. Wait for it to expire 🙄 
3. Status should update

Instead of 2. you can set up a trigger update the subscription cache with mocked instance.


---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
