### PR TITLE
Fixes the VPN restarting logic on update

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -599,15 +599,12 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             return
         }
 
-        await stop(tunnelManager: manager, disableOnDemand: true)
+        await stop(tunnelManager: manager)
     }
 
     @MainActor
-    private func stop(tunnelManager: NETunnelProviderManager, disableOnDemand: Bool) async {
-        if disableOnDemand {
-            // disable reconnect on demand if requested to stop
-            try? await self.disableOnDemand(tunnelManager: tunnelManager)
-        }
+    private func stop(tunnelManager: NETunnelProviderManager) async {
+        try? await self.disableOnDemand(tunnelManager: tunnelManager)
 
         switch tunnelManager.connection.status {
         case .connected, .connecting, .reasserting:
@@ -625,8 +622,11 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             return
         }
 
-        await stop(tunnelManager: manager, disableOnDemand: false)
+        await stop(tunnelManager: manager)
         await start()
+
+        // When restarting the tunnel we enable on-demand optimistically
+        try? await enableOnDemand(tunnelManager: manager)
     }
 
     // MARK: - On Demand & Kill Switch


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206999858530015/f

## Description:

I noticed that we're getting increased number of failures when a new version of our app is released.  After researching this I found that the mechanism we use for restarting the VPN can sometimes fail, but even if it doesn't fail it always fires failure pixels.

This is likely caused by the fact that not disabling on-demand makes the connection try to start while we're stopping it and starting it ourselves.

We'll now go back to disabling on-demand, but we'll now enable it optimistically right after starting the VPN again.

## Testing

Open Console.app, start the logging and filter by "👾"

1. Run the app once
2. Connect the VPN
3. Run the app again (in Debug this should cause the VPN to reconnect)
4. Make sure you don't see tunnel start failures in the logs
5. Make sure the VPN reconnects just fine.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
