### PR TITLE
Run more parallel operations on manual scans

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationsCollection.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerOperationsCollection.swift
@@ -28,14 +28,13 @@ protocol DataBrokerOperationsCollectionErrorDelegate: AnyObject {
                                         didErrorBeforeStartingBrokerOperations error: Error)
 }
 
+enum OperationType {
+    case manualScan
+    case optOut
+    case all
+}
+
 final class DataBrokerOperationsCollection: Operation {
-
-    enum OperationType {
-        case manualScan
-        case optOut
-        case all
-    }
-
     public var error: Error?
     public weak var errorDelegate: DataBrokerOperationsCollectionErrorDelegate?
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessorConfiguration.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionProcessorConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  DataBrokerProtectionSchedulerConfig.swift
+//  DataBrokerProtectionProcessorConfiguration.swift
 //
 //  Copyright © 2023 DuckDuckGo. All rights reserved.
 //
@@ -18,13 +18,19 @@
 
 import Foundation
 
-protocol SchedulerConfig {
-    var concurrentOperationsDifferentBrokers: Int { get }
-    var intervalBetweenSameBrokerOperations: TimeInterval { get }
-}
-
-struct DataBrokerProtectionSchedulerConfig: SchedulerConfig {
+struct DataBrokerProtectionProcessorConfiguration {
     // Arbitrary numbers for now
-    var concurrentOperationsDifferentBrokers: Int = 2
-    var intervalBetweenSameBrokerOperations: TimeInterval = 2
+    let intervalBetweenSameBrokerOperations: TimeInterval = 2
+    private let concurrentOperationsDifferentBrokers: Int = 2
+    // https://app.asana.com/0/481882893211075/1206981742767469/f
+    private let concurrentOperationsOnManualScans: Int = 6
+
+    func concurrentOperationsFor(_ operation: OperationType) -> Int {
+        switch operation {
+        case .all, .optOut:
+            return concurrentOperationsDifferentBrokers
+        case .manualScan:
+            return concurrentOperationsOnManualScans
+        }
+    }
 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionScheduler.swift
@@ -150,7 +150,6 @@ public final class DefaultDataBrokerProtectionScheduler: DataBrokerProtectionSch
                                                                captchaService: captchaService)
 
         return DataBrokerProtectionProcessor(database: dataManager.database,
-                                             config: DataBrokerProtectionSchedulerConfig(),
                                              operationRunnerProvider: runnerProvider,
                                              notificationCenter: notificationCenter,
                                              pixelHandler: pixelHandler,

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionProcessorConfigurationTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionProcessorConfigurationTests.swift
@@ -1,0 +1,44 @@
+//
+//  DataBrokerProtectionProcessorConfigurationTests.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Foundation
+@testable import DataBrokerProtection
+
+final class DataBrokerProtectionProcessorConfigurationTests: XCTestCase {
+
+    private let sut = DataBrokerProtectionProcessorConfiguration()
+
+    func testWhenOperationIsManualScans_thenConcurrentOperationsBetweenBrokersIsSix() {
+        let value = sut.concurrentOperationsFor(.manualScan)
+        let expectedValue = 6
+        XCTAssertEqual(value, expectedValue)
+    }
+
+    func testWhenOperationIsAll_thenConcurrentOperationsBetweenBrokersIsTwo() {
+        let value = sut.concurrentOperationsFor(.all)
+        let expectedValue = 2
+        XCTAssertEqual(value, expectedValue)
+    }
+
+    func testWhenOperationIsOptOut_thenConcurrentOperationsBetweenBrokersIsTwo() {
+        let value = sut.concurrentOperationsFor(.optOut)
+        let expectedValue = 2
+        XCTAssertEqual(value, expectedValue)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1206981742767461/f
Tech Design URL:
CC:

**Description**:
Runs more parallel operations when the operation is manual scans. We want to increase the number only for manual scans, other operations should be kept to six for the moment.

I also renamed the configuration file, is not related to the scheduler. I also refactored to just be a struct, we do not need to make it a protocol, if we want to mock it we can just initialize it with the values that we want.

**Steps to test this PR**:
1. Run manual scans showing the web views. Check that six windows are opened
2. Run queued operations showing web views. Check that two windows are opened