### PR TITLE
Fix updating window title from selected tab title

### DIFF
--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -306,7 +306,7 @@ final class MainViewController: NSViewController {
         guard let selectedTabViewModel else { return }
 
         // Only subscribe once the view is added to the window.
-        let windowPublisher = view.publisher(for: \.window).filter({ $0 != nil }).prefix(1)
+        let windowPublisher = view.publisher(for: \.window).filter({ $0 != nil }).prefix(1).asVoid()
 
         windowPublisher
             .combineLatest(selectedTabViewModel.$title) { $1 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206849846085672/f

**Description**:
When main window subscribes to selected tab view model changes and it's not yet on the screen
(this happens on window creation - during state restoration or opening a new window), subscribe
to selected tab view model's title updates only when the window is added to the screen.

**Steps to test this PR**:
1. Run the release app. Verify that Main Menu -> Window (or Dock icon context menu) doesn't show the window list.
2. Run the app from Xcode. Verify that Main Menu -> Window and Dock icon context menu show the window list.
3. Open a new window. Verify that windows menu lists all open windows.
4. Drag a tab to create a new window. Verify that windows menu lists all open windows.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
