### PR TITLE
Fix DBP debug logging using wrong type for arguments

### DIFF
--- a/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionDebugMenu.swift
@@ -211,7 +211,7 @@ final class DataBrokerProtectionDebugMenu: NSMenu {
                 }
                 if let operationErrors = errors.operationErrors,
                           operationErrors.count != 0 {
-                    os_log("Queued operations finished, operation errors count: %{public}@", log: .dataBrokerProtection, operationErrors.count)
+                    os_log("Queued operations finished, operation errors count: %{public}d", log: .dataBrokerProtection, operationErrors.count)
                 }
             } else {
                 os_log("Queued operations finished", log: .dataBrokerProtection)
@@ -226,11 +226,11 @@ final class DataBrokerProtectionDebugMenu: NSMenu {
         DataBrokerProtectionManager.shared.scheduler.scanAllBrokers(showWebView: showWebView) { errors in
             if let errors = errors {
                 if let oneTimeError = errors.oneTimeError {
-                    os_log("scan operations finished,  error: %{public}@", log: .dataBrokerProtection, oneTimeError.localizedDescription)
+                    os_log("scan operations finished, error: %{public}@", log: .dataBrokerProtection, oneTimeError.localizedDescription)
                 }
                 if let operationErrors = errors.operationErrors,
                           operationErrors.count != 0 {
-                    os_log("scan operations finished, operation errors count: %{public}@", log: .dataBrokerProtection, operationErrors.count)
+                    os_log("scan operations finished, operation errors count: %{public}d", log: .dataBrokerProtection, operationErrors.count)
                 }
             } else {
                 os_log("Scan operations finished", log: .dataBrokerProtection)
@@ -249,7 +249,7 @@ final class DataBrokerProtectionDebugMenu: NSMenu {
                 }
                 if let operationErrors = errors.operationErrors,
                           operationErrors.count != 0 {
-                    os_log("Optout operations finished, operation errors count: %{public}@", log: .dataBrokerProtection, operationErrors.count)
+                    os_log("Optout operations finished, operation errors count: %{public}d", log: .dataBrokerProtection, operationErrors.count)
                 }
             } else {
                 os_log("Optout operations finished", log: .dataBrokerProtection)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207087120335153/f
Tech Design URL:
CC:

**Description**:
Small and straightforward, fixes some argument types being wrong in some os_log statements. in the debug menu

**Steps to test this PR**:
1. Run each type of DBP operation from the debug menu, and test that the os log correctly prints the count of operation errors

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
