### PR TITLE
Fix layout issue on DBP

### DIFF
--- a/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -112,8 +112,9 @@ final class DBPHomeViewController: NSViewController {
 
     override func viewDidLayout() {
         super.viewDidLayout()
-        dataBrokerProtectionViewController.view.frame = view.bounds
-        errorViewController.view.frame = view.bounds
+        if let currentChildViewController = currentChildViewController {
+            currentChildViewController.view.frame = view.bounds
+        }
     }
 
     private func setupUI() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207165247619683/f

**Description**:
Fix issue when laying out DBPHomeViewController

**Steps to test this PR**:
1. Open DBP from the ... menu
2. Resize the window to force trigger the layout call
3. Do the same with other prerequisite status
4. You can change the code here https://github.com/duckduckgo/macos-browser/blob/d06331180166d04a3ecda7ee9ab507e53cb69393/DuckDuckGo/DBP/DataBrokerPrerequisitesStatusVerifier.swift#L41
5. Also you can change it so it always return a random value so you test the UI changing. i.e:
```swift
func checkStatus() -> DataBrokerPrerequisitesStatus {
    let possibleStatuses: [DataBrokerPrerequisitesStatus] = [.invalidSystemPermission, .invalidDirectory, .valid]
    
    let randomIndex = Int.random(in: 0..<possibleStatuses.count)
    return possibleStatuses[randomIndex]
}

```

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
