### PR TITLE
Run UI tests on push to release branch

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
      - cron: '0 3 * * 1-5' # 3AM UTC offsetted to legacy to avoid action-junit-report@v4 bug
-  push:
+  pull_request:
     branches:
       - hotfix/*
       - release/*
@@ -119,7 +119,7 @@ jobs:
 
   notify-failure:
     name: Notify on failure
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') && (needs.ui-tests.result == 'failure' || needs.ui-tests.result == 'cancelled') }}
+    if: ${{ always() && github.event_name == 'schedule' && (needs.ui-tests.result == 'failure' || needs.ui-tests.result == 'cancelled') }}
     needs: [ui-tests]
     runs-on: ubuntu-latest
 
@@ -131,7 +131,4 @@ jobs:
         asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
         asana-project: ${{ vars.MACOS_APP_DEVELOPMENT_ASANA_PROJECT_ID }}
         asana-task-name: GH Workflow Failure - UI Tests
-        asana-task-description: |
-          The UI Tests workflow run on ${{ github.ref_name }} branch has failed. See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
-
-          If the workflow was run on push and got cancelled because it was superseded by another push event, feel free to close this task straight away.
+        asana-task-description: The UI Tests workflow has failed. See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1207610721118526/f

**Description**:
This change causes UI tests workflow to be run on every push to release and hotfix branches.
It also adds mechanism of cancelling previous unfinished workflows in case a new push event is triggered.

**Steps to test this PR**:
See the history of UI tests runs: https://github.com/duckduckgo/macos-browser/actions/workflows/ui_tests.yml

You can also check out `dominik/ui-tests-test-branch` (note a different name from the PR branch).
That branch has a modified workflow that times out after 10 minutes and also runs on pushes to that branch.
Push a commit there (e.g. use `git commit --allow-empty -m "ping"`) to trigger a workflow run.
Push another commit to trigger another workflow run.
Verify that the previous workflow run has been cancelled. Note that it also creates a task about it (it's a GHA limitation that we can't distinguish between workflows cancelled manually/by system or those cancelled due to timeout).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
