### PR TITLE
Closing empty tabs after download

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DownloadsTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DownloadsTabExtension.swift
@@ -224,21 +224,13 @@ extension DownloadsTabExtension: NavigationResponder {
             return true
         }
 
+        // If the download has started from a popup Tab - close it after starting the download
+        // e.g. download button on this page:
+        // https://en.wikipedia.org/wiki/Guitar#/media/File:GuitareClassique5.png
         guard let webView = download.webView,
               isMainFrameNavigationActionWithNoHistory
                 // if converted from navigation response but no page was loaded
                 || navigationAction == nil && webView.backForwardList.currentItem == nil else { return }
-
-        // If the download has started from a popup Tab - close it after starting the download
-        // e.g. download button on this page:
-        // https://en.wikipedia.org/wiki/Guitar#/media/File:GuitareClassique5.png
-        guard let navigationAction,
-              navigationAction.isForMainFrame,
-              navigationAction.isTargetingNewWindow,
-              let webView = download.webView,
-              // webView has no navigation history (downloaded navigationAction has started from an empty state)
-              (navigationAction.redirectHistory?.first ?? navigationAction).fromHistoryItemIdentity == nil
-        else { return }
 
         self.closeWebView(webView, afterDownloadTaskHasStarted: task)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206835038894671/f

**Description**:
Fix of empty tabs remaining in the tab bar after a download finishes.

**Steps to test this PR**:
**Test downloads which open a new tab are closed**
1. Visit [this task](https://app.asana.com/0/1142021229838617/1206919179674977/f)
2. Click on the download icon on the first image
3. Make sure the new tab is closed after download finishes
4. Click on the same image again
5. Make sure the new tab is closed after download finishes

**Test downloads which doesn't open a new tab**
1. Visit [this task](https://www.w3schools.com/TAGS/tryit.asp?filename=tryhtml5_a_download)
2. Click on the image to start the download
3. Make sure the current tab is not closed

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
