### PR TITLE
fix crash on quit right after launch

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -636,13 +636,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    @MainActor
     private func setUpAutoClearHandler() {
-        DispatchQueue.main.async {
-            self.autoClearHandler = AutoClearHandler(preferences: .shared,
+        let autoClearHandler = AutoClearHandler(preferences: .shared,
                                                 fireViewModel: FireCoordinator.fireViewModel,
-                                                     stateRestorationManager: self.stateRestorationManager)
-            self.autoClearHandler.handleAppLaunch()
-            self.autoClearHandler.onAutoClearCompleted = {
+                                                stateRestorationManager: self.stateRestorationManager)
+        self.autoClearHandler = autoClearHandler
+        DispatchQueue.main.async {
+            autoClearHandler.handleAppLaunch()
+            autoClearHandler.onAutoClearCompleted = {
                 NSApplication.shared.reply(toApplicationShouldTerminate: true)
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1207629503281977/f
Sentry URL: https://errors.duckduckgo.com/organizations/ddg/issues/23562/events/20f7de362f1711efad0e85bf8f8f9cca/?project=6

**Description**:
- Fixes crash due to implicitly unwrapped optional access when the quit command is sent right after the app launch (because of asynchronous `autoClearHandler` initialization)

**Steps to test this PR**:
1. Add `RunLoop.main.run(until: Date().addingTimeInterval(5))` to the `AppDelegate.applicationWillFinishLaunching` method
2. Run the app, right after running it run `osascript -e 'tell application "/Applications/DEBUG/DuckDuckGo.app" to quit'` in terminal
3. Validate clear-on-quit logics is correctly handled and no crash happens

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
