### PR TITLE
Fixes an issue that's causing the Allow VPN to show up twice when dis…

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -532,7 +532,9 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
                 NetworkProtectionPixelEvent.networkProtectionControllerStartFailure(error), frequency: .dailyAndCount, includeAppVersionParameter: true
             )
 
-            await stop()
+            if await isConnected {
+                await stop()
+            }
 
             // Always keep the first error message shown, as it's the more actionable one.
             if controllerErrorStore.lastErrorMessage == nil {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207210448609392/f

## Description

We no longer ask twice to allow the VPN configuration if the user decides to not allow it.

## Testing

1. Make sure you remove the VPN configuration from System Settings > VPN
2. Run the app, and try to start the VPN
3. When the dialog that ask you to allow the creation of the VPN configuration comes up, disallow it.
4. Make sure it doesn't show up again.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
