### PR TITLE
Do not consider deprecated scans in the scan UI

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationsCollection.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationsCollection.swift
@@ -31,7 +31,7 @@ protocol DataBrokerOperationsCollectionErrorDelegate: AnyObject {
 final class DataBrokerOperationsCollection: Operation {
 
     enum OperationType {
-        case scan
+        case manualScan
         case optOut
         case all
     }
@@ -119,8 +119,8 @@ final class DataBrokerOperationsCollection: Operation {
         switch operationType {
         case .optOut:
             operationsData = brokerProfileQueriesData.flatMap { $0.optOutOperationsData }
-        case .scan:
-            operationsData = brokerProfileQueriesData.compactMap { $0.scanOperationData }
+        case .manualScan:
+            operationsData = brokerProfileQueriesData.filter { $0.profileQuery.deprecated == false }.compactMap { $0.scanOperationData }
         case .all:
             operationsData = brokerProfileQueriesData.flatMap { $0.operationsData }
         }
@@ -181,7 +181,7 @@ final class DataBrokerOperationsCollection: Operation {
                                                                                 runner: runner,
                                                                                 pixelHandler: pixelHandler,
                                                                                 showWebView: showWebView,
-                                                                                isManualScan: operationType == .scan,
+                                                                                isManualScan: operationType == .manualScan,
                                                                                 userNotificationService: userNotificationService,
                                                                                 shouldRunNextStep: { [weak self] in
                     guard let self = self else { return false }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessor.swift
@@ -59,7 +59,7 @@ final class DataBrokerProtectionProcessor {
                           completion: ((DataBrokerProtectionSchedulerErrorCollection?) -> Void)? = nil) {
 
         operationQueue.cancelAllOperations()
-        runOperations(operationType: .scan,
+        runOperations(operationType: .manualScan,
                       priorityDate: nil,
                       showWebView: showWebView) { errors in
             os_log("Scans done", log: .dataBrokerProtection)

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/MapperToUITests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/MapperToUITests.swift
@@ -105,6 +105,22 @@ final class MapperToUITests: XCTestCase {
         XCTAssertEqual(result.resultsFound.count, 1)
     }
 
+    func testWhenScansHaveDeprecatedProfileQueriesThatDidNotRun_thenThoseAreNotTakenIntoAccount() {
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date(), extractedProfile: .mockWithRemovedDate),
+            .mock(dataBrokerName: "Broker #1", lastRunDate: Date()),
+            .mock(dataBrokerName: "Broker #1", lastRunDate: nil, deprecated: true),
+            .mock(dataBrokerName: "Broker #2", lastRunDate: Date()),
+            .mock(dataBrokerName: "Broker #3", lastRunDate: Date(), extractedProfile: .mockWithRemovedDate, deprecated: true)
+        ]
+
+        let result = sut.initialScanState(brokerProfileQueryData)
+
+        XCTAssertEqual(result.scanProgress.totalScans, 2)
+        XCTAssertEqual(result.scanProgress.currentScans, 2)
+        XCTAssertEqual(result.resultsFound.count, 1)
+    }
+
     func testInProgressAndCompletedOptOuts_areMappedCorrectly() {
         let brokerProfileQueryData: [BrokerProfileQueryData] = [
             .mock(extractedProfile: .mockWithRemovedDate),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1207208737318475/f

**Description**:
Do not consider deprecated scans in the scan UI

**Steps to test this PR**:
1. Before testing this PR, see if you can reproduce by creating a profile, run scans, as soon as you see some extracted profiles being returned, go back, change the name to something else, start scans again.
2. You should see in the terminal operations being ran on deprecated profiles as well
3. Now delete the database and start fresh `rm -rf ~/Library/Group\ Containers/HKE973VLUW.com.duckduckgo.macos.browser.dbp.debug`
4. Do the same as before, check that we're not running scans on deprecated profile queries anymore

