### PR TITLE
macOS: Set Error Reporter on All SecureVault Initializations 

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDatabase.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDatabase.swift
@@ -323,7 +323,7 @@ final class DataBrokerProtectionDatabase: DataBrokerProtectionRepository {
 
     func fetchScanHistoryEvents(brokerId: Int64, profileQueryId: Int64) throws -> [HistoryEvent] {
         do {
-            let vault = try self.vault ?? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: nil)
+            let vault = try self.vault ?? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: secureVaultErrorReporter)
             guard let scan = try vault.fetchScan(brokerId: brokerId, profileQueryId: profileQueryId) else {
                 return [HistoryEvent]()
             }
@@ -338,7 +338,7 @@ final class DataBrokerProtectionDatabase: DataBrokerProtectionRepository {
 
     func fetchOptOutHistoryEvents(brokerId: Int64, profileQueryId: Int64, extractedProfileId: Int64) throws -> [HistoryEvent] {
         do {
-            let vault = try self.vault ?? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: nil)
+            let vault = try self.vault ?? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: secureVaultErrorReporter)
             guard let optOut = try vault.fetchOptOut(brokerId: brokerId, profileQueryId: profileQueryId, extractedProfileId: extractedProfileId) else {
                 return [HistoryEvent]()
             }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProtectionBrokerUpdater.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProtectionBrokerUpdater.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Common
+import SecureStorage
 
 protocol ResourcesRepository {
     func fetchBrokerFromResourceFiles() throws -> [DataBroker]?
@@ -118,7 +119,7 @@ public struct DataBrokerProtectionBrokerUpdater {
     }
 
     public static func provide() -> DataBrokerProtectionBrokerUpdater? {
-        if let vault = try? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: nil) {
+        if let vault = try? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: DataBrokerProtectionSecureVaultErrorReporter.shared) {
             return DataBrokerProtectionBrokerUpdater(vault: vault)
         }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
@@ -114,7 +114,7 @@ final class DataBrokerProtectionProcessor {
                                completion: @escaping ((DataBrokerProtectionSchedulerErrorCollection?) -> Void)) {
 
         // Before running new operations we check if there is any updates to the broker files.
-        if let vault = try? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: nil) {
+        if let vault = try? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: DataBrokerProtectionSecureVaultErrorReporter.shared) {
             let brokerUpdater = DataBrokerProtectionBrokerUpdater(vault: vault, pixelHandler: pixelHandler)
             brokerUpdater.checkForUpdatesInBrokerJSONFiles()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1207182308262542/f
CC: @THISISDINOSAUR 

**Description**:
* Passes the static `DataBrokerProtectionSecureVaultErrorReporter.shared` at all points where we initialize the DBP Secure Vault using `makeVault`

_Note: In terms of testing, as we are simply passing an expected parameter to our `makeVault` function, and we know from our existing error Pixels that Secure Vault errors are propagated when we pass this parameter, I think all that is needed here is smoke testing of the feature_

**Steps to test this PR**:
1. Smoke test the feature - launch, initiate a scan

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
