### PR TITLE
Create a new window when making a feedback form if necessary

### DIFF
--- a/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -223,13 +223,19 @@ extension WindowControllersManager {
         let feedbackFormViewController = VPNFeedbackFormViewController()
         let feedbackFormWindowController = feedbackFormViewController.wrappedInWindowController()
 
-        guard let feedbackFormWindow = feedbackFormWindowController.window,
-              let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController else {
-            assertionFailure("Failed to present native VPN feedback form")
+        guard let feedbackFormWindow = feedbackFormWindowController.window else {
+            assertionFailure("Couldn't get window for feedback form")
             return
         }
 
-        parentWindowController.window?.beginSheet(feedbackFormWindow)
+        if let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController {
+            parentWindowController.window?.beginSheet(feedbackFormWindow)
+        } else {
+            let tabCollection = TabCollection(tabs: [])
+            let tabCollectionViewModel = TabCollectionViewModel(tabCollection: tabCollection)
+            let window = WindowsManager.openNewWindow(with: tabCollectionViewModel)
+            window?.beginSheet(feedbackFormWindow)
+        }
     }
 
     func showLocationPickerSheet() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207016420146353/f
Tech Design URL:
CC:

**Description**:

This PR makes sure that the VPN feedback form button always succeeds, even when there is no browser window available to display in. After the change, the VPN feedback option will open a new window if none was available.

(We should probably have some cleaner way to do that, since get-or-create-window seems like a pretty common operation. Maybe there is and I missed it?)

**Steps to test this PR**:
1. Run the app and make sure that the VPN menu bar item is running
2. Click the X button in the browser window to close it
3. Open the menu bar item and click "Send VPN feedback..."
4. Make sure that the browser window opens and the form appears

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
