### PR TITLE
Controller start failure miscounting cancellations

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppAndExtensionAndAgentTargets/NetworkProtectionPixelEvent.swift
+++ b/DuckDuckGo/NetworkProtection/AppAndExtensionAndAgentTargets/NetworkProtectionPixelEvent.swift
@@ -28,6 +28,7 @@ enum NetworkProtectionPixelEvent: PixelKitEventV2 {
 
     case networkProtectionControllerStartAttempt
     case networkProtectionControllerStartSuccess
+    case networkProtectionControllerStartCancelled
     case networkProtectionControllerStartFailure(_ error: Error)
 
     case networkProtectionTunnelStartAttempt
@@ -114,6 +115,9 @@ enum NetworkProtectionPixelEvent: PixelKitEventV2 {
 
         case .networkProtectionControllerStartSuccess:
             return "netp_controller_start_success"
+
+        case .networkProtectionControllerStartCancelled:
+            return "netp_controller_start_cancelled"
 
         case .networkProtectionControllerStartFailure:
             return "netp_controller_start_failure"
@@ -322,6 +326,7 @@ enum NetworkProtectionPixelEvent: PixelKitEventV2 {
                 .networkProtectionNewUser,
                 .networkProtectionControllerStartAttempt,
                 .networkProtectionControllerStartSuccess,
+                .networkProtectionControllerStartCancelled,
                 .networkProtectionControllerStartFailure,
                 .networkProtectionTunnelStartAttempt,
                 .networkProtectionTunnelStartSuccess,
@@ -388,6 +393,7 @@ enum NetworkProtectionPixelEvent: PixelKitEventV2 {
                 .networkProtectionNewUser,
                 .networkProtectionControllerStartAttempt,
                 .networkProtectionControllerStartSuccess,
+                .networkProtectionControllerStartCancelled,
                 .networkProtectionTunnelStartAttempt,
                 .networkProtectionTunnelStartSuccess,
                 .networkProtectionTunnelStopAttempt,

--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -448,14 +448,18 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 
     // MARK: - Starting & Stopping the VPN
 
-    enum StartError: LocalizedError {
+    enum StartError: LocalizedError, CustomNSError {
+        case cancelled
         case noAuthToken
         case connectionStatusInvalid
         case connectionAlreadyStarted
         case simulateControllerFailureError
+        case startTunnelFailure(_ error: Error)
 
         var errorDescription: String? {
             switch self {
+            case .cancelled:
+                return nil
             case .noAuthToken:
                 return "You need a subscription to start the VPN"
             case .connectionAlreadyStarted:
@@ -473,6 +477,34 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 #endif
             case .simulateControllerFailureError:
                 return "Simulated a controller error as requested"
+            case .startTunnelFailure(let error):
+                return error.localizedDescription
+            }
+        }
+
+        var errorCode: Int {
+            switch self {
+            case .cancelled: return 0
+                // MARK: Setup errors
+            case .noAuthToken: return 1
+            case .connectionStatusInvalid: return 2
+            case .connectionAlreadyStarted: return 3
+            case .simulateControllerFailureError: return 4
+                // MARK: Actual connection attempt issues
+            case .startTunnelFailure: return 100
+            }
+        }
+
+        var errorUserInfo: [String: Any] {
+            switch self {
+            case .cancelled,
+                    .noAuthToken,
+                    .connectionStatusInvalid,
+                    .connectionAlreadyStarted,
+                    .simulateControllerFailureError:
+                return [:]
+            case .startTunnelFailure(let error):
+                return [NSUnderlyingErrorKey: error]
             }
         }
     }
@@ -502,6 +534,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             } catch {
                 if case NEVPNError.configurationReadWriteFailed = error {
                     onboardingStatusRawValue = OnboardingStatus.isOnboarding(step: .userNeedsToAllowVPNConfiguration).rawValue
+
+                    throw StartError.cancelled
                 }
 
                 throw error
@@ -528,9 +562,15 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
         } catch {
             VPNOperationErrorRecorder().recordControllerStartFailure(error)
 
-            PixelKit.fire(
-                NetworkProtectionPixelEvent.networkProtectionControllerStartFailure(error), frequency: .dailyAndCount, includeAppVersionParameter: true
-            )
+            if case StartError.cancelled = error {
+                PixelKit.fire(
+                    NetworkProtectionPixelEvent.networkProtectionControllerStartCancelled, frequency: .dailyAndCount, includeAppVersionParameter: true
+                )
+            } else {
+                PixelKit.fire(
+                    NetworkProtectionPixelEvent.networkProtectionControllerStartFailure(error), frequency: .dailyAndCount, includeAppVersionParameter: true
+                )
+            }
 
             await stop()
 
@@ -577,7 +617,11 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             throw StartError.simulateControllerFailureError
         }
 
-        try tunnelManager.connection.startVPNTunnel(options: options)
+        do {
+            try tunnelManager.connection.startVPNTunnel(options: options)
+        } catch {
+            throw StartError.startTunnelFailure(error)
+        }
 
         PixelKit.fire(
             NetworkProtectionPixelEvent.networkProtectionNewUser,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207193126056882

## Description

Stop counting when the user disables the VPN configuration creation as a controller start failure.

## Testing

IMPORTANT: there's an issue that's causing the VPN allow dialog to come up twice, I'm currently debugging this but haven't reached a conclusion yet.

1. Open Console.app and filter by "👾"
2. Make sure you've deleted the VPN configuration from system settings
3. Start the VPN and when the dialog to allow the VPN configuration creation comes up, cancel it.
4. Check in the console that you see the pixel `netp_controller_start_cancelled`

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
