### PR TITLE
Select URL in address bar when editing and use cmd+L

### DIFF
--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -318,7 +318,13 @@ extension MainViewController {
             os_log("MainViewController: Cannot reference address bar text field", type: .error)
             return
         }
-        addressBarTextField.makeMeFirstResponder()
+
+        // If the address bar is already the first responder it means that the user is editing the URL and wants to select the whole url.
+        if addressBarTextField.isFirstResponder {
+            addressBarTextField.selectText(nil)
+        } else {
+            addressBarTextField.makeMeFirstResponder()
+        }
     }
 
     @objc func closeTab(_ sender: Any?) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206969217970523/f

**Description**:
This PR aligns the behaviour of the macOS browser with the other browsers when editing the address bar and pressing cmd+L. At the moment when the user is inputting something in the address bar and presses cmd+l nothing happens.

**Steps to test this PR**:
Scenario 1: 
1. Load a page and left-click in some area of the web page.
2. Press cmd+l
Expected Result: The Address bar text field should become first responder.

Scenario 2: 
1. Input a url on the address bar.
2. Instead of loading the page press cmd+l
Expected Result: The whole text should be selected.

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
