### PR TITLE
Use NotLocalizedString on DBP error screen copy

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -185,6 +185,10 @@
 		31A2FD172BAB41C500D0E741 /* DataBrokerProtectionVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A2FD162BAB41C500D0E741 /* DataBrokerProtectionVisibilityTests.swift */; };
 		31A2FD182BAB43BA00D0E741 /* DataBrokerProtectionVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A2FD162BAB41C500D0E741 /* DataBrokerProtectionVisibilityTests.swift */; };
 		31A3A4E32B0C115F0021063C /* DataBrokerProtection in Frameworks */ = {isa = PBXBuildFile; productRef = 31A3A4E22B0C115F0021063C /* DataBrokerProtection */; };
+		31A83FB52BE28D7D00F74E67 /* UserText+DBP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A83FB42BE28D7D00F74E67 /* UserText+DBP.swift */; };
+		31A83FB62BE28D7D00F74E67 /* UserText+DBP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A83FB42BE28D7D00F74E67 /* UserText+DBP.swift */; };
+		31A83FB72BE28D8A00F74E67 /* UserText+DBP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A83FB42BE28D7D00F74E67 /* UserText+DBP.swift */; };
+		31A83FB82BE28D8A00F74E67 /* UserText+DBP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A83FB42BE28D7D00F74E67 /* UserText+DBP.swift */; };
 		31AA6B972B960B870025014E /* DataBrokerProtectionLoginItemPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AA6B962B960B870025014E /* DataBrokerProtectionLoginItemPixels.swift */; };
 		31AA6B982B960BA50025014E /* DataBrokerProtectionLoginItemPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AA6B962B960B870025014E /* DataBrokerProtectionLoginItemPixels.swift */; };
 		31B4AF532901A4F20013585E /* NSEventExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B4AF522901A4F20013585E /* NSEventExtension.swift */; };
@@ -2850,6 +2854,7 @@
 		3199C6F82AF94F5B002A7BA1 /* DataBrokerProtectionFeatureDisabler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionFeatureDisabler.swift; sourceTree = "<group>"; };
 		3199C6FC2AF97367002A7BA1 /* DataBrokerProtectionAppEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionAppEvents.swift; sourceTree = "<group>"; };
 		31A2FD162BAB41C500D0E741 /* DataBrokerProtectionVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionVisibilityTests.swift; sourceTree = "<group>"; };
+		31A83FB42BE28D7D00F74E67 /* UserText+DBP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserText+DBP.swift"; sourceTree = "<group>"; };
 		31AA6B962B960B870025014E /* DataBrokerProtectionLoginItemPixels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionLoginItemPixels.swift; sourceTree = "<group>"; };
 		31B4AF522901A4F20013585E /* NSEventExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSEventExtension.swift; sourceTree = "<group>"; };
 		31C3CE0128EDC1E70002C24A /* CustomRoundedCornersShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRoundedCornersShape.swift; sourceTree = "<group>"; };
@@ -6798,6 +6803,7 @@
 			children = (
 				AA80EC53256BE3BC007083E7 /* UserText.swift */,
 				4B4D60D22A0C84F700BCD287 /* UserText+NetworkProtection.swift */,
+				31A83FB42BE28D7D00F74E67 /* UserText+DBP.swift */,
 			);
 			path = Localizables;
 			sourceTree = "<group>";
@@ -9981,6 +9987,7 @@
 				3706FC2F293F65D500E42796 /* MouseOverButton.swift in Sources */,
 				3706FC30293F65D500E42796 /* FireInfoViewController.swift in Sources */,
 				B6F1B02F2BCE6B47005E863C /* TunnelControllerProvider.swift in Sources */,
+				31A83FB62BE28D7D00F74E67 /* UserText+DBP.swift in Sources */,
 				56BA1E832BAC506F001CF69F /* SSLErrorPageUserScript.swift in Sources */,
 				3706FC31293F65D500E42796 /* PermissionButton.swift in Sources */,
 				3706FC32293F65D500E42796 /* MoreOptionsMenu.swift in Sources */,
