### PR TITLE
enable going back to YT

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -289,6 +289,9 @@ extension DuckPlayerTabExtension: NavigationResponder {
            let mainFrame = navigationAction.mainFrameTarget {
 
             switch navigationAction.navigationType {
+            case .backForward:
+                // disable redirecting from YT when going back/forward
+                return .next
             case .custom, .redirect(.server):
                 PixelKit.fire(GeneralPixel.duckPlayerViewFromOther)
             case .other:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207121069690040/f

**Description**:
- don‘t redirect to Duck Player when going back/forward

**Steps to test this PR**:
1. set duck player to always enabled
2. whilst watching any video in duck player...
3. click 'watch in youtube'
4. from the youtube video page, click a recommendation from the list on the right
5. now you're back in duck player, try clicking the browsers 'back' button - YT should open

1. Set "Always ask to open duck player"
2. Search for a video at DDT, open on YouTube
3. On YT choose "Always open in duck player" - the duck player opens
4. Click back; Validate SERP is open.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
