### PR TITLE
Search bar clickable area is too small

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -491,7 +491,6 @@ extension AddressBarViewController {
             self.clickPoint = event.locationInWindow
         }
         return event
-
     }
 
     func rightMouseDown(with event: NSEvent) -> NSEvent? {
@@ -499,8 +498,11 @@ extension AddressBarViewController {
         // Convert the point to view system
         let pointInView = view.convert(event.locationInWindow, from: nil)
 
-        // Check if the farthest view of the point location is not a NSButton or LottieAnimationView
-        guard view.hitTest(pointInView)?.shouldShowArrowCursor == false else { return event }
+        // If the view where the touch occurred is outside the AddressBar forward the event
+        guard let viewWithinAddressBar = view.hitTest(pointInView) else { return event }
+
+        // If the farthest view of the point location is a NSButton or LottieAnimationView don't show contextual menu
+        guard viewWithinAddressBar.shouldShowArrowCursor == false else { return nil }
 
         // The event location is not a button so we can forward the event to the textfield
         addressBarTextField.rightMouseDown(with: event)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1203899219213416/f

**Description**:

When the user right-clicks on the address search bar but not exactly in the NSTextField area, we show the contextual menu to add shortcuts to the navigation bar. This PR fixes the behaviour by intercepting right-clicks in the `AddressBarViewController` and forwarding them to the `AddressBarTextField` if necessary.  

**NOTE**
I’ve also prevented showing the context menu when we right-click above a button or Lottie animation view within the AddressBar because it felt right. If we don’t want this behaviour, I can change it back. 

**Steps to test this PR**:
1. Right-click at the edge of the address bar as per the video attached in [task](https://app.asana.com/0/1177771139624306/1203899219213416/f).
**Expected result:** The contextual menu for the `AddressBarTextField` should show  

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