@@ -10682,6 +10689,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				31A83FB72BE28D8A00F74E67 /* UserText+DBP.swift in Sources */,
 				9D9AE92C2AAB84FF0026E7DC /* DBPMocks.swift in Sources */,
 				7B0099792B65013800FE7C31 /* BrowserWindowManager.swift in Sources */,
 				9D9AE9292AAA43EB0026E7DC /* DataBrokerProtectionBackgroundManager.swift in Sources */,
@@ -10695,6 +10703,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				31A83FB82BE28D8A00F74E67 /* UserText+DBP.swift in Sources */,
 				7B1459542B7D437200047F2C /* BrowserWindowManager.swift in Sources */,
 				9D9AE92D2AAB84FF0026E7DC /* DBPMocks.swift in Sources */,
 				9D9AE92A2AAA43EB0026E7DC /* DataBrokerProtectionBackgroundManager.swift in Sources */,
@@ -11457,6 +11466,7 @@
 				B634DBDF293C8F7F00C3C99E /* Tab+UIDelegate.swift in Sources */,
 				B6F1B02E2BCE6B47005E863C /* TunnelControllerProvider.swift in Sources */,
 				37AFCE8127DA2CA600471A10 /* PreferencesViewController.swift in Sources */,
+				31A83FB52BE28D7D00F74E67 /* UserText+DBP.swift in Sources */,
 				4B02198A25E05FAC00ED7DEA /* FireproofDomains.swift in Sources */,
 				4B677442255DBEEA00025BD8 /* Database.swift in Sources */,
 				1DDC85032B83903E00670238 /* PreferencesWebTrackingProtectionView.swift in Sources */,

