### PR TITLE
Add platform filters for survey attributes

### DIFF
--- a/DuckDuckGo/Common/Surveys/SurveyRemoteMessage.swift
+++ b/DuckDuckGo/Common/Surveys/SurveyRemoteMessage.swift
@@ -36,6 +36,8 @@ struct SurveyRemoteMessage: Codable, Equatable, Identifiable, Hashable {
     struct Attributes: Codable, Equatable, Hashable {
         let subscriptionStatus: String?
         let subscriptionBillingPeriod: String?
+        let sparkleSubscriptionPurchasePlatforms: [String]?
+        let appStoreSubscriptionPurchasePlatforms: [String]?
         let minimumDaysSinceSubscriptionStarted: Int?
         let maximumDaysUntilSubscriptionExpirationOrRenewal: Int?
         let daysSinceVPNEnabled: Int?

--- a/DuckDuckGo/Common/Surveys/SurveyRemoteMessaging.swift
+++ b/DuckDuckGo/Common/Surveys/SurveyRemoteMessaging.swift
@@ -208,6 +208,26 @@ final class DefaultSurveyRemoteMessaging: SurveyRemoteMessaging {
                 }
             }
 
+            #if APPSTORE
+            if let appStorePurchasePlatforms = message.attributes.appStoreSubscriptionPurchasePlatforms {
+                if appStorePurchasePlatforms.contains(subscription.platform.rawValue) {
+                    attributeMatchStatus = true
+                } else {
+                    return false
+                }
+            }
+            #endif
+
+            #if SPARKLE
+            if let sparklePurchasePlatforms = message.attributes.sparkleSubscriptionPurchasePlatforms {
+                if sparklePurchasePlatforms.contains(subscription.platform.rawValue) {
+                    attributeMatchStatus = true
+                } else {
+                    return false
+                }
+            }
+            #endif
+
             return attributeMatchStatus
 
         }

--- a/UnitTests/HomePage/Resources/survey-messages.json
+++ b/UnitTests/HomePage/Resources/survey-messages.json
@@ -9,7 +9,9 @@
             "minimumDaysSinceSubscriptionStarted": 1,
             "maximumDaysUntilSubscriptionExpirationOrRenewal": 30,
             "daysSinceVPNEnabled": 2,
-            "daysSincePIREnabled": 3
+            "daysSincePIREnabled": 3,
+            "sparkleSubscriptionPurchasePlatforms": ["stripe"],
+            "appStoreSubscriptionPurchasePlatforms": ["stripe"]
         },
         "action": {
             "actionTitle": "Action 1",

--- a/UnitTests/HomePage/SurveyRemoteMessageTests.swift
+++ b/UnitTests/HomePage/SurveyRemoteMessageTests.swift
@@ -59,6 +59,8 @@ final class SurveyRemoteMessageTests: XCTestCase {
         XCTAssertEqual(firstMessage.attributes.daysSinceVPNEnabled, 2)
         XCTAssertEqual(firstMessage.attributes.daysSincePIREnabled, 3)
         XCTAssertEqual(firstMessage.attributes.maximumDaysUntilSubscriptionExpirationOrRenewal, 30)
+        XCTAssertEqual(firstMessage.attributes.appStoreSubscriptionPurchasePlatforms, ["stripe"])
+        XCTAssertEqual(firstMessage.attributes.sparkleSubscriptionPurchasePlatforms, ["stripe"])
         XCTAssertNotNil(firstMessagePresentableSurveyURL)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207569632254644/f
Tech Design URL:
CC:

**Description**:

This PR updates the survey mechanism to support limiting messages to users who purchased their subscription on specific platforms, on a Sparkle/App Store basis. This will let us show surveys to users on App Store builds who purchased through the App Store, for example.

**Steps to test this PR**:
1. Check that CI passes
2. Sign into a Privacy Pro account that matches the place that you bought it (i.e., Stripe in the Sparkle build) and check that when you run it, a card appears in the new tab page after launching the app and backgrounding/foregrounding it a couple times
3. If you use this same account in the other build, no card should appear as the purchase platform doesn't match

![CleanShot 2024-06-13 at 19 01 18@2x](https://github.com/duckduckgo/macos-browser/assets/183774/694d7d71-b2e7-4b3b-b7d3-87d75e0c5713)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
