### PR TITLE
Prevent showing multiple VPN uninstalled popovers

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -384,6 +384,7 @@ final class NavigationBarViewController: NSViewController {
         UserDefaults.netP
             .publisher(for: \.networkProtectionShouldShowVPNUninstalledMessage)
             .receive(on: DispatchQueue.main)
+            .removeDuplicates()
             .sink { [weak self] shouldShowUninstalledMessage in
                 if shouldShowUninstalledMessage {
                     self?.showVPNUninstalledFeedback()
@@ -394,7 +395,8 @@ final class NavigationBarViewController: NSViewController {
     }
 
     @objc private func showVPNUninstalledFeedback() {
-        guard view.window?.isKeyWindow == true else { return }
+        // Only show the popover if we aren't already presenting one:
+        guard view.window?.isKeyWindow == true, (self.presentedViewControllers ?? []).isEmpty else { return }
 
         DispatchQueue.main.async {
             let viewController = PopoverMessageViewController(message: "DuckDuckGo VPN was uninstalled")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1193060753475688/1207481654222172/f
Tech Design URL:
CC:

**Description**:

This PR updates the VPN uninstaller flow to avoid showing multiple VPN uninstalled popovers at once.

It does this by filtering out duplicates from the publisher we listen to, and checking that the window we're presenting on doesn't already have a presented view controller.

**Steps to test this PR**:
1. Uninstall the VPN and check that you only see the popover once

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
