### PR TITLE
Dismiss Pinned Tab Previews when exiting full screen or hovering the semaphore buttons

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1822,6 +1822,10 @@
 		9FBD847B2BB3EC3300220859 /* MockAttributionOriginProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBD84792BB3EC3300220859 /* MockAttributionOriginProvider.swift */; };
 		9FDA6C212B79A59D00E099A9 /* BookmarkFavoriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDA6C202B79A59D00E099A9 /* BookmarkFavoriteView.swift */; };
 		9FDA6C222B79A59D00E099A9 /* BookmarkFavoriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDA6C202B79A59D00E099A9 /* BookmarkFavoriteView.swift */; };
+		9FDB93EB2BFEF71600AC50F6 /* Publishers.withLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDB93EA2BFEF71600AC50F6 /* Publishers.withLatestFrom.swift */; };
+		9FDB93EC2BFEF71600AC50F6 /* Publishers.withLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDB93EA2BFEF71600AC50F6 /* Publishers.withLatestFrom.swift */; };
+		9FDB93EE2BFEF84E00AC50F6 /* TabPreviewEventsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDB93ED2BFEF84E00AC50F6 /* TabPreviewEventsHandler.swift */; };
+		9FDB93EF2BFEF84E00AC50F6 /* TabPreviewEventsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDB93ED2BFEF84E00AC50F6 /* TabPreviewEventsHandler.swift */; };
 		9FEE98652B846870002E44E8 /* AddEditBookmarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FEE98642B846870002E44E8 /* AddEditBookmarkView.swift */; };
 		9FEE98662B846870002E44E8 /* AddEditBookmarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FEE98642B846870002E44E8 /* AddEditBookmarkView.swift */; };
 		9FEE98692B85B869002E44E8 /* BookmarksDialogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FEE98682B85B869002E44E8 /* BookmarksDialogViewModel.swift */; };
@@ -3541,6 +3545,8 @@
 		9FBD84762BB3E54200220859 /* InstallationAttributionPixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationAttributionPixelHandlerTests.swift; sourceTree = "<group>"; };
 		9FBD84792BB3EC3300220859 /* MockAttributionOriginProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAttributionOriginProvider.swift; sourceTree = "<group>"; };
 		9FDA6C202B79A59D00E099A9 /* BookmarkFavoriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFavoriteView.swift; sourceTree = "<group>"; };
+		9FDB93EA2BFEF71600AC50F6 /* Publishers.withLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publishers.withLatestFrom.swift; sourceTree = "<group>"; };
+		9FDB93ED2BFEF84E00AC50F6 /* TabPreviewEventsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPreviewEventsHandler.swift; sourceTree = "<group>"; };
 		9FEE98642B846870002E44E8 /* AddEditBookmarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditBookmarkView.swift; sourceTree = "<group>"; };
 		9FEE98682B85B869002E44E8 /* BookmarksDialogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksDialogViewModel.swift; sourceTree = "<group>"; };
 		9FEE986C2B85BA17002E44E8 /* AddEditBookmarkDialogCoordinatorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditBookmarkDialogCoordinatorViewModel.swift; sourceTree = "<group>"; };
@@ -7466,6 +7472,7 @@
 				B6A9E46A2614618A0067D1B9 /* OperatingSystemVersionExtension.swift */,
 				B637273C26CCF0C200C8CB02 /* OptionalExtension.swift */,
 				B684592125C93BE000DC17B6 /* Publisher.asVoid.swift */,
+				9FDB93EA2BFEF71600AC50F6 /* Publishers.withLatestFrom.swift */,
 				B68C2FB127706E6A00BF2C7D /* ProcessExtension.swift */,
 				B684592625C93C0500DC17B6 /* Publishers.NestedObjectChanges.swift */,
 				B6AAAC3D26048F690029438D /* RandomAccessCollectionExtension.swift */,
@@ -7551,6 +7558,7 @@
 			children = (
 				AAC82C5F258B6CB5009B6B42 /* TabPreviewWindowController.swift */,
 				AAE8B10F258A456C00E81239 /* TabPreviewViewController.swift */,
+				9FDB93ED2BFEF84E00AC50F6 /* TabPreviewEventsHandler.swift */,
 				1DB67F272B6FE21D003DF243 /* Model */,
 				1DC6696E2B6CF08200AA0645 /* Services */,
 			);
