### PR TITLE
fix crash on favicons removal error; add database index by UUID

### DIFF
--- a/DuckDuckGo/Favicons/Services/Favicons.xcdatamodeld/Favicons.xcdatamodel/contents
+++ b/DuckDuckGo/Favicons/Services/Favicons.xcdatamodeld/Favicons.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="FaviconHostReferenceManagedObject" representedClassName="FaviconHostReferenceManagedObject" syncable="YES" codeGenerationType="class">
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="documentUrlEncrypted" attributeType="Transformable" valueTransformerName="NSURLTransformer"/>
@@ -16,16 +16,14 @@
         <attribute name="relation" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="urlEncrypted" attributeType="Transformable" valueTransformerName="NSURLTransformer"/>
     </entity>
-    <entity name="FaviconUrlReferenceManagedObject" representedClassName="FaviconUrlReferenceManagedObject" syncable="YES" codeGenerationType="class">
+    <entity name="FaviconUrlReferenceManagedObject" representedClassName="FaviconUrlReferenceManagedObject" versionHashModifier="added UUID index" syncable="YES" codeGenerationType="class">
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="documentUrlEncrypted" attributeType="Transformable" valueTransformerName="NSURLTransformer"/>
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="mediumFaviconUrlEncrypted" optional="YES" attributeType="Transformable" valueTransformerName="NSURLTransformer"/>
         <attribute name="smallFaviconUrlEncrypted" optional="YES" attributeType="Transformable" valueTransformerName="NSURLTransformer"/>
+        <fetchIndex name="byUUIDIndex">
+            <fetchIndexElement property="identifier" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
-    <elements>
-        <element name="FaviconHostReferenceManagedObject" positionX="-54" positionY="-9" width="128" height="119"/>
-        <element name="FaviconManagedObject" positionX="-63" positionY="-18" width="128" height="14"/>
-        <element name="FaviconUrlReferenceManagedObject" positionX="-18" positionY="63" width="128" height="104"/>
-    </elements>
 </model>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1207643414069373/f
Sentry URL: https://errors.duckduckgo.com/organizations/ddg/issues/63972/events/96d4f51e331111ef8d1fa048a5a13d9e/?project=6&query=is%3Aunresolved+app_version%3A1.92.0&referrer=next-event&sort=freq&statsPeriod=14d&stream_index=20

**Description**:
- Fixed crash on 2nd `continuation.resume` call in favicons store remove method
- Added index by UUID to favicons database

**Steps to test this PR**:
1. Validate favicons are migrated and loaded on first launch of the updated db
2. Validate favicons removal works (use Fire)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
