### PR TITLE
Add X-DuckDuckGo-Client header to all pixel requests

### DIFF
--- a/DuckDuckGo/Statistics/Pixel.swift
+++ b/DuckDuckGo/Statistics/Pixel.swift
@@ -91,7 +91,10 @@ final class Pixel {
         self.sendRequest = requestSender
     }
 
-    private static let moreInfoHeader: HTTPHeaders = [APIRequest.HTTPHeaderField.moreInfo: "See " + URL.duckDuckGoMorePrivacyInfo.absoluteString]
+    private static let pixelRequestHeaders: HTTPHeaders = [
+        APIRequest.HTTPHeaderField.moreInfo: "See " + URL.duckDuckGoMorePrivacyInfo.absoluteString,
+        "X-DuckDuckGo-Client": "macOS"
+    ]
 
     // Temporary for activation pixels
     static private var aMonthAgo = Calendar.current.date(byAdding: .month, value: -1, to: Date())!
@@ -103,7 +106,7 @@ final class Pixel {
               withAdditionalParameters parameters: [String: String]? = nil,
               allowedQueryReservedCharacters: CharacterSet? = nil,
               includeAppVersionParameter: Bool = true,
-              withHeaders headers: APIRequest.Headers = APIRequest.Headers(additionalHeaders: moreInfoHeader),
+              withHeaders headers: APIRequest.Headers = APIRequest.Headers(additionalHeaders: pixelRequestHeaders),
               onComplete: @escaping (Error?) -> Void = {_ in }) {
 
         func repetition() -> Event.Repetition {

--- a/LocalPackages/PixelKit/Sources/PixelKit/PixelKit.swift
+++ b/LocalPackages/PixelKit/Sources/PixelKit/PixelKit.swift
@@ -47,6 +47,7 @@ public final class PixelKit {
         public static let userAgent = "User-Agent"
         public static let ifNoneMatch = "If-None-Match"
         public static let moreInfo = "X-DuckDuckGo-MoreInfo"
+        public static let client = "X-DuckDuckGo-Client"
     }
 
     /// A closure typealias to request sending pixels through the network.
@@ -168,6 +169,7 @@ public final class PixelKit {
 
         var headers = headers ?? defaultHeaders
         headers[Header.moreInfo] = "See " + Self.duckDuckGoMorePrivacyInfo.absoluteString
+        headers[Header.client] = "macOS"
 
         switch frequency {
         case .standard:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1206619559464399/f

**Description**:
This change adds an extra header to all pixel requests.

**Steps to test this PR**:
1. Start a network sniffer
2. Install the review build created by [this workflow](https://github.com/duckduckgo/macos-browser/actions/runs/8481519287)
3. Run the build and verify that all requests to improving.duckduckgo.com contain `X-DuckDuckGo-Client: macOS` header

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
