### PR TITLE
DBP: Fix identifer and type not being parsed on data brokers

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/ExtractedProfile.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/ExtractedProfile.swift
@@ -24,6 +24,8 @@ struct ProfileSelector: Codable {
     let afterText: String?
     let beforeText: String?
     let separator: String?
+    let identifier: String?
+    let identifierType: String?
 }
 
 struct ExtractProfileSelectors: Codable, Sendable {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/BrokerJSONCodableTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/BrokerJSONCodableTests.swift
@@ -79,7 +79,9 @@ final class BrokerJSONCodableTests: XCTestCase {
                              "findElements": true
                            },
                            "profileUrl": {
-                             "selector": "a"
+                             "selector": ".link-to-details",
+                             "identifierType": "path",
+                             "identifier": "https://www.advancedbackgroundchecks.com/${id}"
                            }
                          }
                        }
@@ -341,6 +343,18 @@ final class BrokerJSONCodableTests: XCTestCase {
             for mirror in broker.mirrorSites {
                 XCTAssertNotEqual(mirror.url, mirror.name)
             }
+        } catch {
+            XCTFail("JSON string should be parsed correctly.")
+        }
+    }
+
+    func testVerecorJSONProfileURLSelector_isCorrectlyParsed() {
+        do {
+            let broker = try JSONDecoder().decode(DataBroker.self, from: verecorWithURLJSONString.data(using: .utf8)!)
+            let scanStep = try broker.scanStep()
+            let extractAction = scanStep.actions.first(where: { $0.actionType == .extract })! as! ExtractAction
+            XCTAssertEqual(extractAction.profile.profileUrl?.identifierType, "path")
+            XCTAssertEqual(extractAction.profile.profileUrl?.identifier, "https://www.advancedbackgroundchecks.com/${id}")
         } catch {
             XCTFail("JSON string should be parsed correctly.")
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207310210572645/f
Tech Design URL:
CC:

**Description**:
Fix `ExtractedProfileSelectors` not parsing `identifier` and `identifierType` from the broker JSON file.

**Steps to test this PR**:
1. Test that when scanning profiles on PeopleFinders for example
2. C-S-S returns extracted profiles where the identifier is the `id` query param instead of the full URL.