### PR TITLE
DBP: Check if exponential backoff exceeds Int.max before converting it

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OperationPreferredDateCalculator.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OperationPreferredDateCalculator.swift
@@ -99,6 +99,16 @@ struct OperationPreferredDateCalculator {
     private func calculateNextRunDateOnError(schedulingConfig: DataBrokerScheduleConfig,
                                              historyEvents: [HistoryEvent]) -> TimeInterval {
         let pastTries = historyEvents.filter { $0.isError }.count
-        return min(Int(pow(2.0, Double(pastTries))), schedulingConfig.retryError).hoursToSeconds
+        let doubleValue = pow(2.0, Double(pastTries))
+
+        // Check if the double value is within the range of Int before converting
+        let intValue: Int
+        if doubleValue > Double(Int.max) {
+            intValue = Int.max
+        } else {
+            intValue = Int(doubleValue)
+        }
+
+        return min(intValue, schedulingConfig.retryError).hoursToSeconds
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1207642874812352/f
Tech Design URL:
CC:

**Description**:
We were calculating the past tries exponential backoff using a power of 2. The problem was if we had more than 1074 errors, we will pass the `Int.max` that equals: `9,223,372,036,854,775,807` on a 64-bit machine.

pow(2, 1074) > `9,223,372,036,854,775,807`

**Steps to test this PR**:
1. I’ve added unit testing for it, but in order to test it, you can try to insert more than 1076 opt-out errors manually in the database in the history events and test the agent does not crash.