### PR TITLE
Delegate SecureVault KeyStore Events in All Scenarios

### DIFF
--- a/DuckDuckGo/Autofill/ContentOverlayViewController.swift
+++ b/DuckDuckGo/Autofill/ContentOverlayViewController.swift
@@ -313,6 +313,10 @@ extension ContentOverlayViewController: SecureVaultManagerDelegate {
         SecureVaultReporter.shared.secureVaultError(error)
     }
 
+    public func secureVaultKeyStoreEvent(_ event: SecureStorageKeyStoreEvent) {
+        SecureVaultReporter.shared.secureVaultKeyStoreEvent(event)
+    }
+
     public func secureVaultManager(_: BrowserServicesKit.SecureVaultManager, didReceivePixel pixel: AutofillUserScript.JSPixel) {
         if pixel.isEmailPixel {
             let emailParameters = self.emailManager.emailPixelParameters

--- a/DuckDuckGo/Tab/TabExtensions/AutofillTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/AutofillTabExtension.swift
@@ -167,6 +167,10 @@ extension AutofillTabExtension: SecureVaultManagerDelegate {
         SecureVaultReporter.shared.secureVaultError(error)
     }
 
+    func secureVaultKeyStoreEvent(_ event: SecureStorageKeyStoreEvent) {
+        SecureVaultReporter.shared.secureVaultKeyStoreEvent(event)
+    }
+
     public func secureVaultManager(_: BrowserServicesKit.SecureVaultManager, didReceivePixel pixel: AutofillUserScript.JSPixel) {
         PixelKit.fire(GeneralPixel.jsPixel(pixel))
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207236816134198/f

**Description**:

**Context**
As part of [✓ macOS: Reduce Negative User Feedback Relating to Password Entry Prompts](https://app.asana.com/0/0/1206924205159008), we added Pixel event reporting for Keychain migrations. These events are reported via calls to SecureVaultReporter

**Current Behavior**
In some cases where an intermediate is used to communicate with SecureVaultReporter, we are not delegating SecureVault events

**Expected Behavior**
In all cases where an intermediate is used to communicate with SecureVaultReporter, we should delegate SecureVault events

**Steps to test this PR**:
1. As this is straightforward delegation of an event call, only smoke testing of the app is required

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
