### PR TITLE
fix objc_retain called with Tab in cleanup on deinit

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -356,7 +356,6 @@ protocol NewWindowPolicyDecisionMaker {
         self.extensions[keyPath: keyPath]
     }
 
-    @Published
     private(set) var userContentController: UserContentController?
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206959015087322/f

**Description**:
- fixes objc_retain called with Tab in cleanup on deinit

**Steps to test this PR**:
1. Launch the browser (prefer testing in `RELEASE`/`REVIEW`)
2. Set a breakpoint at `Tab.swift:339` (`func cleanUpBeforeClosing`)
3. Open new window and instantly close it
4. When the breakpoint is hit, add a symbolic breakpoint for `objc_retain` symbol
5. Run through the `objc_retain` breakpoint hits and validate `retain` is only called against `UserContentController` and `WebView` and not against the `Tab` (by calling `po $arg1` in xcode console)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
