### PR TITLE
Fix AutocompleteTests to match updated suggestions list behavior

### DIFF
--- a/UITests/AutocompleteTests.swift
+++ b/UITests/AutocompleteTests.swift
@@ -137,11 +137,11 @@ class AutocompleteTests: XCTestCase {
             "The enclosing cell for the suggestion cell for the website didn't become available in a reasonable timeframe. If this is unexpected, it could be due to a significant change in the layout of this interface."
         )
 
-        // And that should be a website suggestion
+        // And that should be a search suggestion (not website)
         XCTAssertEqual(
             containerCellForWebsiteSuggestion.images.firstMatch.label,
-            "Web",
-            "Although the suggestion was found, it didn't have the \"Web\" image next to it in suggestions."
+            "Search",
+            "Although the suggestion was found, it didn't have the \"Search\" image next to it in suggestions."
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1207585357593923/f

**Description**:
We're not converting url-like search suggestions to URLs, so this change updates the UI test to fix it.

**Steps to test this PR**:
Verify that [this workflow run](https://github.com/duckduckgo/macos-browser/actions/runs/9544285314) is green.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
