### PR TITLE
Hotfixing an issue with VPN visibility for certain waitlist users

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -338,18 +338,26 @@ final class NavigationBarViewController: NSViewController {
         }
         #endif
 
-        // 1. If the user is on the waitlist but hasn't been invited or accepted terms and conditions, show the waitlist screen.
-        // 2. If the user has no waitlist state but has an auth token, show the NetP popover.
-        // 3. If the user has no state of any kind, show the waitlist screen.
+        // Note: the following code is quite contrived but we're aiming to hotfix issues without mixing subscription and
+        // waitlist logic.  This should be cleaned up once waitlist can safely be removed.
 
-        if NetworkProtectionWaitlist().shouldShowWaitlistViewController {
-            NetworkProtectionWaitlistViewControllerPresenter.show()
-            DailyPixel.fire(pixel: .networkProtectionWaitlistIntroDisplayed, frequency: .dailyAndCount)
-        } else if NetworkProtectionKeychainTokenStore().isFeatureActivated {
-            popovers.toggleNetworkProtectionPopover(usingView: networkProtectionButton, withDelegate: networkProtectionButtonModel)
+        if DefaultSubscriptionFeatureAvailability().isFeatureAvailable {
+            if NetworkProtectionKeychainTokenStore().isFeatureActivated {
+                popovers.toggleNetworkProtectionPopover(usingView: networkProtectionButton, withDelegate: networkProtectionButtonModel)
+            }
         } else {
-            NetworkProtectionWaitlistViewControllerPresenter.show()
-            DailyPixel.fire(pixel: .networkProtectionWaitlistIntroDisplayed, frequency: .dailyAndCount)
+            // 1. If the user is on the waitlist but hasn't been invited or accepted terms and conditions, show the waitlist screen.
+            // 2. If the user has no waitlist state but has an auth token, show the NetP popover.
+            // 3. If the user has no state of any kind, show the waitlist screen.
+
+            if NetworkProtectionWaitlist().shouldShowWaitlistViewController {
+                NetworkProtectionWaitlistViewControllerPresenter.show()
+                DailyPixel.fire(pixel: .networkProtectionWaitlistIntroDisplayed, frequency: .dailyAndCount)
+            } else if NetworkProtectionKeychainTokenStore().isFeatureActivated {
+                popovers.toggleNetworkProtectionPopover(usingView: networkProtectionButton, withDelegate: networkProtectionButtonModel)
+            } else {
+                NetworkProtectionWaitlistViewControllerPresenter.show()
+            }
         }
     }
 #endif

--- a/DuckDuckGo/Waitlist/NetworkProtectionFeatureDisabler.swift
+++ b/DuckDuckGo/Waitlist/NetworkProtectionFeatureDisabler.swift
@@ -76,6 +76,9 @@ final class NetworkProtectionFeatureDisabler: NetworkProtectionFeatureDisabling 
     @MainActor
     @discardableResult
     func disable(keepAuthToken: Bool, uninstallSystemExtension: Bool) async -> Bool {
+        // We can do this optimistically as it has little if any impact.
+        unpinNetworkProtection()
+
         // To disable NetP we need the login item to be running
         // This should be fine though as we'll disable them further down below
         guard canUninstall(includingSystemExtension: uninstallSystemExtension) else {
@@ -85,7 +88,6 @@ final class NetworkProtectionFeatureDisabler: NetworkProtectionFeatureDisabling 
         isDisabling = true
 
         defer {
-            unpinNetworkProtection()
             resetUserDefaults(uninstallSystemExtension: uninstallSystemExtension)
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207040067636855/f

## Description

Fixes an issue where some users were seeing waitlist UI when the subscription was avilable.

## Testing

1. Be a non-internal user
2. Sign up for waitlist but don't get an invite
3. Become an internal user
4. Purchase Privacy Pro
5. When trying to enable the VPN you'll see waitlist UI.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
