### PR TITLE
Fix reporting success in create_variants.yml

### DIFF
--- a/.github/workflows/create_variants.yml
+++ b/.github/workflows/create_variants.yml
@@ -143,7 +143,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          curl -fLSs $(gh api https://api.github.com/repos/${{ github.repository }}/contents/scripts/assets/variants-release-mm-template.json?ref=${{ github.ref }} --jq .download_url) \
+          curl -fLSs $(gh api https://api.github.com/repos/${{ github.repository }}/contents/scripts/assets/variants-release-mm-template.json --jq .download_url) \
               --output message-template.json
     
           export MM_USER_HANDLE=$(base64 -d <<< ${{ secrets.MM_HANDLES_BASE64 }} | jq ".${{ github.actor }}" | tr -d '"')


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207192089896666/f

**Description**:
Always fetch Mattermost message template from main branch.

**Steps to test:**
Verify that the following command works in your terminal:
```
gh api https://api.github.com/repos/duckduckgo/macos-browser/contents/scripts/assets/variants-release-mm-template.json --jq .download_url
```

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
