### PR TITLE
Remove obsolete second subscription and entitlement refresh call

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionAppEvents.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionAppEvents.swift
@@ -81,10 +81,6 @@ final class NetworkProtectionAppEvents {
     func applicationDidBecomeActive() {
         Task { @MainActor in
             await featureVisibility.disableIfUserHasNoAccess()
-
-#if SUBSCRIPTION
-            await AccountManager(subscriptionAppGroup: Bundle.main.appGroup(bundle: .subs)).refreshSubscriptionAndEntitlements()
-#endif
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203936086921904/1207025896069381/f

**Description**:
The following call is obsolete as subscription and entitlement refresh is already handled AppDelegate. Additionally refreshSubscriptionAndEntitlements() method is deprecated and going to be removed as it has baked in side effect of signing out user when the subscription is found expired.

**Steps to test this PR**:
1. Purchase or activate subscription
2. Make app inactive and active again
3. Ensure that there are singular calls to auth and subscription endpoints for fetching entitlements and subscription infor

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
