### PR TITLE
Changes to identify a zombie object

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -333,15 +333,15 @@ protocol NewWindowPolicyDecisionMaker {
     }
 
     deinit {
-        cleanUpBeforeClosing(onDeinit: true, webView: webView, userContentController: userContentController)
+        cleanUpBeforeClosing(onDeinit: true, webView: webView)
     }
 
     func cleanUpBeforeClosing() {
-        cleanUpBeforeClosing(onDeinit: false, webView: webView, userContentController: userContentController)
+        cleanUpBeforeClosing(onDeinit: false, webView: webView)
     }
 
     @MainActor(unsafe)
-    private func cleanUpBeforeClosing(onDeinit: Bool, webView: WebView, userContentController: UserContentController?) {
+    private func cleanUpBeforeClosing(onDeinit: Bool, webView: WebView) {
         let job = { [webView, userContentController] in
             webView.stopAllMedia(shouldStopLoading: true)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207265589515528/f

## Description

Partially rolls back some changes so we'll know if the zombie object showing up in stack traces is the `webView` or the `userContentController` property.

In other words, depending on how the stack trace looks like one our next reports we'll know which one is the zombie (with a priority checking the web view).

## Testing

Just make sure opening and closing tabs works.  Opening and closing windows should work too.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
