### PR TITLE
Remave semaphore on debug screen

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONViewModel.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONViewModel.swift
@@ -184,18 +184,14 @@ final class DataBrokerRunCustomJSONViewModel: ObservableObject {
 
         Task.detached {
             var scanResults = [DebugScanReturnValue]()
-            let semaphore = DispatchSemaphore(value: 10)
+
             try await withThrowingTaskGroup(of: DebugScanReturnValue.self) { group in
                 for queryData in brokerProfileQueryData {
-                    semaphore.wait()
                     let debugScanOperation = DebugScanOperation(privacyConfig: self.privacyConfigManager, prefs: self.contentScopeProperties, query: queryData) {
                         true
                     }
 
                     group.addTask {
-                        defer {
-                            semaphore.signal()
-                        }
                         do {
                             return try await debugScanOperation.run(inputValue: (), showWebView: false)
                         } catch {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1206968294847278/f
Tech Design URL:
CC:

**Description**:
Removes the semaphore usage on the debug PIR screen. The max concurrent to 10 is not needed, I added it because I thought it was causing an issue, but the issue ended up being something else

**Steps to test this PR**:
1. check there is no warning in the `DataBrokerRunCustomJSONViewModel`