### PR TITLE
fix(duckplayer): prevent valid video links from opening in a new tab

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -137,7 +137,7 @@ extension DuckPlayerTabExtension: NewWindowPolicyDecisionMaker {
         // from opening, and just load it inside the current one instead
         if navigationAction.targetFrame == nil,
            navigationAction.safeSourceFrame?.webView?.url?.isDuckPlayer == true,
-           navigationAction.request.url?.isYoutubeVideoRecommendation == true || navigationAction.request.url?.isYoutubeVideo == true,
+           navigationAction.request.url?.isYoutubeVideo == true,
            let webView, let url = navigationAction.request.url {
             webView.load(URLRequest(url: url))
             return .cancel


### PR DESCRIPTION
---

Task/Issue URL: https://app.asana.com/0/1201141132935289/1207271615212493/f
Tech Design URL:
CC:

**Description**:

### TL;DR
This change refines the handling of certain links in the DuckPlayer. Specifically, it aims to prevent new tabs from opening when clicking on YouTube video links that would otherwise spawn a new tab.

### What changed?
Before we only captured links that would open in a new tab if it was a recommendation. After testing, I think we can loosen this to cover any valid youtube link. 

**Steps to test this PR**:
1. ensure your duck player setting is 'always enabled'
2. go to the following link `https://www.youtube.com/watch?v=Lpyl21JH6mA`
3. ^ this is a restricted video, so click 'watch on youtube'
4. If the PR is working, then the page should navigate to YouTube and NOT open a new tab

---
**BEFORE**

https://github.com/duckduckgo/macos-browser/assets/1643522/f0a009d4-0cce-412a-abde-5b902d42dc6f

---
**AFTER**

https://github.com/duckduckgo/macos-browser/assets/1643522/75bf25cf-1752-480a-80e4-17f76be0424c



<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
