### PR TITLE
Fix popover not displayed reliably when VPN shortcut is unpinned

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -973,6 +973,7 @@ extension NavigationBarViewController: NSMenuDelegate {
             .store(in: &cancellables)
 
         networkProtectionButtonModel.$showButton
+            .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { [weak self] show in
                 let isPopUpWindow = self?.view.window?.isPopUpWindow ?? false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1207059171151302/f
Tech Design URL:
CC:

**Description**:

When the VPN shortcut is unpinned & the user tries to open the popover from the More Options menu, the temporarily shown VPN shortcut is hidden prematurely and (?) cause the popover to be closed right away.

**Steps to test this PR**:
1. Unpin the VPN shortcut
2. Try opening the VPN popover
3. It should work 100% of the time

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
