### PR TITLE
Remove "Thank You" prompts

### DIFF
--- a/DuckDuckGo/HomePage/Model/HomePageContinueSetUpModel.swift
+++ b/DuckDuckGo/HomePage/Model/HomePageContinueSetUpModel.swift
@@ -124,8 +124,6 @@ extension HomePage.Models {
 
         lazy var statisticsStore: StatisticsStore = LocalStatisticsStore()
 
-        lazy var waitlistBetaThankYouPresenter = WaitlistThankYouPromptPresenter()
-
         lazy var listOfFeatures = isFirstSession ? firstRunFeatures : randomisedFeatures
 
         private var featuresMatrix: [[FeatureType]] = [[]] {
@@ -191,18 +189,9 @@ extension HomePage.Models {
 #if DBP
                 DataBrokerProtectionAppEvents().handleWaitlistInvitedNotification(source: .cardUI)
 #endif
-            case .vpnThankYou:
-                guard let window = NSApp.keyWindow,
-                      case .normal = NSApp.runType else { return }
-                waitlistBetaThankYouPresenter.presentVPNThankYouPrompt(in: window)
-            case .pirThankYou:
-                guard let window = NSApp.keyWindow,
-                      case .normal = NSApp.runType else { return }
-                waitlistBetaThankYouPresenter.presentPIRThankYouPrompt(in: window)
             }
         }
 
-        // swiftlint:disable:next cyclomatic_complexity
         func removeItem(for featureType: FeatureType) {
             switch featureType {
             case .defaultBrowser:
@@ -227,10 +216,6 @@ extension HomePage.Models {
 #endif
             case .dataBrokerProtectionWaitlistInvited:
                 shouldShowDBPWaitlistInvitedCardUI = false
-            case .vpnThankYou:
-                waitlistBetaThankYouPresenter.didDismissVPNThankYouCard()
-            case .pirThankYou:
-                waitlistBetaThankYouPresenter.didDismissPIRThankYouCard()
             }
             refreshFeaturesMatrix()
         }
@@ -258,14 +243,6 @@ extension HomePage.Models {
                     pixel: .networkProtectionRemoteMessageDisplayed(messageID: message.id),
                     frequency: .dailyOnly
                 )
-            }
-
-            if waitlistBetaThankYouPresenter.canShowVPNCard {
-                features.append(.vpnThankYou)
-            }
-
-            if waitlistBetaThankYouPresenter.canShowPIRCard {
-                features.append(.pirThankYou)
             }
 
             for feature in listOfFeatures {
@@ -297,9 +274,7 @@ extension HomePage.Models {
                     }
                 case .networkProtectionRemoteMessage,
                         .dataBrokerProtectionRemoteMessage,
-                        .dataBrokerProtectionWaitlistInvited,
-                        .vpnThankYou,
-                        .pirThankYou:
+                        .dataBrokerProtectionWaitlistInvited:
                     break // Do nothing, these messages get appended first
                 }
             }
@@ -507,8 +482,6 @@ extension HomePage.Models {
         case networkProtectionRemoteMessage(NetworkProtectionRemoteMessage)
         case dataBrokerProtectionRemoteMessage(DataBrokerProtectionRemoteMessage)
         case dataBrokerProtectionWaitlistInvited
-        case vpnThankYou
-        case pirThankYou
 
         var title: String {
             switch self {
@@ -530,10 +503,6 @@ extension HomePage.Models {
                 return message.cardTitle
             case .dataBrokerProtectionWaitlistInvited:
                 return "Personal Information Removal"
-            case .vpnThankYou:
-                return "Thanks for testing DuckDuckGo VPN!"
-            case .pirThankYou:
-                return "Thanks for testing Personal Information Removal!"
             }
         }
 
@@ -557,10 +526,6 @@ extension HomePage.Models {
                 return message.cardDescription
             case .dataBrokerProtectionWaitlistInvited:
                 return "You're invited to try Personal Information Removal beta!"
-            case .vpnThankYou:
-                return "To keep using it, subscribe to DuckDuckGo Privacy Pro."
-            case .pirThankYou:
-                return "To keep using it, subscribe to DuckDuckGo Privacy Pro."
             }
         }
 
@@ -584,10 +549,6 @@ extension HomePage.Models {
                 return message.action.actionTitle
             case .dataBrokerProtectionWaitlistInvited:
                 return "Get Started"
-            case .vpnThankYou:
-                return "See Special Offer For Testers"
-            case .pirThankYou:
-                return "See Special Offer For Testers"
             }
         }
 
@@ -612,10 +573,6 @@ extension HomePage.Models {
             case .dataBrokerProtectionRemoteMessage:
                 return .dbpInformationRemover.resized(to: iconSize)!
             case .dataBrokerProtectionWaitlistInvited:
-                return .dbpInformationRemover.resized(to: iconSize)!
-            case .vpnThankYou:
-                return .vpnEnded.resized(to: iconSize)!
-            case .pirThankYou:
                 return .dbpInformationRemover.resized(to: iconSize)!
             }
         }

--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -188,7 +188,6 @@ final class MainViewController: NSViewController {
         updateReloadMenuItem()
         updateStopMenuItem()
         browserTabViewController.windowDidBecomeKey()
-        presentWaitlistThankYouPromptIfNecessary()
 
         refreshNetworkProtectionMessages()
 
@@ -428,16 +427,6 @@ final class MainViewController: NSViewController {
             return
         }
         NSApp.mainMenuTyped.stopMenuItem.isEnabled = selectedTabViewModel.isLoading
-    }
-
-    func presentWaitlistThankYouPromptIfNecessary() {
-        guard let window = self.view.window else {
-            assertionFailure("Couldn't get main view controller's window")
-            return
-        }
-
-        let presenter = WaitlistThankYouPromptPresenter()
-        presenter.presentThankYouPromptIfNecessary(in: window)
     }
 
     // MARK: - First responder


### PR DESCRIPTION
This only removes the calls to show the prompts themselves. All of the UI classes and copy will be cleaned up on the main branch, this is done to keep the release branch change as small as possible.

Task/Issue URL: https://app.asana.com/0/1199230911884351/1207105265255740/f
Tech Design URL:
CC:

**Description**:

This PR removes the Thank You prompts that are presented to waitlist users.

This is being done because the code is being taken down on the Stripe side next week, so we should no longer show the prompt to waitlist users who haven't yet upgraded.

**Steps to test this PR**:
1. Change `canShowPromptCheck()` to always return `true` and check that the prompt doesn't appear when you launch the app
2. Also check that no Thank You cards are displayed on the new tab page

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
