### PR TITLE
Use the default action button style for VPN onboarding

### DIFF
--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/PromptActionView/PromptActionView.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/PromptActionView/PromptActionView.swift
@@ -30,35 +30,6 @@ fileprivate extension View {
             .foregroundColor(Color(.defaultText))
     }
 
-    @ViewBuilder
-    func applyStepButtonAttributes(colorScheme: ColorScheme) -> some View {
-        switch colorScheme {
-        case .dark:
-            self.buttonStyle(.plain)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 0)
-                .frame(height: 20, alignment: .center)
-                .background(Color(.onboardingButtonBackgroundColor))
-                .cornerRadius(5)
-                .shadow(color: .black.opacity(0.2), radius: 0.5, x: 0, y: 1)
-                .shadow(color: .black.opacity(0.05), radius: 0.5, x: 0, y: 0)
-                .shadow(color: .black.opacity(0.1), radius: 0, x: 0, y: 0)
-        default:
-            self.buttonStyle(.plain)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 0)
-                .frame(height: 20, alignment: .center)
-                .background(Color(.onboardingButtonBackgroundColor))
-                .cornerRadius(5)
-                .shadow(color: .black.opacity(0.1), radius: 0.5, x: 0, y: 1)
-                .shadow(color: .black.opacity(0.05), radius: 0.5, x: 0, y: 0)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 5)
-                        .inset(by: -0.25)
-                        .stroke(.black.opacity(0.1), lineWidth: 0.5)
-                )
-        }
-    }
 }
 
 struct PromptActionView: View {
@@ -95,7 +66,7 @@ struct PromptActionView: View {
                         .multilineText()
 
                         Button(model.actionTitle, action: model.action)
-                            .applyStepButtonAttributes(colorScheme: colorScheme)
+                            .keyboardShortcut(.defaultAction)
                             .padding(.top, 3)
                     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206958823796186/f
Tech Design URL:
CC:

**Description**:

This PR changes the onboarding button style to the default action style, to fix UX problems where the button doesn't appear clickable enough.

**Steps to test this PR**:
1. Run the app and get to VPN onboarding
2. Make sure that the onboarding button looks very obviously clickable

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
