### PR TITLE
Remove noise from wake pixel

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13021,8 +13021,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = ad2df51ab5023e3ebd81f523bce77c864e8d7504;
+				kind = exactVersion;
+				version = "159.0.2-1";
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "ad2df51ab5023e3ebd81f523bce77c864e8d7504"
+        "revision" : "27b2330b2c65779760d55e866ed0fa6182b2fce4",
+        "version" : "159.0.2-1"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "159.0.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "159.0.2-1"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),
     ],

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "159.0.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "159.0.2-1"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.1"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "159.0.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "159.0.2-1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206580121312550/1207646371500325/f

iOS PR: https://github.com/duckduckgo/iOS/pull/2986
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/860

## Description

We're emoving known noise from wake pixels, and tunnel update pixels, plus potentially removing unnecessary calls to backend and other code handling that shouldn't happen when the VPN is disconnected.

## Testing

1. Launch Console.app
2. Filter by "👾" and `process:com.duckduckgo.macos.vpn.network-extension.debug` (process is important to remove noise from release builds in your computer)
3. Start the VPN
4. Put computer to sleep for 1 min
5. Wake computer
6. Check you see pixels for the wake attempt.
7. Turn the VPN off from the UI
8. Put computer to sleep for 1 min
9. Wake computer
10. Check there are no wake attempt pixels

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
