### PR TITLE
autofill: don't prefix autofill email pixels with `m.mac.`

### DIFF
--- a/DuckDuckGo/Autofill/ContentOverlayViewController.swift
+++ b/DuckDuckGo/Autofill/ContentOverlayViewController.swift
@@ -325,7 +325,7 @@ extension ContentOverlayViewController: SecureVaultManagerDelegate {
 
             self.emailManager.updateLastUseDate()
 
-            PixelKit.fire(GeneralPixel.jsPixel(pixel), withAdditionalParameters: pixelParameters)
+            PixelKit.fire(NonStandardEvent(GeneralPixel.jsPixel(pixel)), withAdditionalParameters: pixelParameters)
         } else {
             PixelKit.fire(GeneralPixel.jsPixel(pixel), withAdditionalParameters: pixel.pixelParameters)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206682621538333/1207380134103391/f
Tech Design URL: N/A
CC: @GioSensation 

**Description**:
Pixels fired for email autofill use-cases are intentionally not prefixed with `m.mac.`, though the historical reason isn't clear to me. The migration to PixelKit for pixel management[^1] caused those email-related pixels to be prefixed. Wrap email-related JS pixels in `NonStandardEvent`s to prevent that prefixing, to restore their original intended names.

[^1]: d885fd02d (PixelKit adoption (#2557), 2024-04-17)

**Steps to test this PR**:
1. Run tests via XCode
2. Load debug build with Pixel debug logging enabled
3. Click on a personal duck address and a generated duck address in autofill
4. Ensure the fired events are `email_filled_*_macos_desktop` instead of `m_mac_email_filled_*_macos_desktop`
5. Fill a form with a saved identity and ensure the fired event still has the `m_mac_` prefix.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
