### PR TITLE
VPN: Replace available interfaces in VPN metadata

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14543,8 +14543,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 0921e440364d660aad76be28d6fc128d5a35f677;
+				kind = exactVersion;
+				version = "134.1.0-1";
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "0921e440364d660aad76be28d6fc128d5a35f677"
+        "revision" : "543398a776f522998918eefd3df4150fae041838",
+        "version" : "134.1.0-1"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "134.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "134.1.0-1"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "134.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "134.1.0-1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../LoginItems"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "134.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "134.1.0-1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207087903608440/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2750
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/782

## Description

Removes `availableInterfaces` from VPN metadata and instead replaces it with the type of the first available interface, a count of tunnels and DNS interfaces.

## Testing

1. Send feedback
2. Place a breakpoint [here](https://github.com/duckduckgo/BrowserServicesKit/pull/782/files#diff-23f00201585daed436d5fbd92aa32966dbe3fb89c17fe2a67ef5313629d0fb5aR175) to `po` the description.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
