### PR TITLE
Hard-codes the VPN waitlist flags to ON

### DIFF
--- a/DuckDuckGo/Waitlist/NetworkProtectionFeatureVisibility.swift
+++ b/DuckDuckGo/Waitlist/NetworkProtectionFeatureVisibility.swift
@@ -166,29 +166,11 @@ struct DefaultNetworkProtectionVisibility: NetworkProtectionFeatureVisibility {
     }
 
     private var isWaitlistBetaActive: Bool {
-        switch featureOverrides.waitlistActive {
-        case .useRemoteValue:
-            guard privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(NetworkProtectionSubfeature.waitlistBetaActive) else {
-                return false
-            }
-
-            return true
-        case .on:
-            return true
-        case .off:
-            return false
-        }
+        true
     }
 
     private var isWaitlistEnabled: Bool {
-        switch featureOverrides.waitlistEnabled {
-        case .useRemoteValue:
-            return privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(NetworkProtectionSubfeature.waitlist)
-        case .on:
-            return true
-        case .off:
-            return false
-        }
+        true
     }
 
     func disableForAllUsers() async {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207169061635762/f

## Description

Hardcodes the waitlist remote flags to be ON, since we're relying on those flags for the PPro subscription.

This is meant to be a quick fix, and a better cleanup will follow.

## Testing

1. Test the VPN works as usual.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
