### PR TITLE
Fix for VPN stop issues.

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12646,8 +12646,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 158ad0ec71b7116576d27f8e4f0fb27de80d82ea;
+				kind = exactVersion;
+				version = "138.0.0-1";
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "158ad0ec71b7116576d27f8e4f0fb27de80d82ea"
+        "revision" : "ad13fb66e5afc2cf27496a56f5b412f83ea507ad",
+        "version" : "138.0.0-1"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "138.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "138.0.0-1"),
         .package(path: "../PixelKit"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "138.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "138.0.0-1"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "138.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "138.0.0-1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207063924984126/f

iOS PR: Not needed
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/794

## Description:

Tentative fix for an issue where the tunnel provider is taking a long time to stop.

## Testing

Since this is a tentative fix it's not feasible to propose testing steps.  Testing in this PR should be directed at making sure that the tunnel starts and stop properly.

Try:
1. Starting and stopping tune VPN
2. Start the VPN, re-run the app from Xcode to simulate an update and ensure the VPN restarts normally.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
