### PR TITLE
prevent target=_blank links in duckplayer

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -131,6 +131,17 @@ extension DuckPlayerTabExtension: YoutubeOverlayUserScriptDelegate {
 extension DuckPlayerTabExtension: NewWindowPolicyDecisionMaker {
 
     func decideNewWindowPolicy(for navigationAction: WKNavigationAction) -> NavigationDecision? {
+        // if a link was clicked inside duckplayer (like a recommendation)
+        // and has target=_blank - then we want to prevent a new tab
+        // opening, and just load it inside the current one instead
+        if navigationAction.targetFrame == nil,
+           navigationAction.safeSourceFrame?.webView?.url?.isDuckPlayer == true,
+           navigationAction.request.url?.isYoutubeVideoRecommendation == true,
+           let webView, let url = navigationAction.request.url {
+            webView.load(URLRequest(url: url))
+            return .cancel
+        }
+
         if let shouldSelectNextNewTab {
             defer {
                 self.shouldSelectNextNewTab = nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206957893781167/f
Tech Design URL:
CC:

**Description**:

The goal of this PR is to alter how URLs are handled within DuckPlayer, especially those opening in a new tab like video recommendations. Now, instead of being opened in a new tab, these URLs will be loaded within DuckPlayer itself. The changes mainly involve adding a new case 'preventTargetBlank' to the NavigationDecision enum and implementing it in decideNewWindowPolicy method in DuckPlayerTabExtension.

**Steps to test this PR**:
1. watch a video in duck player 
2. at the end, click a recommended link
3. it should load in the same tab

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
