### PR TITLE
Fix secure coding error

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
@@ -60,8 +60,8 @@ public class DataBrokerProtectionSchedulerErrorCollection: NSObject, NSSecureCod
     }
 
     public required init?(coder: NSCoder) {
-        oneTimeError = coder.decodeObject(forKey: NSSecureCodingKeys.oneTimeError) as? Error
-        operationErrors = coder.decodeObject(forKey: NSSecureCodingKeys.operationErrors) as? [Error]
+        oneTimeError = coder.decodeObject(of: NSError.self, forKey: NSSecureCodingKeys.oneTimeError)
+        operationErrors = coder.decodeArrayOfObjects(ofClass: NSError.self, forKey: NSSecureCodingKeys.operationErrors)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1207056719863102/f

**Description**:
Fix issue sending XPC messages on error

**Steps to test this PR**:
1. To make your life easier, delete all data brokers from the DBP package Resources/JSON and leave a single broker. Also, I recommend deleting the database on `/Library/Group\ Containers/HKE973VLUW.com.duckduckgo.macos.browser.dbp*`
2. Change the broker in a way that it's going to force an error, for example, changing a selector to something that doesn't exist ("selector": ".search-item", -> "selector": ".potato-item",)
3. Run the scan flow using the normal user flow making sure you're debugging the background agent
4. Add a breakpoint on https://github.com/duckduckgo/macos-browser/blob/4a45c4bdc74c06c99d89e3a846267d93c21426a4/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift#L64 to make sure errors are returning
5. Run the scan to completion, it shouldn't throw any crash or assertion 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
