### PR TITLE
Add XPC reregistering to DBP in an attempt to reduce our xpc error rate

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/IPC/DataBrokerProtectionIPCClient.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/IPC/DataBrokerProtectionIPCClient.swift
@@ -65,6 +65,18 @@ public final class DataBrokerProtectionIPCClient: NSObject {
         super.init()
 
         xpc.delegate = self
+        xpc.onDisconnect = { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                try await Task.sleep(interval: .seconds(1))
+                // By calling register we make sure that XPC will connect as soon as it
+                // becomes available again, as requests are queued.  This helps ensure
+                // that the client app will always be connected to XPC.
+                self.register()
+            }
+        }
+
+        self.register()
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207093119500799/f
Tech Design URL:
CC:

**Description**:
Add XPC reregistering to DBP in an attempt to reduce our xpc error rate. Should be exactly the same logic as with NetP.

**Steps to test this PR**:
1. Really go ham on trying to break xpc. Go through the DBP process, put the machine to sleep and do it again. Spam the call to ScanAllBrokers(), really whatever you can think to stress test it.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
