### PR TITLE
Fix an issue where the origin sent in the pixel would be empty due to…

### DIFF
--- a/.github/workflows/create_variant.yml
+++ b/.github/workflows/create_variant.yml
@@ -120,7 +120,7 @@ jobs:
       run: |
         codesign -d --entitlements :- DuckDuckGo.app > entitlements.plist
         echo "${{ env.ATB_VARIANT_NAME }}" > "DuckDuckGo.app/Contents/Resources/variant.txt"
-        echo "${{ env.ORIGIN_VARIANT_NAME }}" > "DuckDuckGo.app/Contents/Resources/origin.txt"
+        echo "${{ env.ORIGIN_VARIANT_NAME }}" > "DuckDuckGo.app/Contents/Resources/Origin.txt"
         sign_identity="$(security find-certificate -a -c "Developer ID Application" -Z | grep ^SHA-1 | cut -d " " -f3 | uniq)"
 
         /usr/bin/codesign \


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207084618662354/f

**Description**:
Fix an issue where the Installation Attribution origin sent with the pixel is empty due to the wrong file referenced to read its value.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)