--- a/DuckDuckGo/Common/Localizables/UserText+DBP.swift
+++ b/DuckDuckGo/Common/Localizables/UserText+DBP.swift
@@ -1,0 +1,86 @@
+//
+//  UserText+DBP.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+
+#if DBP
+// MARK: - Data Broker Protection Waitlist
+extension UserText {
+    // "data-broker-protection.privacy-policy.title" - Privacy Policy title for Personal Information Removal
+    static let dataBrokerProtectionPrivacyPolicyTitle = "Privacy Policy"
+    // "data-broker-protection.waitlist.notification.title" - Title for Personal Information Removal waitlist notification
+    static let dataBrokerProtectionWaitlistNotificationTitle = "Personal Information Removal beta is ready!"
+    // "data-broker-protection.waitlist.notification.text" - Title for Personal Information Removal waitlist notification
+    static let dataBrokerProtectionWaitlistNotificationText = "Open your invite"
+    // "data-broker-protection.waitlist.join.title" - Title for Personal Information Removal join waitlist screen
+    static let dataBrokerProtectionWaitlistJoinTitle = "Personal Information Removal Beta"
+    // "data-broker-protection.waitlist.join.subtitle.1" - First subtitle for Personal Information Removal join waitlist screen
+    static let dataBrokerProtectionWaitlistJoinSubtitle1 = "Automatically scan and remove your data from 17+ sites that sell personal information with DuckDuckGo’s Personal Information Removal."
+    // "data-broker-protection.waitlist.joined.title" - Title for Personal Information Removal joined waitlist screen
+    static let dataBrokerProtectionWaitlistJoinedTitle = "You’re on the list!"
+    // "data-broker-protection.waitlist.joined.with-notifications.subtitle.1" - Subtitle 1 for Personal Information Removal joined waitlist screen when notifications are enabled
+    static let dataBrokerProtectionWaitlistJoinedWithNotificationsSubtitle1 = "New invites are sent every few days, on a first come, first served basis."
+    // "data-broker-protection.waitlist.joined.with-notifications.subtitle.2" - Subtitle 2 for Personal Information Removal joined waitlist screen when notifications are enabled
+    static let dataBrokerProtectionWaitlistJoinedWithNotificationsSubtitle2 = "We’ll notify you when your invite is ready."
+    // "data-broker-protection.waitlist.enable-notifications" - Enable notifications prompt for Personal Information Removal joined waitlist screen
+    static let dataBrokerProtectionWaitlistEnableNotifications = "Want to get a notification when your Personal Information Removal invite is ready?"
+    // "data-broker-protection.waitlist.invited.title" - Title for Personal Information Removal invited screen
+    static let dataBrokerProtectionWaitlistInvitedTitle = "You’re invited to try\nPersonal Information Removal beta!"
+    // "data-broker-protection.waitlist.invited.subtitle" - Subtitle for Personal Information Removal invited screen
+    static let dataBrokerProtectionWaitlistInvitedSubtitle = "Automatically find and remove your personal information – such as your name and address – from 17+ sites that store and sell it, reducing the risk of identity theft and spam."
+    // "data-broker-protection.waitlist.enable.title" - Title for Personal Information Removal enable screen
+    static let dataBrokerProtectionWaitlistEnableTitle = "Let’s get started"
+    // "data-broker-protection.waitlist.enable.subtitle" - Subtitle for Personal Information Removal enable screen
+    static let dataBrokerProtectionWaitlistEnableSubtitle = "We’ll need your name, address and the year you were born in order to find your personal information on data broker sites\n\nThis info is stored securely on your device, and is never sent to DuckDuckGo."
+    // "data-broker-protection.waitlist.availability-disclaimer" - Availability disclaimer for Personal Information Removal join waitlist screen
+    static let dataBrokerProtectionWaitlistAvailabilityDisclaimer = "Personal Information Removal is free during the beta.\nJoin the waitlist and we'll notify you when ready."
+    // "data-broker-protection.waitlist.button.close" - Close button for Personal Information Removal join waitlist screen
+    static let dataBrokerProtectionWaitlistButtonClose = "Close"
+    // "data-broker-protection.waitlist.button.done" - Close button for Personal Information Removal joined waitlist screen
+    static let dataBrokerProtectionWaitlistButtonDone = "Done"
+    // "data-broker-protection.waitlist.button.dismiss" - Dismiss button for Personal Information Removal join waitlist screen
+    static let dataBrokerProtectionWaitlistButtonDismiss = "Dismiss"
+    // "data-broker-protection.waitlist.button.cancel" - Cancel button for Personal Information Removal join waitlist screen
+    static let dataBrokerProtectionWaitlistButtonCancel = "Cancel"
+    // "data-broker-protection.waitlist.button.no-thanks" - No Thanks button for Personal Information Removal joined waitlist screen
+    static let dataBrokerProtectionWaitlistButtonNoThanks = "No Thanks"
+    // "data-broker-protection.waitlist.button.get-started" - Get Started button for Personal Information Removal joined waitlist screen
+    static let dataBrokerProtectionWaitlistButtonGetStarted = "Get Started"
+    // "data-broker-protection.waitlist.button.got-it" - Get started button for Personal Information Removal joined waitlist screen
+    static let dataBrokerProtectionWaitlistButtonGotIt = "Get started"
+    // "data-broker-protection.waitlist.button.enable-notifications" - Enable Notifications button for Personal Information Removal joined waitlist screen
+    static let dataBrokerProtectionWaitlistButtonEnableNotifications = "Enable Notifications"
+    // "data-broker-protection.waitlist.button.join-waitlist" - Join Waitlist button for Personal Information Removal join waitlist screen
+    static let dataBrokerProtectionWaitlistButtonJoinWaitlist = "Join the Waitlist"
+    // "data-broker-protection.waitlist.button.agree-and-continue" - Agree and Continue button for Personal Information Removal join waitlist screen
+    static let dataBrokerProtectionWaitlistButtonAgreeAndContinue = "Agree and Continue"
+}
+
+// MARK: - DBP Error pages
+extension UserText {
+    static let dbpErrorPageBadPathTitle = NotLocalizedString("dbp.errorpage.bad.path.title", value: "Move DuckDuckGo App to Applications", comment: "Title for Personal Information Removal bad path error screen")
+    static let dbpErrorPageBadPathMessage = NotLocalizedString("dbp.errorpage.bad.path.message", value: "To use Personal Information Removal, the DuckDuckGo app needs to be in the Applications folder on your Mac. You can move the app yourself and restart the browser, or we can do it for you.", comment: "Message for Personal Information Removal bad path error screen")
+    static let dbpErrorPageBadPathCTA = NotLocalizedString("dbp.errorpage.bad.path.cta", value: "Move App for Me...", comment: "Call to action for moving the app to the Applications folder")
+
+    static let dbpErrorPageNoPermissionTitle = NotLocalizedString("dbp.errorpage.no.permission.title", value: "Change System Setting", comment: "Title for error screen when there is no permission")
+    static let dbpErrorPageNoPermissionMessage = NotLocalizedString("dbp.errorpage.no.permission.message", value: "Open System Settings and allow DuckDuckGo Personal Information Removal to run in the background.", comment: "Message for error screen when there is no permission")
+    static let dbpErrorPageNoPermissionCTA = NotLocalizedString("dbp.errorpage.no.permission.cta", value: "Open System Settings...", comment: "Call to action for opening system settings")
+}
+
+#endif

