### PR TITLE
Update Sparkle to 2.6.3

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13038,7 +13038,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle.git";
 			requirement = {
 				kind = exactVersion;
-				version = 2.6.0;
+				version = 2.6.3;
 			};
 		};
 		B65CD8C92B316DF100A595BB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "0a4caaf7a81eea2cece651ef4b17331fa0634dff",
-        "version" : "2.6.0"
+        "revision" : "b456fd404954a9e13f55aa0c88cd5a40b8399638",
+        "version" : "2.6.3"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1207585576095794/f

**Description**:

Update to [Sparkle 2.6.3](https://github.com/sparkle-project/Sparkle/releases/tag/2.6.3).

[Sparkle 2.6.1](https://github.com/sparkle-project/Sparkle/releases/tag/2.6.1) included a major security fix that fixes a vulnerability that allows an attacker to replace an existing signed update with another payload, which bypasses Sparkle’s (Ed)DSA signing checks.

**Steps to test this PR:**

Scenario 1: App up to date

1. Ensure that DuckDuckGo Privacy Browser target version is 1.92.0 and build number 203.
2. Ensure that DuckDuckGo Privacy Browser scheme is selected.
3. Run the App
4. Click on Main Menu -> DuckDuckGo -> Check for Updates…

Expected Result: A popup should appear informing the user that they’re up to date.

Scenario 2: App needs update

1. Change the DuckDuckGo Privacy Browser target build number to 199. You can leave version to 1.91.0.
2. Ensure that DuckDuckGo Privacy Browser scheme is selected.
3. Run the App
4. Click on Main Menu -> DuckDuckGo -> Check for Updates…

Expected Result: A popup should appear informing the user that an update is available. Make sure the update can be installed.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
