### PR TITLE
Update "Autofill" to "Passwords & Autofill” in Relevant UI

### DIFF
--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -415,7 +415,6 @@ struct UserText {
     static let downloadsOpenPopupOnCompletion = NSLocalizedString("downloads.open.on.completion", value: "Automatically open the Downloads panel when downloads complete", comment: "Checkbox to open a Download Manager popover when downloads are completed")
 
     // MARK: Password Manager
-    static let passwordManagement = NSLocalizedString("passsword.management", value: "Autofill", comment: "Used as title for password management user interface")
     static let passwordManagementAllItems = NSLocalizedString("passsword.management.all-items", value: "All Items", comment: "Used as title for the Autofill All Items option")
     static let passwordManagementLogins = NSLocalizedString("passsword.management.logins", value: "Passwords", comment: "Used as title for the Autofill Logins option")
     static let passwordManagementIdentities = NSLocalizedString("passsword.management.identities", value: "Identities", comment: "Used as title for the Autofill Identities option")
@@ -434,6 +433,7 @@ struct UserText {
         let localized = NSLocalizedString("passsword.management.save.credentials.account.label", value: "Connected to %@", comment: "In the password manager dialog, label that specifies the password manager vault we are connected with")
         return String(format: localized, activeVault)
     }
+    static let passwordManagementTitle = NSLocalizedString("password.management.title", value: "Passwords & Autofill", comment: "Used as the title for menu item and related Settings page")
     static let settingsSuspended = NSLocalizedString("Settings…", comment: "Menu item")
     static let passwordManagerUnlockAutofill = NSLocalizedString("passsword.manager.unlock.autofill", value: "Unlock your Autofill info", comment: "In the password manager text of button to unlock autofill info")
     static let passwordManagerEmptyStateTitle = NSLocalizedString("passsword.manager.empty.state.title", value: "No logins or credit card info yet", comment: "In the password manager title when there are no items")

--- a/DuckDuckGo/Localizable.xcstrings
+++ b/DuckDuckGo/Localizable.xcstrings
@@ -33361,7 +33361,7 @@
     },
     "passsword.management" : {
       "comment" : "Used as title for password management user interface",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -35074,6 +35074,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не удалось импортировать пароли."
+          }
+        }
+      }
+    },
+    "password.management.title" : {
+      "comment" : "Used as the title for menu item and related Settings page",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Passwords & Autofill"
           }
         }
       }

--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -273,7 +273,7 @@ final class MoreOptionsMenu: NSMenu {
         let loginsSubMenu = LoginsSubMenu(targetting: self,
                                           passwordManagerCoordinator: passwordManagerCoordinator)
 
-        addItem(withTitle: UserText.passwordManagement, action: #selector(openAutofillWithAllItems), keyEquivalent: "")
+        addItem(withTitle: UserText.passwordManagementTitle, action: #selector(openAutofillWithAllItems), keyEquivalent: "")
             .targetting(self)
             .withImage(.passwordManagement)
             .withSubmenu(loginsSubMenu)
@@ -610,7 +610,7 @@ final class ZoomSubMenu: NSMenu {
 final class BookmarksSubMenu: NSMenu {
 
     init(targetting target: AnyObject, tabCollectionViewModel: TabCollectionViewModel) {
-        super.init(title: UserText.passwordManagement)
+        super.init(title: UserText.passwordManagementTitle)
         self.autoenablesItems = false
         addMenuItems(with: tabCollectionViewModel, target: target)
     }
@@ -708,7 +708,7 @@ final class LoginsSubMenu: NSMenu {
 
     init(targetting target: AnyObject, passwordManagerCoordinator: PasswordManagerCoordinating) {
         self.passwordManagerCoordinator = passwordManagerCoordinator
-        super.init(title: UserText.passwordManagement)
+        super.init(title: UserText.passwordManagementTitle)
         updateMenuItems(with: target)
     }
 

--- a/DuckDuckGo/Preferences/Model/PreferencesSection.swift
+++ b/DuckDuckGo/Preferences/Model/PreferencesSection.swift
@@ -167,7 +167,7 @@ enum PreferencePaneIdentifier: String, Equatable, Hashable, Identifiable {
         case .subscription:
             return UserText.subscription
         case .autofill:
-            return UserText.autofill
+            return UserText.passwordManagementTitle
         case .accessibility:
             return UserText.accessibility
         case .duckPlayer:

--- a/DuckDuckGo/Preferences/View/PreferencesAutofillView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesAutofillView.swift
@@ -63,7 +63,7 @@ extension Preferences {
         }
 
         var body: some View {
-            PreferencePane(UserText.autofill) {
+            PreferencePane(UserText.passwordManagementTitle) {
 
                 // Autofill Content  Button
                 PreferencePaneSection {

--- a/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -203,7 +203,7 @@ final class PasswordManagementViewController: NSViewController {
         deleteAllPasswordsMenuItem.title = UserText.deleteAllPasswords
         settingsMenuItem.title = UserText.settingsSuspended
         unlockYourAutofillLabel.title = UserText.passwordManagerUnlockAutofill
-        autofillTitleLabel.stringValue = UserText.autofill
+        autofillTitleLabel.stringValue = UserText.passwordManagementTitle
         emptyStateTitle.stringValue = UserText.pmEmptyStateDefaultTitle
         emptyStateMessage.stringValue = UserText.pmEmptyStateDefaultDescription
         emptyStateButton.title = UserText.importData

--- a/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -82,7 +82,7 @@ final class MoreOptionsMenuTests: XCTestCase {
         XCTAssertTrue(moreOptionMenu.items[7].isSeparatorItem)
         XCTAssertEqual(moreOptionMenu.items[8].title, UserText.bookmarks)
         XCTAssertEqual(moreOptionMenu.items[9].title, UserText.downloads)
-        XCTAssertEqual(moreOptionMenu.items[10].title, UserText.passwordManagement)
+        XCTAssertEqual(moreOptionMenu.items[10].title, UserText.passwordManagementTitle)
         XCTAssertTrue(moreOptionMenu.items[11].isSeparatorItem)
         XCTAssertEqual(moreOptionMenu.items[12].title, UserText.emailOptionsMenuItem)
 
@@ -118,7 +118,7 @@ final class MoreOptionsMenuTests: XCTestCase {
         XCTAssertTrue(moreOptionMenu.items[7].isSeparatorItem)
         XCTAssertEqual(moreOptionMenu.items[8].title, UserText.bookmarks)
         XCTAssertEqual(moreOptionMenu.items[9].title, UserText.downloads)
-        XCTAssertEqual(moreOptionMenu.items[10].title, UserText.passwordManagement)
+        XCTAssertEqual(moreOptionMenu.items[10].title, UserText.passwordManagementTitle)
         XCTAssertTrue(moreOptionMenu.items[11].isSeparatorItem)
         XCTAssertEqual(moreOptionMenu.items[12].title, UserText.emailOptionsMenuItem)
         XCTAssertTrue(moreOptionMenu.items[13].isSeparatorItem)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207044475588305/f

**Description**:
* Update “Autofill” to “Passwords & Autofill” in:
   * Overflow menu
   * Autofill dialog title
   * Settings sidebar
   * Settings page title 

**Steps to test this PR**:
1. Open overflow menu -> Ensure title for autofill is “Passwords & Autofill”
2. Open Autofill dialog -> Ensure title is “Passwords & Autofill”
3. Open Settings -> Ensure title for autofill sidebar menu item is “Passwords & Autofill”
4. Open Settings/Passwords & Autofill -> Ensure title is “Passwords & Autofill"

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
