### PR TITLE
Add subscription status to the macOS metadata

### DIFF
--- a/UnitTests/VPNFeedbackForm/VPNFeedbackFormViewModelTests.swift
+++ b/UnitTests/VPNFeedbackForm/VPNFeedbackFormViewModelTests.swift
@@ -128,7 +128,8 @@ private class MockVPNMetadataCollector: VPNMetadataCollector {
 
         let privacyProInfo = VPNMetadata.PrivacyProInfo(
             betaParticipant: false,
-            subscriptionActive: true
+            hasPrivacyProAccount: true,
+            hasVPNEntitlement: true
         )
 
         return VPNMetadata(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207144276620677/f
Tech Design URL:
CC:

**Description**:

This PR adds the Privacy Pro status to the VPN metadata. It also reports if the user was a beta user (i.e. they have an old-style auth token) just in case we see anything strange related to that.

**Steps to test this PR**:
1. Use the `Debug` menu metadata log feature to test that metadata reflects subscription status

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