--- a/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
+++ b/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
@@ -189,60 +189,6 @@ extension UserText {
     }
 }
 
-#if DBP
-// MARK: - Data Broker Protection Waitlist
-extension UserText {
-    // "data-broker-protection.privacy-policy.title" - Privacy Policy title for Personal Information Removal
-    static let dataBrokerProtectionPrivacyPolicyTitle = "Privacy Policy"
-    // "data-broker-protection.waitlist.notification.title" - Title for Personal Information Removal waitlist notification
-    static let dataBrokerProtectionWaitlistNotificationTitle = "Personal Information Removal beta is ready!"
-    // "data-broker-protection.waitlist.notification.text" - Title for Personal Information Removal waitlist notification
-    static let dataBrokerProtectionWaitlistNotificationText = "Open your invite"
-    // "data-broker-protection.waitlist.join.title" - Title for Personal Information Removal join waitlist screen
-    static let dataBrokerProtectionWaitlistJoinTitle = "Personal Information Removal Beta"
-    // "data-broker-protection.waitlist.join.subtitle.1" - First subtitle for Personal Information Removal join waitlist screen
-    static let dataBrokerProtectionWaitlistJoinSubtitle1 = "Automatically scan and remove your data from 17+ sites that sell personal information with DuckDuckGo’s Personal Information Removal."
-    // "data-broker-protection.waitlist.joined.title" - Title for Personal Information Removal joined waitlist screen
-    static let dataBrokerProtectionWaitlistJoinedTitle = "You’re on the list!"
-    // "data-broker-protection.waitlist.joined.with-notifications.subtitle.1" - Subtitle 1 for Personal Information Removal joined waitlist screen when notifications are enabled
-    static let dataBrokerProtectionWaitlistJoinedWithNotificationsSubtitle1 = "New invites are sent every few days, on a first come, first served basis."
-    // "data-broker-protection.waitlist.joined.with-notifications.subtitle.2" - Subtitle 2 for Personal Information Removal joined waitlist screen when notifications are enabled
-    static let dataBrokerProtectionWaitlistJoinedWithNotificationsSubtitle2 = "We’ll notify you when your invite is ready."
-    // "data-broker-protection.waitlist.enable-notifications" - Enable notifications prompt for Personal Information Removal joined waitlist screen
-    static let dataBrokerProtectionWaitlistEnableNotifications = "Want to get a notification when your Personal Information Removal invite is ready?"
-    // "data-broker-protection.waitlist.invited.title" - Title for Personal Information Removal invited screen
-    static let dataBrokerProtectionWaitlistInvitedTitle = "You’re invited to try\nPersonal Information Removal beta!"
-    // "data-broker-protection.waitlist.invited.subtitle" - Subtitle for Personal Information Removal invited screen
-    static let dataBrokerProtectionWaitlistInvitedSubtitle = "Automatically find and remove your personal information – such as your name and address – from 17+ sites that store and sell it, reducing the risk of identity theft and spam."
-    // "data-broker-protection.waitlist.enable.title" - Title for Personal Information Removal enable screen
-    static let dataBrokerProtectionWaitlistEnableTitle = "Let’s get started"
-    // "data-broker-protection.waitlist.enable.subtitle" - Subtitle for Personal Information Removal enable screen
-    static let dataBrokerProtectionWaitlistEnableSubtitle = "We’ll need your name, address and the year you were born in order to find your personal information on data broker sites\n\nThis info is stored securely on your device, and is never sent to DuckDuckGo."
-    // "data-broker-protection.waitlist.availability-disclaimer" - Availability disclaimer for Personal Information Removal join waitlist screen
-    static let dataBrokerProtectionWaitlistAvailabilityDisclaimer = "Personal Information Removal is free during the beta.\nJoin the waitlist and we'll notify you when ready."
-    // "data-broker-protection.waitlist.button.close" - Close button for Personal Information Removal join waitlist screen
-    static let dataBrokerProtectionWaitlistButtonClose = "Close"
-    // "data-broker-protection.waitlist.button.done" - Close button for Personal Information Removal joined waitlist screen
-    static let dataBrokerProtectionWaitlistButtonDone = "Done"
-    // "data-broker-protection.waitlist.button.dismiss" - Dismiss button for Personal Information Removal join waitlist screen
-    static let dataBrokerProtectionWaitlistButtonDismiss = "Dismiss"
-    // "data-broker-protection.waitlist.button.cancel" - Cancel button for Personal Information Removal join waitlist screen
-    static let dataBrokerProtectionWaitlistButtonCancel = "Cancel"
-    // "data-broker-protection.waitlist.button.no-thanks" - No Thanks button for Personal Information Removal joined waitlist screen
-    static let dataBrokerProtectionWaitlistButtonNoThanks = "No Thanks"
-    // "data-broker-protection.waitlist.button.get-started" - Get Started button for Personal Information Removal joined waitlist screen
-    static let dataBrokerProtectionWaitlistButtonGetStarted = "Get Started"
-    // "data-broker-protection.waitlist.button.got-it" - Get started button for Personal Information Removal joined waitlist screen
-    static let dataBrokerProtectionWaitlistButtonGotIt = "Get started"
-    // "data-broker-protection.waitlist.button.enable-notifications" - Enable Notifications button for Personal Information Removal joined waitlist screen
-    static let dataBrokerProtectionWaitlistButtonEnableNotifications = "Enable Notifications"
-    // "data-broker-protection.waitlist.button.join-waitlist" - Join Waitlist button for Personal Information Removal join waitlist screen
-    static let dataBrokerProtectionWaitlistButtonJoinWaitlist = "Join the Waitlist"
-    // "data-broker-protection.waitlist.button.agree-and-continue" - Agree and Continue button for Personal Information Removal join waitlist screen
-    static let dataBrokerProtectionWaitlistButtonAgreeAndContinue = "Agree and Continue"
-}
-#endif
-
 // MARK: - Thank You Modals
 
 extension UserText {

--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1163,13 +1163,4 @@ struct UserText {
     // Comment: "Progress view title when completing the purchase"
     static let completingPurchaseTitle = "Completing purchase..."
 
-    // MARK: - DBP Error pages
-
-    static let dbpErrorPageBadPathTitle = "Move DuckDuckGo App to Applications"
-    static let dbpErrorPageBadPathMessage = "To use Personal Information Removal, the DuckDuckGo app needs to be in the Applications folder on your Mac. You can move the app yourself and restart the browser, or we can do it for you."
-    static let dbpErrorPageBadPathCTA = "Move App for Me..."
-
-    static let dbpErrorPageNoPermissionTitle = "Change System Setting"
-    static let dbpErrorPageNoPermissionMessage = "Open System Settings and allow DuckDuckGo Personal Information Removal to run in the background."
-    static let dbpErrorPageNoPermissionCTA = "Open System Settings..."
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207141364289924/f

**Description**:
Use NotLocalizedString on DBP error screen copy

**Steps to test this PR**:
1. Go to https://github.com/duckduckgo/macos-browser/blob/71e3c0cd911dcc6240fe1fca54bf560a139ed5d2/DuckDuckGo/DBP/DataBrokerPrerequisitesStatusVerifier.swift#L41 
2. Open PIR from the ... menu
3. Return invalidSystemPermission and check if the DBP error page correctly displays the error message
4. Do the same returning invalidDirectory 

