### PR TITLE
Make Clear All History shortcut available without entering Main Menu

### DIFF
--- a/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/DuckDuckGo/Menus/HistoryMenu.swift
@@ -53,7 +53,9 @@ final class HistoryMenu: NSMenu {
             reopenLastClosedMenuItem
             recentlyClosedMenuItem
             reopenAllWindowsFromLastSessionMenuItem
-            NSMenuItem.separator()
+
+            clearAllHistorySeparator
+            clearAllHistoryMenuItem
         }
 
         reopenMenuItemKeyEquivalentManager.reopenLastClosedMenuItem = reopenLastClosedMenuItem


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1206028920433046/f

**Description**:
Populate Clear All History menu item in HistoryMenu initializer so it's always available.

**Steps to test this PR**:
1. Quit the production app and relaunch it. Click cmd+shift+backspace and verify that it has no effect.
2. Open any menu on the production app. Click cmd+shift+backspace and verify that it shows "Clear History" popup.
3. Launch the app from this branch in Xcode. Click cmd+shift+backspace and verify that it shows "Clear History" popup.
4. Visit some pages. Click cmd+shift+backspace, proceed to clearing browsing history and verify that history is cleared.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
