### PR TITLE
Fix address bar different focus state color when new tab vs new window

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -25,7 +25,7 @@ final class AddressBarViewController: NSViewController {
     @IBOutlet var addressBarTextField: AddressBarTextField!
     @IBOutlet var passiveTextField: NSTextField!
     @IBOutlet var inactiveBackgroundView: NSView!
-    @IBOutlet var activeBackgroundView: NSView!
+    @IBOutlet var activeBackgroundView: ColorView!
     @IBOutlet var activeOuterBorderView: NSView!
     @IBOutlet var activeBackgroundViewWithSuggestions: NSView!
     @IBOutlet var progressIndicator: LoadingProgressView!
@@ -319,10 +319,8 @@ final class AddressBarViewController: NSViewController {
         let isKey = self.view.window?.isKeyWindow ?? false
         activeOuterBorderView.alphaValue = isKey && isFirstResponder && isHomePage ? 1 : 0
 
-        activeOuterBorderView.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.2).cgColor
-        activeBackgroundView.layer?.borderColor = NSColor.controlAccentColor.withAlphaComponent(0.8).cgColor
         activeOuterBorderView.layer?.backgroundColor = accentColor.withAlphaComponent(0.2).cgColor
-        activeBackgroundView.layer?.borderColor = accentColor.withAlphaComponent(0.8).cgColor
+        activeBackgroundView.borderColor = accentColor.withAlphaComponent(0.8)
 
         addressBarTextField.placeholderString = tabViewModel?.tab.content == .newtab ? UserText.addressBarPlaceholder : ""
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1207076354771782/f

**Description**:

This PR fixes the issue where the address bar border color displayed is wrong when a new window is opened.

**Video**

https://github.com/duckduckgo/macos-browser/assets/1089358/390a1545-28b1-481e-9f45-552cfbcb7f10

**Steps that I took to get to the solution:**

1. I noticed that the address bar was in focus even though the border color was different.
2. Changing the border color programmatically with a random color wasn’t updating the view.
3. Changing the boder color to a random color in the storyboard was actually working.
4. I noticed that the particular view in the storyboard is a `ColorView` but the outlet is a `NSView`.
5. I changed the outlet to `ColorView` and used the `borderColor` property defined in `ColorView`. This one implements `updateLayer()` during the view update cycle. `updateLayer()` seems to re-assign the border color to the layer during the update.

**Steps to test this PR**:
1. Open a new browsing window.
**Expected Result:** The Address bar focused border color should be blue(ish) instead of black.

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
