### PR TITLE
Fix a bug that caused a single pinned tabs to expand in full screen mode

### DIFF
--- a/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
+++ b/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
@@ -27,7 +27,7 @@ struct PinnedTabsView: View {
             ForEach(model.items) { item in
                 PinnedTabView(model: item, showsHover: draggedTab == nil)
                     .environmentObject(model)
-                    .frame(maxHeight: PinnedTabView.Const.dimension)
+                    .frame(maxWidth: PinnedTabView.Const.dimension, maxHeight: PinnedTabView.Const.dimension)
             }
         }
         .frame(minHeight: PinnedTabView.Const.dimension)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205566351996167/f

**Description**:

This PR fixes the pinned tab width when the application is in full screen. Setting the maxWidth on the PinnedTabView seems to fix the issue.

**Before Fix Video**

https://github.com/duckduckgo/macos-browser/assets/1089358/b7750e65-ce82-4358-8601-5b85e2a37a3e

**After Fix Video**

https://github.com/duckduckgo/macos-browser/assets/1089358/1cf009ac-e23e-4194-b8d1-82cc3aac0a68

**NOTE**

Unfortunately, I cannot really write tests for this. Maybe snapshot testing could cover this scenario, but I’m not sure if Git LFS is set up. Perhaps this is something we can talk about.

**Steps to test this PR**:
1. Ensure only one tab is pinned.
2. Click on the semaphore green button and put the app in full-screen mode.
**Expected Result:** The pinned tab width shouldn’t grow but should maintain its default size. 

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
