### PR TITLE
Keep windows miniaturized upon relaunching

### DIFF
--- a/DuckDuckGo/StateRestoration/WindowManager+StateRestoration.swift
+++ b/DuckDuckGo/StateRestoration/WindowManager+StateRestoration.swift
@@ -52,7 +52,7 @@ extension WindowsManager {
     }
 
     private class func setUpWindow(from item: WindowRestorationItem) {
-        guard let window = openNewWindow(with: item.model, showWindow: true) else { return }
+        guard let window = openNewWindow(with: item.model, showWindow: !item.isMiniaturized, isMiniaturized: item.isMiniaturized) else { return }
         window.setContentSize(item.frame.size)
         window.setFrameOrigin(item.frame.origin)
     }
@@ -135,11 +135,13 @@ final class WindowRestorationItem: NSObject, NSSecureCoding {
     private enum NSSecureCodingKeys {
         static let frame = "frame"
         static let model = "model"
+        static let isMiniaturized = "isMiniaturized"
 
     }
 
     let model: TabCollectionViewModel
     let frame: NSRect
+    let isMiniaturized: Bool
 
     @MainActor
     init?(windowController: MainWindowController) {
@@ -150,6 +152,7 @@ final class WindowRestorationItem: NSObject, NSSecureCoding {
 
         self.frame = windowController.window!.frame
         self.model = windowController.mainViewController.tabCollectionViewModel
+        self.isMiniaturized = windowController.window!.isMiniaturized
     }
 
     static var supportsSecureCoding: Bool { true }
@@ -161,10 +164,12 @@ final class WindowRestorationItem: NSObject, NSSecureCoding {
         }
         self.model = model
         self.frame = coder.decodeRect(forKey: NSSecureCodingKeys.frame)
+        self.isMiniaturized = coder.decodeBool(forKey: NSSecureCodingKeys.isMiniaturized)
     }
 
     func encode(with coder: NSCoder) {
         coder.encode(frame, forKey: NSSecureCodingKeys.frame)
         coder.encode(model, forKey: NSSecureCodingKeys.model)
+        coder.encode(isMiniaturized, forKey: NSSecureCodingKeys.isMiniaturized)
     }
 }

--- a/DuckDuckGo/Windows/View/WindowsManager.swift
+++ b/DuckDuckGo/Windows/View/WindowsManager.swift
@@ -61,7 +61,8 @@ final class WindowsManager {
                              contentSize: NSSize? = nil,
                              showWindow: Bool = true,
                              popUp: Bool = false,
-                             lazyLoadTabs: Bool = false) -> MainWindow? {
+                             lazyLoadTabs: Bool = false,
+                             isMiniaturized: Bool = false) -> MainWindow? {
         let mainWindowController = makeNewWindow(tabCollectionViewModel: tabCollectionViewModel,
                                                  popUp: popUp,
                                                  burnerMode: burnerMode,
@@ -70,6 +71,8 @@ final class WindowsManager {
         if let contentSize {
             mainWindowController.window?.setContentSize(contentSize)
         }
+
+        mainWindowController.window?.setIsMiniaturized(isMiniaturized)
 
         if let droppingPoint {
             mainWindowController.window?.setFrameOrigin(droppingPoint: droppingPoint)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/276630244458377/1206774148393444/f
Tech Design URL:
CC:

**Description**:
Stores `isMiniaturized` property in `WindowRestorationItem` and applies to respective window during launch.

**Steps to test this PR**:
1. Open a bunch of windows (preferably with a loaded URL).
2. Minimize some of them.
3. Restart the app.
4. Previously miniaturized windows should reopen in the same state (visible only in dock).

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
