### PR TITLE
Call finish in the correct place

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationsCollection.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationsCollection.swift
@@ -192,8 +192,6 @@ final class DataBrokerOperationsCollection: Operation {
                     try await Task.sleep(nanoseconds: UInt64(sleepInterval) * 1_000_000_000)
                 }
 
-                finish()
-
             } catch {
                 os_log("Error: %{public}@", log: .dataBrokerProtection, error.localizedDescription)
                 self.error = error
@@ -203,6 +201,8 @@ final class DataBrokerOperationsCollection: Operation {
                                                               withDataBrokerName: brokerProfileQueriesData.first?.dataBroker.name)
             }
         }
+
+        finish()
     }
 
     private func finish() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1207169472324666/f
Tech Design URL:
CC:

**Description**:

Correctly finish an operation collection when all operations are done

**Steps to test this PR**:
1. Run a scan with multiple names and addresses
2. Add a breakpoint to the scan completion handler 
3. https://github.com/duckduckgo/macos-browser/blob/fa727b1a7e7c0d83559f9d23dacb969a7e76d79d/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift#L289
4. Check if this is only called after all operations are finished 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
