### PR TITLE
Web Inspector focus for new tabs

### DIFF
--- a/DuckDuckGo/Tab/View/WebView.swift
+++ b/DuckDuckGo/Tab/View/WebView.swift
@@ -38,6 +38,12 @@ final class WebView: WKWebView {
 
     private var isLoadingObserver: Any?
 
+    private var shouldShowWebInspector: Bool {
+        // When a new tab is open, we don't want the web inspector to be active on screen and gain focus.
+        // When a new tab is open the other tab views are removed from the window, hence, we should not show the web inspector.
+        isInspectorShown && window != nil
+    }
+
     override func addTrackingArea(_ trackingArea: NSTrackingArea) {
         /// disable mouseEntered/mouseMoved/mouseExited events passing to Web View while it‘s loading
         /// see https://app.asana.com/0/1177771139624306/1206990108527681/f
@@ -163,8 +169,8 @@ final class WebView: WKWebView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if self.isInspectorShown {
-            self.openDeveloperTools()
+        if shouldShowWebInspector {
+            openDeveloperTools()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1204065533298601/f

**Description**:

Fix an issue that causes the web inspector to gain focus when a new tab is open.

**Steps to test this PR**:
1. Load a URL in a tab.
2. Select `View` -> `Developer` -> `Open Developer Tools` from the main menu.
3. On the web inspector, click the icon to detach it into a separate window.
4. Open a new tab.
**Expected Result:** The new tab address bar should be focused, and the web inspector should not be visible.
5. Click on the tab with the URL.
**Expected Result:** The web inspector should be visible and focused.

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
