### PR TITLE
Remove waitlist recovery logic

### DIFF
--- a/DuckDuckGo/Waitlist/Waitlist.swift
+++ b/DuckDuckGo/Waitlist/Waitlist.swift
@@ -208,7 +208,7 @@ struct NetworkProtectionWaitlist: Waitlist {
 
     func fetchNetworkProtectionInviteCodeIfAvailable(completion: @escaping (WaitlistInviteCodeFetchError?) -> Void) {
         // Never fetch the invite code if the Privacy Pro flag is enabled:
-        guard !DefaultSubscriptionFeatureAvailability().isFeatureAvailable else {
+        if DefaultSubscriptionFeatureAvailability().isFeatureAvailable {
             completion(nil)
             return
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206942956764105/f
Tech Design URL:
CC:

**Description**:

This PR removes recovery logic used by the app when fetching an auth token fails.

This logic was only used for waitlist users, and I want to remove it now so that when we remove the old auth token, the app doesn't try to get it back and cause problems.

**Steps to test this PR**:
1. Don't really need to QA this one too strongly, just check that NetP in waitlist and subscription user mode still works

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