@@ -9688,6 +9696,7 @@
 				3706FB0E293F65D500E42796 /* FaviconManager.swift in Sources */,
 				3706FB0F293F65D500E42796 /* ChromiumFaviconsReader.swift in Sources */,
 				4B0BD7B82A9FE6E600EF609D /* NetworkProtectionOnboardingMenu.swift in Sources */,
+				9FDB93EF2BFEF84E00AC50F6 /* TabPreviewEventsHandler.swift in Sources */,
 				3706FB10293F65D500E42796 /* SuggestionTableRowView.swift in Sources */,
 				3706FB11293F65D500E42796 /* DownloadsPreferences.swift in Sources */,
 				3706FB12293F65D500E42796 /* PasswordManagementItemList.swift in Sources */,
@@ -9697,6 +9706,7 @@
 				EE6666702B56EDE4001D898D /* VPNLocationsHostingViewController.swift in Sources */,
 				3706FB16293F65D500E42796 /* StoredPermission.swift in Sources */,
 				3706FB17293F65D500E42796 /* FirePopoverCollectionViewHeader.swift in Sources */,
+				9FDB93EC2BFEF71600AC50F6 /* Publishers.withLatestFrom.swift in Sources */,
 				85774B042A71CDD000DE0561 /* BlockMenuItem.swift in Sources */,
 				3706FB19293F65D500E42796 /* FireViewController.swift in Sources */,
 				B6E3E55C2BC0041A00A41922 /* DownloadListStoreMock.swift in Sources */,
@@ -10901,6 +10911,7 @@
 				B6106BAD26A7BF390013B453 /* PermissionState.swift in Sources */,
 				371C0A2927E33EDC0070591F /* FeedbackPresenter.swift in Sources */,
 				B66260DD29AC5D4300E9E3EE /* NavigationProtectionTabExtension.swift in Sources */,
+				9FDB93EE2BFEF84E00AC50F6 /* TabPreviewEventsHandler.swift in Sources */,
 				1D1A33492A6FEB170080ACED /* BurnerMode.swift in Sources */,
 				14505A08256084EF00272CC6 /* UserAgent.swift in Sources */,
 				987799F12999993C005D8EB6 /* LegacyBookmarkStore.swift in Sources */,
@@ -11215,6 +11226,7 @@
 				B69A14F22B4D6FE800B9417D /* AddBookmarkFolderPopoverViewModel.swift in Sources */,
 				4BE65478271FCD41008D1D63 /* PasswordManagementNoteItemView.swift in Sources */,
 				AA5C8F632591021700748EB7 /* NSApplicationExtension.swift in Sources */,
+				9FDB93EB2BFEF71600AC50F6 /* Publishers.withLatestFrom.swift in Sources */,
 				AA9E9A5625A3AE8400D1959D /* NSWindowExtension.swift in Sources */,
 				7BD3AF5D2A8E7AF1006F9F56 /* KeychainType+ClientDefault.swift in Sources */,
 				370A34B12AB24E3700C77F7C /* SyncDebugMenu.swift in Sources */,

