### PR TITLE
add LSHandlerRank for .duckload document type

### DIFF
--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -43,6 +43,8 @@
 			<string>Editor</string>
 			<key>NSIsRelatedItemType</key>
 			<true/>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
 		</dict>
 	</array>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1206980087581641/f

**Description**:
- add missing LSHandlerRank to info.plist for `.duckload` document type

**Steps to test this PR**:
1. Validate Info.plist has LSHandlerRank for the `.duckload` document type

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
