### PR TITLE
Update BSK with autofill 11.0.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14447,8 +14447,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 133.0.0;
+				kind = revision;
+				revision = 5f61de7efac9e0de4f81dcb415a2148c3d60e3ea;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207036666985255/1207036666985255
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/11.0.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/768

## Description
Updates Autofill to version [11.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/11.0.0).

### Autofill 11.0.0 release notes
## What's Changed
* It's a major version change, but the API change is only affecting Android.
* Android: enable iframe support by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/536


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.3.0...11.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).