### PR TITLE
Fix race condition in WKDownload release on main queue fix

### DIFF
--- a/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
+++ b/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
@@ -582,7 +582,7 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
                 withExtendedLifetime(download) {}
             }
             // to avoid race condition we clear the ivar first,
-            // then pass the WKDownload liftime extension to the main queue
+            // then pass the WKDownload lifetime extension to the main queue
             self.download = nil
             DispatchQueue.main.async(execute: extendLifetime)
         }
@@ -756,7 +756,7 @@ extension WebKitDownloadTask {
             return ""
         }
         return MainActor.assumeIsolated {
-            "<Task \(download) – \(state)>"
+            "<Task \(download!) – \(state)>"
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202406491309510/1207645017736465/f
Sentry: https://errors.duckduckgo.com/organizations/ddg/issues/18872/?project=6&query=is%3Aunresolved+app_version%3A1.86.1&referrer=issue-stream&statsPeriod=24h&stream_index=7

**Description**:
- Fix possible race condition when `WKDownload` main queue lifetime extension passes before the ivars deallocation block leading to crash on macOS 11

**Steps to test this PR**:
1. Test on macOS 11
2. Add `try? await Task.sleep(interval: 2)` at line `WebKitDownloadTask.swift:201` (in the `tempFileUrlUpdated` method; and `Thread.sleep(forTimeInterval: 1)` at the end of `WebKitDownloadTask.deinit` - to easier simulate the race condition
3. Open Fire Window, paste&go to https://proof.ovh.net/files/1Mb.dat – this will initiate a quick download; Instantly close the fire window. Repeat several times – validate the downloads are completed and the browser doesn‘t crash

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
