### PR TITLE
Hide the `DuckDuckGo on Other Platforms` section on the App Store

### DIFF
--- a/DuckDuckGo/Preferences/Model/PreferencesSection.swift
+++ b/DuckDuckGo/Preferences/Model/PreferencesSection.swift
@@ -49,7 +49,12 @@ struct PreferencesSection: Hashable, Identifiable {
             return panes
         }()
 
+#if APPSTORE
+        // App Store guidelines don't allow references to other platforms, so the Mac App Store build omits the otherPlatforms section.
+        let otherPanes: [PreferencePaneIdentifier] = [.about]
+#else
         let otherPanes: [PreferencePaneIdentifier] = [.about, .otherPlatforms]
+#endif
 
         var sections: [PreferencesSection] = [
             .init(id: .privacyProtections, panes: privacyPanes),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207033225544215/f
Tech Design URL:
CC:

**Description**:

This PR updates the "DuckDuckGo on Other Platforms" section of the Settings page to only show on Sparkle builds. This is done because Apple forbids references to other platforms on the App Store.

**Steps to test this PR**:
1. Run the Sparkle target and make sure that the "DuckDuckGo on Other Platforms" section appears in settings, and works as expected
2. Run the App Store target and check that "DuckDuckGo on Other Platforms" does not appear, you should only see the "About" section at the bottom

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
