### PR TITLE
Fix closing full-screen videos with the X button on macOS 14.4 and above

### DIFF
--- a/DuckDuckGo/Tab/View/WebViewContainerView.swift
+++ b/DuckDuckGo/Tab/View/WebViewContainerView.swift
@@ -141,6 +141,7 @@ final class WebViewContainerView: NSView {
             }
             .store(in: &cancellables)
 
+        // https://app.asana.com/0/72649045549333/1206959015087322/f
         if #unavailable(macOS 14.4) {
             fullScreenWindowWillCloseCancellable = NotificationCenter.default.publisher(for: NSWindow.willCloseNotification, object: fullScreenWindow)
                 .sink { [weak self] notification in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1206959015087322/f
CC: @mallexxx 

**Description**:
Partially revert a fix to #1618 on macOS 14.4 and above because the original issue seems to be gone
and that fix seemed to have started breaking full screen videos in macOS Sonoma 14.4 and above.

**Steps to test this PR**:
1. Perform testing for #1618
2. Open a YouTube video in full screen (in Duck Player or not)
3. Close the full screen view using red 'X' button in the top left corner
4. Verify that the app doesn't crash and the YouTube (or Duck Player) tab looks good (has the pre-full-screen content).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
