### PR TITLE
Fix Address Bar unfocusing

### DIFF
--- a/DuckDuckGo/Common/Extensions/NSPointExtension.swift
+++ b/DuckDuckGo/Common/Extensions/NSPointExtension.swift
@@ -20,6 +20,12 @@ import Foundation
 
 extension NSPoint {
 
+    func distance(to point: NSPoint) -> CGFloat {
+        let deltaX = self.x - point.x
+        let deltaY = self.y - point.y
+        return sqrt(deltaX * deltaX + deltaY * deltaY)
+    }
+
     func isNearRect(_ rect: NSRect, allowedDistance: CGFloat) -> Bool {
         let expandedRect = rect.insetBy(dx: -allowedDistance, dy: -allowedDistance)
         return expandedRect.contains(self)

--- a/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -168,12 +168,7 @@ final class AddressBarViewController: NSViewController {
             return true
         }
 
-        // If the webview doesn't have content it doesn't handle becoming the first responder properly
-        if tabViewModel?.tab.webView.url != nil {
-            tabViewModel?.tab.webView.makeMeFirstResponder()
-        } else {
-            view.superview?.becomeFirstResponder()
-        }
+        view.window?.makeFirstResponder(nil)
 
         return true
     }
@@ -496,12 +491,16 @@ extension AddressBarViewController {
         return event
     }
 
+    private static let maxClickReleaseDistanceToResignFirstResponder: CGFloat = 4
+
     func mouseUp(with event: NSEvent) -> NSEvent? {
         // click (same position down+up) outside of the field: resign first responder
         guard event.window === self.view.window,
               self.view.window?.firstResponder === addressBarTextField.currentEditor(),
-              self.clickPoint == event.locationInWindow
-        else { return event }
+              let clickPoint,
+              clickPoint.distance(to: event.locationInWindow) <= Self.maxClickReleaseDistanceToResignFirstResponder else {
+            return event
+        }
 
         self.view.window?.makeFirstResponder(nil)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207078378083701/f

**Description**:
- Fixes unfocusing Address Bar on Esc/loose click outside when Settings page is active

**Steps to test this PR**:
1. Open Settings
2. Activate Address Bar
3. Loosely click in the Settings pane, validate address bar is deactivated
4. Hit Esc, validate address bar is deactivated
5. Validate on other pages (home tab, bookmarks, regular website - should set focus to the web view)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
