### PR TITLE
[Release PR] Fix lottie high Windowserver load

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -222,6 +222,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         PrivacyFeatures.httpsUpgrade.loadDataAsync()
         bookmarksManager.loadBookmarks()
+
+        // Force use of .mainThread to prevent high WindowServer Usage
+        // Pending Fix with newer Lottie versions
+        // https://app.asana.com/0/1177771139624306/1207024603216659/f
+        LottieConfiguration.shared.renderingEngine = .mainThread
+
         if case .normal = NSApp.runType {
             FaviconManager.shared.loadFavicons()
         }

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -553,7 +553,13 @@ final class AddressBarButtonsViewController: NSViewController {
     }
 
     private func setupAnimationViews() {
-        func addAndLayoutAnimationViewIfNeeded(animationView: LottieAnimationView?, animationName: String, renderingEngine: Lottie.RenderingEngineOption = .automatic) -> LottieAnimationView {
+
+        func addAndLayoutAnimationViewIfNeeded(animationView: LottieAnimationView?,
+                                               animationName: String,
+                                               // Default use of .mainThread to prevent high WindowServer Usage
+                                               // Pending Fix with newer Lottie versions
+                                               // https://app.asana.com/0/1177771139624306/1207024603216659/f
+                                               renderingEngine: Lottie.RenderingEngineOption = .mainThread) -> LottieAnimationView {
             if let animationView = animationView, animationView.identifier?.rawValue == animationName {
                 return animationView
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1207024603216659/f
Tech Design URL:
CC:

**Description**:

This PR cherry pick's @afterxleep's changes to fix Lottie CPU usage. (https://github.com/duckduckgo/macos-browser/pull/2595)

**Steps to test this PR**:
1. See https://github.com/duckduckgo/macos-browser/pull/2595 for testing instructions
2. Also, check the diff of that same PR above and make sure it matches this PR

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
