### PR TITLE
Password Settings Page Updates

### DIFF
--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -394,7 +394,7 @@ struct UserText {
     static let autofillViewContentButtonPasswords = NSLocalizedString("autofill.view-autofill-content.passwords", value: "View Passwords…", comment: "View Password Content Button title in the autofill Settings")
     static let autofillViewContentButtonPaymentMethods = NSLocalizedString("autofill.view-autofill-content.payment-methods", value: "View Payment Methods…", comment: "View Payment Methods Content Button title in the autofill Settings")
     static let autofillViewContentButtonIdentities = NSLocalizedString("autofill.view-autofill-content.identities", value: "View Identities…", comment: "View Identities Content Button title in the autofill Settings")
-    static let autofillAskToSave = NSLocalizedString("autofill.ask-to-save", value: "Ask to save and Autofill", comment: "Autofill settings section title")
+    static let autofillAskToSave = NSLocalizedString("autofill.ask-to-save", value: "Ask to Save and Autofill", comment: "Autofill settings section title")
     static let autofillAskToSaveExplanation = NSLocalizedString("autofill.ask-to-save.explanation", value: "Receive prompts to save new information and autofill online forms.", comment: "Description of Autofill autosaving feature - used in settings")
     static let autofillPasswords = NSLocalizedString("autofill.passwords", value: "Passwords", comment: "Autofill autosaved data type")
     static let autofillAddresses = NSLocalizedString("autofill.addresses", value: "Addresses", comment: "Autofill autosaved data type")

--- a/DuckDuckGo/Localizable.xcstrings
+++ b/DuckDuckGo/Localizable.xcstrings
@@ -3040,7 +3040,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Ask to save and Autofill"
+            "value" : "Ask to Save and Autofill"
           }
         },
         "es" : {

--- a/DuckDuckGo/Preferences/View/PreferencesAutofillView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesAutofillView.swift
@@ -70,11 +70,11 @@ extension Preferences {
                     Button(UserText.autofillViewContentButtonPasswords) {
                         model.showAutofillPopover(.logins)
                     }
-                    Button(UserText.autofillViewContentButtonPaymentMethods) {
-                        model.showAutofillPopover(.cards)
-                    }
                     Button(UserText.autofillViewContentButtonIdentities) {
                         model.showAutofillPopover(.identities)
+                    }
+                    Button(UserText.autofillViewContentButtonPaymentMethods) {
+                        model.showAutofillPopover(.cards)
                     }
 #if APPSTORE
                     Button(UserText.importPasswords) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207044475588306/f

**Description**:
Updates the ‘Passwords’ Settings page

**Steps to test this PR**:
1. Open Settings/Passwords -> Ensure there are now separate entry points for each Autofill type - “View Passwords...”, “View Payment Methods…”, and “View Identities"
2. Open Settings/Passwords -> The import/export buttons titles should now be “Import passwords” and “Export passwords” (this should also be reflected in the Autofill dialog overflow menu)
3. Open Settings/Passwords -> “Save and Autofill” should now be “Ask to save and Autofill"
4. Open Settings/Passwords -> Under “Ask to save and Autofill”, “Usernames and passwords” should now be “Passwords"

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
