### PR TITLE
Fix broken back navigation on Privacy Pro purchase page after redirect

### DIFF
--- a/DuckDuckGo/Tab/Navigation/RedirectNavigationResponder.swift
+++ b/DuckDuckGo/Tab/Navigation/RedirectNavigationResponder.swift
@@ -40,7 +40,7 @@ struct RedirectNavigationResponder: NavigationResponder {
             let shouldHidePrivacyProDueToNoProducts = SubscriptionPurchaseEnvironment.current == .appStore && SubscriptionPurchaseEnvironment.canPurchase == false
             let isPurchasePageRedirectActive = isFeatureAvailable && !shouldHidePrivacyProDueToNoProducts
 
-            return isPurchasePageRedirectActive ? URL.subscriptionPurchase : nil
+            return isPurchasePageRedirectActive ? URL.subscriptionBaseURL : nil
         }
 
         return nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1207085358710521/f

**Description**:
Fix broken back navigation on Privacy Pro purchase page after redirect

**Steps to test this PR**:
1. Go to the launch blog post preview: https://spreadprivacy.com/meetprivacypro/
2. Click on a “duckduckgo.com/pro” link to load the PP landing page.
3. Click the browser’s back button.



---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
