### PR TITLE
Fix incorrect branded UA

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -120,7 +120,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "46989693916f56d1186bd59ac15124caef896560",
         "version" : "1.3.1"

--- a/DuckDuckGo/UserAgent/Model/UserAgent.swift
+++ b/DuckDuckGo/UserAgent/Model/UserAgent.swift
@@ -51,7 +51,7 @@ extension UserAgent {
         return version
     }()
 
-    static let ddgVersion: String = safariVersion.appending(" Ddg/\(safariVersion)")
+    static let ddgVersion: String = "Ddg/\(safariVersion)"
 
     // MARK: - User Agents
 
@@ -66,7 +66,7 @@ extension UserAgent {
         "Safari/537.36"
     static let `default` = UserAgent.safari
     static let webViewDefault = ""
-    static let brandedDefault = Self.default.appending(ddgVersion)
+    static let brandedDefault = "\(Self.default) \(ddgVersion)"
 
     static let localUserAgentConfiguration: KeyValuePairs<RegEx, String> = [
         // use safari when serving up PDFs from duckduckgo directly

--- a/UnitTests/UserAgent/Model/UserAgentTests.swift
+++ b/UnitTests/UserAgent/Model/UserAgentTests.swift
@@ -72,6 +72,15 @@ final class UserAgentTests: XCTestCase {
         XCTAssertNotEqual(UserAgent.for("https://duckduckgo.com".url, privacyConfig: config), UserAgent.webViewDefault)
     }
 
+    func testWhenDefaultPolicyIsBrandThenBrandedUserAgentIsUsed() {
+        let config = MockPrivacyConfiguration()
+        config.featureSettings = [
+            "defaultPolicy": "brand"
+        ] as! [String: Any]
+
+        XCTAssertEqual(UserAgent.for("http://wikipedia.org".url, privacyConfig: config), UserAgent.brandedDefault)
+    }
+
     func testThatRemoteConfigurationTakesPrecedenceOverLocalConfiguration() {
         let config = MockPrivacyConfiguration()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1207102109845550/f
CC: @jonathanKingston 

**Description**:
Fix incorrect branded UA

**Steps to test this PR**:
1. Open any site and check if the UA is equal to "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15"