### PR TITLE
DBP: Send url on search pixels

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProfileQueryOperationManager.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProfileQueryOperationManager.swift
@@ -118,7 +118,7 @@ struct DataBrokerProfileQueryOperationManager: OperationsManager {
         }
 
         let eventPixels = DataBrokerProtectionEventPixels(database: database, handler: pixelHandler)
-        let stageCalculator = DataBrokerProtectionStageDurationCalculator(dataBroker: brokerProfileQueryData.dataBroker.name, handler: pixelHandler)
+        let stageCalculator = DataBrokerProtectionStageDurationCalculator(dataBroker: brokerProfileQueryData.dataBroker.url, handler: pixelHandler)
 
         do {
             let event = HistoryEvent(brokerId: brokerId, profileQueryId: profileQueryId, type: .scanStarted)


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1199230911884351/1207064601474190/f
Tech Design URL:
CC:

**Description**:
Send URL instead of name. This was fixed before, but I was introduced again in a bad merge.

**Steps to test this PR**:
1. Check that the stage calculator is initialized with the broker URL instead of the name when doing scans.