--- a/DuckDuckGo/Common/Extensions/Publishers.withLatestFrom.swift
+++ b/DuckDuckGo/Common/Extensions/Publishers.withLatestFrom.swift
@@ -1,0 +1,67 @@
+//
+//  Publishers.withLatestFrom.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Combine
+
+// More Info:
+// - RXMarbles: https://rxmarbles.com/#withLatestFrom
+// - https://jasdev.me/notes/with-latest-from
+extension Publisher {
+
+    ///  Upon an emission from self, emit the latest value from the
+    ///  second publisher, if any exists.
+    ///
+    ///  - parameter other: A second publisher source.
+    ///
+    ///  - returns: A publisher containing the latest value from the second publisher, if any.
+    func withLatestFrom<Other: Publisher>(
+        _ other: Other
+    ) -> AnyPublisher<Other.Output, Other.Failure> where Failure == Other.Failure {
+        withLatestFrom(other) { _, otherValue in otherValue }
+    }
+
+    ///  Merges two publishers into a single publisher by combining each value
+    ///  from self with the latest value from the second publisher, if any.
+    ///
+    ///  - parameter other: A second publisher source.
+    ///  - parameter resultSelector: Function to invoke for each value from the self combined
+    ///                              with the latest value from the second source, if any.
+    ///
+    ///  - returns: A publisher containing the result of combining each value of the self
+    ///             with the latest value from the second publisher, if any, using the
+    ///             specified result selector function.
+    func withLatestFrom<Other: Publisher, Result>(
+        _ other: Other,
+        resultSelector: @escaping (Output, Other.Output) -> Result
+    ) -> AnyPublisher<Result, Failure> where Other.Failure == Failure {
+        let upstream = share()
+
+        return other
+            .map { second in
+                upstream.map {
+                    resultSelector($0, second)
+                }
+            }
+            .switchToLatest()
+            .zip(upstream) // `zip`ping and discarding `\.1` allows for upstream completions to be projected down immediately.
+            .map(\.0)
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/DuckDuckGo/Common/View/AppKit/HoverTrackingArea.swift
+++ b/DuckDuckGo/Common/View/AppKit/HoverTrackingArea.swift
@@ -59,7 +59,7 @@ final class HoverTrackingArea: NSTrackingArea {
     private var observers: [NSKeyValueObservation]?
 
     init(owner: some Hoverable) {
-        super.init(rect: .zero, options: [.mouseEnteredAndExited, .activeInKeyWindow, .enabledDuringMouseDrag, .inVisibleRect], owner: owner, userInfo: nil)
+        super.init(rect: .zero, options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow, .enabledDuringMouseDrag, .inVisibleRect], owner: owner, userInfo: nil)
 
         observers = [
             owner.observe(\.backgroundColor) { [weak self] _, _ in self?.updateLayer() },
@@ -113,6 +113,10 @@ final class HoverTrackingArea: NSTrackingArea {
         view?.isMouseOver = false
         updateLayer(animated: true)
         view?.mouseExited(with: event)
+    }
+
+    @objc func mouseMoved(_ event: NSEvent) {
+        view?.mouseMoved(with: event)
     }
 
     private func mouseDownDidChange() {

--- a/DuckDuckGo/Common/View/AppKit/MouseOverView.swift
+++ b/DuckDuckGo/Common/View/AppKit/MouseOverView.swift
@@ -22,6 +22,7 @@ import Combine
 @objc protocol MouseOverViewDelegate: AnyObject {
 
     @objc optional func mouseOverView(_ mouseOverView: MouseOverView, isMouseOver: Bool)
+    @objc optional func mouseOverViewIsMoving(_ mouseOverView: MouseOverView)
 
     @objc optional func mouseClickView(_ mouseClickView: MouseClickView, mouseDownEvent: NSEvent)
     @objc optional func mouseClickView(_ mouseClickView: MouseClickView, mouseUpEvent: NSEvent)
@@ -59,6 +60,7 @@ internal class MouseOverView: NSControl, Hoverable {
             }
         }
     }
+
     @objc dynamic var isMouseDown: Bool = false
 
     override class var cellClass: AnyClass? {
@@ -129,6 +131,16 @@ internal class MouseOverView: NSControl, Hoverable {
 
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
+
+        if eventTypeMask.contains(.init(type: event.type)), let action {
+            NSApp.sendAction(action, to: target, from: self)
+        }
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+
+        delegate?.mouseOverViewIsMoving?(self)
 
         if eventTypeMask.contains(.init(type: event.type)), let action {
             NSApp.sendAction(action, to: target, from: self)

--- a/DuckDuckGo/PinnedTabs/Model/PinnedTabsViewModel.swift
+++ b/DuckDuckGo/PinnedTabs/Model/PinnedTabsViewModel.swift
@@ -65,6 +65,8 @@ final class PinnedTabsViewModel: ObservableObject {
         }
     }
 
+    @Published var mouseMoving: Void = ()
+
     @Published var shouldDrawLastItemSeparator: Bool = true {
         didSet {
             updateItemsWithoutSeparator()

--- a/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -56,9 +56,13 @@ struct PinnedTabView: View {
         }
 
         if controlActiveState == .key {
-            stack.onHover { [weak collectionModel, weak model] isHovered in
-                collectionModel?.hoveredItem = isHovered ? model : nil
-            }
+            stack
+                .onHover { [weak collectionModel, weak model] isHovered in
+                    collectionModel?.hoveredItem = isHovered ? model : nil
+                }
+                .onMouseMoving { [weak collectionModel] in
+                    collectionModel?.mouseMoving = ()
+                }
         } else {
             stack
         }

--- a/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -29,6 +29,7 @@ struct OtherTabBarViewItemsState {
 protocol TabBarViewItemDelegate: AnyObject {
 
     func tabBarViewItem(_ tabBarViewItem: TabBarViewItem, isMouseOver: Bool)
+    func tabBarViewItemMouseIsMoving(_ tabBarViewItem: TabBarViewItem)
 
     func tabBarViewItemCanBeDuplicated(_ tabBarViewItem: TabBarViewItem) -> Bool
     func tabBarViewItemCanBePinned(_ tabBarViewItem: TabBarViewItem) -> Bool
@@ -645,6 +646,10 @@ extension TabBarViewItem: MouseClickViewDelegate {
         }
         self.isMouseOver = isMouseOver
         view.needsLayout = true
+    }
+
+    func mouseOverViewIsMoving(_ mouseOverView: MouseOverView) {
+        delegate?.tabBarViewItemMouseIsMoving(self)
     }
 
     func mouseClickView(_ mouseClickView: MouseClickView, otherMouseDownEvent: NSEvent) {

--- a/DuckDuckGo/TabPreview/TabPreviewEventsHandler.swift
+++ b/DuckDuckGo/TabPreview/TabPreviewEventsHandler.swift
@@ -1,0 +1,83 @@
+//
+//  TabPreviewEventsHandler.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Combine
+
+final class TabPreviewEventsHandler {
+    private let unpinnedTabsMouseEnteredAndExitedPublisher = PassthroughSubject<TabPreviewEvent, Never>()
+    private var cancellables: Set<AnyCancellable> = []
+
+    private let pinnedTabsMouseExitedPublisher: AnyPublisher<TabPreviewEvent, Never>
+    private let pinnedTabsMouseEnteredPublisher: AnyPublisher<TabPreviewEvent, Never>
+
+    var eventPublisher: AnyPublisher<TabPreviewEvent, Never> {
+        Publishers.Merge3(pinnedTabsMouseExitedPublisher, pinnedTabsMouseEnteredPublisher, unpinnedTabsMouseEnteredAndExitedPublisher).eraseToAnyPublisher()
+    }
+
+    init(
+        pinnedTabHoveredIndexPublisher: AnyPublisher<Int?, Never>,
+        pinnedTabMouseMovingPublisher: AnyPublisher<Void, Never>
+    ) {
+        // Instead of showing the tab preview when the mouse enter the tracking area we want to show when the mouse moves within the area.
+        // The reason is that when the mouse is hovered on a Tab and we exit full screen, we don't want to show the preview again.
+        // We want to show it only if the user moves the mouse as per Safari behaviour.
+
+        pinnedTabsMouseExitedPublisher = pinnedTabHoveredIndexPublisher
+            .dropFirst()
+            .removeDuplicates()
+            .filter { index in
+                index == nil
+            }
+            .map { _ -> TabPreviewEvent in
+                TabPreviewEvent.hide(allowQuickRedisplay: true, withDelay: false)
+            }
+            .eraseToAnyPublisher()
+
+        pinnedTabsMouseEnteredPublisher = pinnedTabMouseMovingPublisher
+            .dropFirst()
+            .withLatestFrom(pinnedTabHoveredIndexPublisher)
+            .compactMap { index in
+                guard let index else { return nil }
+                return TabPreviewEvent.show(.pinned(index))
+            }
+            .eraseToAnyPublisher()
+    }
+
+    func unpinnedTabMouseExited() {
+        unpinnedTabsMouseEnteredAndExitedPublisher.send(.hide(allowQuickRedisplay: true, withDelay: true))
+    }
+
+    func unpinnedTabMouseEntered(tabBarViewItem: TabBarViewItem) {
+        unpinnedTabsMouseEnteredAndExitedPublisher.send(.show(.unpinned(tabBarViewItem)))
+    }
+
+}
+
+extension TabPreviewEventsHandler {
+
+    enum TabPreviewEvent {
+        enum Tab {
+            case pinned(Int)
+            case unpinned(TabBarViewItem)
+        }
+        case show(Tab)
+        case hide(allowQuickRedisplay: Bool, withDelay: Bool)
+    }
+
+}

--- a/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/View+MouseMoving.swift
+++ b/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/View+MouseMoving.swift
@@ -1,0 +1,97 @@
+//
+//  View+MouseMoving.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+public extension View {
+    func onMouseMoving(perform action: @escaping () -> Void) -> some View {
+        modifier(MouseMovingModifier(action))
+    }
+}
+
+private struct MouseMovingModifier: ViewModifier {
+    let isMoving: () -> Void
+
+    init(_ isMoving: @escaping () -> Void) {
+        self.isMoving = isMoving
+    }
+
+    func body(content: Content) -> some View {
+        content.background(
+            GeometryReader(content: { proxy in
+                TrackingAreaRepresentable(isMoving: isMoving, frame: proxy.frame(in: .global))
+            })
+        )
+    }
+}
+
+private extension MouseMovingModifier {
+
+    struct TrackingAreaRepresentable: NSViewRepresentable {
+        let isMoving: () -> Void
+        let frame: CGRect
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(isMoving: isMoving)
+        }
+
+        func makeNSView(context: Context) -> NSView {
+            let view = NSView(frame: frame)
+
+            let options: NSTrackingArea.Options = [
+                .mouseMoved,
+                .inVisibleRect,
+                .activeInKeyWindow
+            ]
+
+            let trackingArea = NSTrackingArea(
+                rect: frame,
+                options: options,
+                owner: context.coordinator,
+                userInfo: nil
+            )
+
+            view.addTrackingArea(trackingArea)
+            return view
+        }
+
+        func updateNSView(_ nsView: NSView, context: Context) {}
+
+        static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+            nsView.trackingAreas.forEach(nsView.removeTrackingArea(_:))
+        }
+    }
+
+    final class Coordinator: NSResponder {
+        var isMoving: () -> Void
+
+        init(isMoving: @escaping () -> Void) {
+            self.isMoving = isMoving
+            super.init()
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func mouseMoved(with event: NSEvent) {
+            isMoving()
+        }
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1177771139624306/1205566350070653/f
Cc: @tomasstrba 

**Description**:
Fix an issue that causes the pinned tab previews to stay on screen when hovering on the semaphore buttons and exiting fullscreen.

**Video**
https://github.com/duckduckgo/macos-browser/assets/1089358/99f7558d-2324-410d-bcbf-85fdbb9a7c35

**Steps to test this PR**:

**Scenario 1 - Full Screen**
1. Enter full screen.
2. Point cursor to the screen left corner so the semaphore buttons get shown.
3. Hover over a leftmost tab so the preview gets shown.
4. Exit full screen: Tab preview remains on the screen and doesn‘t change its position when hovering over the browser tabs.
**Expected Result:** The preview should disappear.

**Scenario 2 - Standard Screen**
1. Point to a pinned tab and wait for the preview.
2. Move the cursor to the green semaphore button and wait for the menu to appear.
3. Move the cursor away from the window.
**Expected Result:** The preview should disappear.

** UPDATE **

I converted this PR into a draft PR to get feedback before I implement tests.

I refactored the logic to present the Tab previews due to entering/exiting full screen.

When we exit full screen the mouse jumps on the tab due to the semaphore buttons appearing on the left-hand side of the tabs. This causes the preview to appear again. And if we prevent the preview from appearing by listening to the exit full screen notification, the preview won’t reappear when the user moves the mouse because mouseEntered/onHover is already triggered.

Instead of presenting the preview when the mouse enters the view, we present it when the mouse moves within the view. In this way, when the mouse jumps due to exiting full screen, the preview is not presented automatically, but it will when the user moves the mouse (the same behaviour as Safari).

I created a TabPreviewEventsHandler. Pinned tabs used a reactive stream to show/dismiss the preview, while non-pinned tabs used imperative code. I actually merged the events of pinned and non-pinned tabs into a publisher so there’s a single source. 
  
** NEW VIDEO **

https://github.com/duckduckgo/macos-browser/assets/1089358/5fd82590-de75-4b8a-957a-69784293894a



—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)