### PR TITLE
Stop first scan completed notification being sent if there's an error

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
@@ -261,7 +261,9 @@ public final class DefaultDataBrokerProtectionScheduler: DataBrokerProtectionSch
 
             self.startScheduler(showWebView: showWebView)
 
-            self.userNotificationService.sendFirstScanCompletedNotification()
+            if errors?.oneTimeError == nil {
+                self.userNotificationService.sendFirstScanCompletedNotification()
+            }
 
             if let hasMatches = try? self.dataManager.hasMatches(),
                 hasMatches {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207148631921399/f
Tech Design URL:
CC:

**Description**: 
Stops the "first scan notification' being sent if there is an error. Since we've added a new interrupted error, it will get a lot more common if we don't fix it before releasing.

We seem to have other issues relating to scan completion that this doesn't fix,

**Steps to test this PR**:
1. Test that you can replicate the original issue on main by forcing a "oneTimeError" in scanAllBrokers and checking you see the notification
2. Test the same thing on this PR, you shouldn't see a notification
3. Test that when scans complete you do see a notification

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
