### PR TITLE
Tentative fix for tab crashes

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -328,15 +328,15 @@ protocol NewWindowPolicyDecisionMaker {
     }
 
     deinit {
-        cleanUpBeforeClosing(onDeinit: true)
+        cleanUpBeforeClosing(onDeinit: true, webView: webView, userContentController: userContentController)
     }
 
     func cleanUpBeforeClosing() {
-        cleanUpBeforeClosing(onDeinit: false)
+        cleanUpBeforeClosing(onDeinit: false, webView: webView, userContentController: userContentController)
     }
 
     @MainActor(unsafe)
-    private func cleanUpBeforeClosing(onDeinit: Bool) {
+    private func cleanUpBeforeClosing(onDeinit: Bool, webView: WebView, userContentController: UserContentController?) {
         let job = { [webView, userContentController] in
             webView.stopAllMedia(shouldStopLoading: true)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207210775441763/f

## Description

Tentative fix for `Tab.cleanUpBeforeClosing` crashes.

Please see the video in the referenced task for more details.

## Steps to test this PR

Test opening and closing tabs and ensure all is fine.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
