### PR TITLE
move permanent survey card to first position

### DIFF
--- a/DuckDuckGo/HomePage/Model/HomePageContinueSetUpModel.swift
+++ b/DuckDuckGo/HomePage/Model/HomePageContinueSetUpModel.swift
@@ -286,12 +286,10 @@ extension HomePage.Models {
         }
 
         var randomisedFeatures: [FeatureType] {
-            var features = FeatureType.allCases
-            features.shuffle()
-            for (index, feature) in features.enumerated() where feature == .defaultBrowser {
-                features.remove(at: index)
-                features.insert(feature, at: 0)
-            }
+            var features: [FeatureType]  = [.permanentSurvey, .defaultBrowser]
+            var shuffledFeatures = FeatureType.allCases.filter { $0 != .defaultBrowser && $0 != .permanentSurvey }
+            shuffledFeatures.shuffle()
+            features.append(contentsOf: shuffledFeatures)
             return features
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1207354538419159/f

**Description**: Make the permanent survey first card

**Steps to test this PR**:
1. ./clean-app.sh debug
2. Go To Debug -> ResetData -> Change Activation Date -> More than 5 Days Ago
3. Check the survey card appears first followed by se as default
4. check the other card are shown in random order every time new tab page is opened

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
