### PR TITLE
Fixes clearing the PPro state when going from internal to external user

### DIFF
--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -719,7 +719,13 @@ extension MainViewController {
         let state = internalUserDecider.isInternalUser
         internalUserDecider.debugSetInternalUserState(!state)
 
-        clearPrivacyProState()
+        if !DefaultSubscriptionFeatureAvailability().isFeatureAvailable {
+            // We only clear PPro state when it's not available, as otherwise
+            // there should be no state to clear.  Clearing PPro state can
+            // trigger notifications which we want to avoid unless
+            // necessary.
+            clearPrivacyProState()
+        }
     }
 
     /// Clears the PrivacyPro state to make testing easier.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206940175043523/f

## Description

Fixes an issue with subscription status clearing when it should not be cleared.

## Testing

1. Be external waitlist user.
2. Connect VPN.
3. Become internal user through debug menu.
4. Alt + Tab to activate the thank you dialog.
5. Buy PPro.
6. Connect VPN.
7. Become external user through debug menu.
8. VPN should disconnect and uninstall.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
