### PR TITLE
Fix a division-by-zero crash in the VPN code

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -12841,8 +12841,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = d3bd44976f6252e3f0276343116bb02ec22fdad8;
+				kind = exactVersion;
+				version = "144.0.7-3";
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "d3bd44976f6252e3f0276343116bb02ec22fdad8"
+        "revision" : "ada5f68970f098b3230dbd80a25cd048a606ac12",
+        "version" : "144.0.7-3"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "144.0.6"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "144.0.7-3"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),
     ],

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .library(name: "NetworkProtectionUI", targets: ["NetworkProtectionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "144.0.6"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "144.0.7-3"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.1"),
         .package(path: "../XPCHelper"),
         .package(path: "../SwiftUIExtensions"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "144.0.6"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "144.0.7-3"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1207299387361586/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2862
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/823

## Description

Fixes a crash caused by a division by zero.

## Testing

Just ensure the VPN starts correctly, works, stops, etc.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
