### PR TITLE
Notify Asana about failed UI tests workflows runs

### DIFF
--- a/.github/workflows/sync_end_to_end.yml
+++ b/.github/workflows/sync_end_to_end.yml
@@ -120,8 +120,7 @@ jobs:
 
   notify-failure:
     name: Notify on failure
-    # if: ${{ always() && github.event_name == 'schedule' && (needs.sync-end-to-end-tests.result == 'failure' || needs.sync-end-to-end-tests.result == 'cancelled') }}
-    if: ${{ always() && (needs.sync-end-to-end-tests.result == 'failure' || needs.sync-end-to-end-tests.result == 'cancelled') }}
+    if: ${{ always() && github.event_name == 'schedule' && (needs.sync-end-to-end-tests.result == 'failure' || needs.sync-end-to-end-tests.result == 'cancelled') }}
     needs: [sync-end-to-end-tests]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -111,8 +111,7 @@ jobs:
 
   notify-failure:
     name: Notify on failure
-    # if: ${{ always() && github.event_name == 'schedule' && (needs.ui-tests.result == 'failure' || needs.ui-tests.result == 'cancelled') }}
-    if: ${{ always() && (needs.ui-tests.result == 'failure' || needs.ui-tests.result == 'cancelled') }}
+    if: ${{ always() && github.event_name == 'schedule' && (needs.ui-tests.result == 'failure' || needs.ui-tests.result == 'cancelled') }}
     needs: [ui-tests]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207501370511926/f

**Description**:
Create a task in macOS App Development project for every scheduled workflow run of UI tests or
Sync E2E tests, that fails or times out.

**Steps to test this PR**:
Verify these two tasks that were created when the workflow runs failed:
* https://app.asana.com/0/1201037661562251/1207501893043384/f
* https://app.asana.com/0/1201037661562251/1207501815326389/f
(note that to have tasks created, the `github.event_name == 'schedule'` requirement was temporarily disabled)

Verify that workflow runs that complete successfully do not create tasks in Asana:
* https://github.com/duckduckgo/macos-browser/actions/runs/9396954579
* https://github.com/duckduckgo/macos-browser/actions/runs/9396955277

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
