### PR TITLE
Removes last instance of NETWORK_PROTECTION flag

### DIFF
--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -191,9 +191,7 @@ final class MainViewController: NSViewController {
         browserTabViewController.windowDidBecomeKey()
         presentWaitlistThankYouPromptIfNecessary()
 
-#if NETWORK_PROTECTION
         refreshNetworkProtectionMessages()
-#endif
 
 #if DBP
         DataBrokerProtectionAppEvents().windowDidBecomeMain()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207025130407889/f

## Description

Removes last instance of `NETWORK_PROTECTION`.

## Testing

Just make sure the CI is green.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
