### PR TITLE
Update the title capitalization style

### DIFF
--- a/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/UserText.swift
+++ b/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/UserText.swift
@@ -75,7 +75,7 @@ enum UserText {
     static let haveSubscriptionButton = NSLocalizedString("subscription.preferences.i.have.a.subscription.button", value: "I Have a Subscription", comment: "Button enabling user to activate a subscription user bought earlier or on another device")
 
     // MARK: Preferences when subscription activation is pending
-    static let preferencesSubscriptionPendingHeader = NSLocalizedString("subscription.preferences.subscription.pending.header", value: "Your Subscription is Being Activated", comment: "Header for the subscription preferences pane when the subscription activation is pending")
+    static let preferencesSubscriptionPendingHeader = NSLocalizedString("subscription.preferences.subscription.pending.header", value: "Your subscription is being activated", comment: "Header for the subscription preferences pane when the subscription activation is pending")
     static let preferencesSubscriptionPendingCaption = NSLocalizedString("subscription.preferences.subscription.pending.caption", value: "This is taking longer than usual, please check back later.", comment: "Caption for the subscription preferences pane when the subscription activation is pending")
 
     // MARK: Preferences when subscription is expired


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206924693423599/f

**Description**:
"Your subscription is being activated" should be in sentence case.

**Steps to test this PR**:
Getting the "Your subscription is being activated" state during subscription purchase may be hard to replicate as it requires BE failure.
To force trigger the state, please hardcode for the `statePublisher`  in `PreferencesSubscriptionModel` to always return `PreferencesSubscriptionState.subscriptionPendingActivation`.



---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
