### PR TITLE
fix history items duplicated for same-document navigations

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/HistoryTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/HistoryTabExtension.swift
@@ -205,7 +205,7 @@ extension HistoryTabExtension: NavigationResponder {
     }
 
     func navigation(_ navigation: Navigation, didSameDocumentNavigationOf navigationType: WKSameDocumentNavigationType) {
-        if navigation.isCurrent, navigationType != .sessionStatePop {
+        if navigation.isCurrent, [.sessionStatePush, .anchorNavigation].contains(navigationType) {
             self.url = navigation.navigationAction.url
             addVisit()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1207052244290895/f

**Description**:
- Fixes same-document navigations causing history items duplication

**Steps to test this PR**:
1. Open SERP, search for something - validate SERP pages are not duplicated in the History menu
2. Open youtube, browse through videos - validate every video ends up in the History menu

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
