### PR TITLE
Fixes an encoding issue in the XPC communication

### DIFF
--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionIPC/VPNControllerXPCClient.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionIPC/VPNControllerXPCClient.swift
@@ -37,7 +37,7 @@ protocol XPCClientInterfaceObjC {
     func serverInfoChanged(payload: Data)
     func statusChanged(payload: Data)
     func dataVolumeUpdated(payload: Data)
-    func knownFailureUpdated(failure: KnownFailure?)
+    func knownFailureUpdated(payload: Data)
 }
 
 public final class VPNControllerXPCClient {
@@ -166,6 +166,14 @@ private final class TunnelControllerXPCClientDelegate: XPCClientInterfaceObjC {
 
         dataVolumeObserver.publish(dataVolume)
         clientDelegate?.dataVolumeUpdated(dataVolume)
+    }
+
+    func knownFailureUpdated(payload: Data) {
+        guard let failure = try? JSONDecoder().decode(KnownFailure?.self, from: payload) else {
+            return
+        }
+
+        knownFailureUpdated(failure: failure)
     }
 
     func knownFailureUpdated(failure: KnownFailure?) {

--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionIPC/VPNControllerXPCServer.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionIPC/VPNControllerXPCServer.swift
@@ -179,8 +179,16 @@ extension VPNControllerXPCServer: XPCClientInterface {
     }
 
     public func knownFailureUpdated(_ failure: KnownFailure?) {
+        let payload: Data
+
+        do {
+            payload = try JSONEncoder().encode(failure)
+        } catch {
+            return
+        }
+
         xpc.forEachClient { client in
-            client.knownFailureUpdated(failure: failure)
+            client.knownFailureUpdated(payload: payload)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203108348835387/1207646922380191/f

## Description

XPC can only encode objects that implement `NSSecureCoding`.  We were trying to encode an object that didn't implement that protocol, but just `Codable`.

## Testing

1. Run the app once, make sure the VPN agent starts (start the VPN if needed).
2. Go back to Xcode and attach to the VPN agent app.
3. Add a breakpoint for ObjC exceptions.
4. Increment the version number in `Version.xcconfig`
5. Run the app again

On startup, the VPN agent should not crash.  Double check in `Console.app` to see there's no crash.

The same testing steps can be used in `main` to test the original crash.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
