### PR TITLE
Fix VPN toggle failures

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13021,8 +13021,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = b0997a02b9f4e07d414804386f3fa2c9e64e8573;
+				kind = exactVersion;
+				version = "156.0.0-2";
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "b0997a02b9f4e07d414804386f3fa2c9e64e8573"
+        "revision" : "2806adf8cae5bffebf0cf5043210f29bac0bade1",
+        "version" : "156.0.0-2"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "156.0.0-1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "156.0.0-2"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),
     ],

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "156.0.0-1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "156.0.0-2"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.1"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "156.0.0-1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "156.0.0-2"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1207629954356116/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2979
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/858

## Description

The VPN toggle is sometimes failing silently, apparently due to a race condition created by calls to `sendProviderMessage` while the VPN is starting up.

This PR changes our logic to limit when those calls are made, since none of them make sense to call when the VPN is connecting.

## Testing

- Test turning the VPN ON and OFF.
- Go to activity monitor, kill the tunnel extension and try again.
- Try variants, make sure the server address, location and data volume look right.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
