### PR TITLE
Hide survey messages based on whether others have been interacted with

### DIFF
--- a/DuckDuckGo/Common/Surveys/SurveyRemoteMessage.swift
+++ b/DuckDuckGo/Common/Surveys/SurveyRemoteMessage.swift
@@ -42,6 +42,7 @@ struct SurveyRemoteMessage: Codable, Equatable, Identifiable, Hashable {
         let maximumDaysUntilSubscriptionExpirationOrRenewal: Int?
         let daysSinceVPNEnabled: Int?
         let daysSincePIREnabled: Int?
+        let hideIfInteractedWithMessage: [String]?
     }
 
     let id: String

--- a/DuckDuckGo/Common/Surveys/SurveyRemoteMessaging.swift
+++ b/DuckDuckGo/Common/Surveys/SurveyRemoteMessaging.swift
@@ -131,6 +131,13 @@ final class DefaultSurveyRemoteMessaging: SurveyRemoteMessaging {
 
             var attributeMatchStatus = false
 
+            if let interactedMessagesToCheck = message.attributes.hideIfInteractedWithMessage {
+                let dismissedMessageIDs = messageStorage.dismissedMessageIDs()
+                for interactedMessage in interactedMessagesToCheck where dismissedMessageIDs.contains(interactedMessage) {
+                    return false
+                }
+            }
+
             // Check subscription status:
             if let messageSubscriptionStatus = message.attributes.subscriptionStatus {
                 if let subscriptionStatus = Subscription.Status(rawValue: messageSubscriptionStatus) {

--- a/UnitTests/HomePage/Resources/survey-messages.json
+++ b/UnitTests/HomePage/Resources/survey-messages.json
@@ -18,5 +18,26 @@
             "actionType": "openSurveyURL",
             "actionURL": "https://duckduckgo.com/"
         }
+    },
+    {
+        "id": "message-2",
+        "cardTitle": "Title 2",
+        "cardDescription": "Description 2",
+        "attributes": {
+            "subscriptionStatus": "Auto-Renewable",
+            "subscriptionBillingPeriod": "Monthly",
+            "minimumDaysSinceSubscriptionStarted": 1,
+            "maximumDaysUntilSubscriptionExpirationOrRenewal": 30,
+            "daysSinceVPNEnabled": 2,
+            "daysSincePIREnabled": 3,
+            "sparkleSubscriptionPurchasePlatforms": ["stripe"],
+            "appStoreSubscriptionPurchasePlatforms": ["stripe"],
+            "hideIfInteractedWithMessage": ["message-1"]
+        },
+        "action": {
+            "actionTitle": "Action 1",
+            "actionType": "openSurveyURL",
+            "actionURL": "https://duckduckgo.com/"
+        }
     }
 ]

--- a/UnitTests/HomePage/SurveyRemoteMessageTests.swift
+++ b/UnitTests/HomePage/SurveyRemoteMessageTests.swift
@@ -36,7 +36,7 @@ final class SurveyRemoteMessageTests: XCTestCase {
         let decoder = JSONDecoder()
         let decodedMessages = try decoder.decode([SurveyRemoteMessage].self, from: data)
 
-        XCTAssertEqual(decodedMessages.count, 1)
+        XCTAssertEqual(decodedMessages.count, 2)
 
         guard let firstMessage = decodedMessages.first(where: { $0.id == "message-1"}) else {
             XCTFail("Failed to find expected message")
@@ -62,6 +62,13 @@ final class SurveyRemoteMessageTests: XCTestCase {
         XCTAssertEqual(firstMessage.attributes.appStoreSubscriptionPurchasePlatforms, ["stripe"])
         XCTAssertEqual(firstMessage.attributes.sparkleSubscriptionPurchasePlatforms, ["stripe"])
         XCTAssertNotNil(firstMessagePresentableSurveyURL)
+
+        guard let lastMessage = decodedMessages.first(where: { $0.id == "message-2"}) else {
+            XCTFail("Failed to find expected message")
+            return
+        }
+
+        XCTAssertEqual(lastMessage.attributes.hideIfInteractedWithMessage, ["message-1"])
     }
 
     func testWhenGettingSurveyURL_AndSurveyURLHasParameters_ThenParametersAreReplaced() {

--- a/UnitTests/HomePage/SurveyRemoteMessagingTests.swift
+++ b/UnitTests/HomePage/SurveyRemoteMessagingTests.swift
@@ -224,13 +224,82 @@ final class SurveyRemoteMessagingTests: XCTestCase {
         XCTAssertEqual(presentableMessages, [message])
     }
 
+    func testWhenMessageHasBeenDismissed_AndOtherMessageShouldHideBasedOnThat_ThenPresentableMessagesAreEmpty() async {
+        let request = MockNetworkProtectionRemoteMessagingRequest()
+        let storage = MockSurveyRemoteMessagingStorage()
+        let activationDateStorage = MockWaitlistActivationDateStore()
+        let dismissedMessageID = "dismissed-message"
+
+        let messages = [
+            mockMessage(id: "123", hideIfInteractedWithMessage: dismissedMessageID)
+        ]
+
+        request.result = .success(messages)
+        activationDateStorage._daysSinceActivation = 10
+
+        let messaging = DefaultSurveyRemoteMessaging(
+            messageRequest: request,
+            messageStorage: storage,
+            accountManager: accountManager,
+            subscriptionFetcher: subscriptionFetcher,
+            vpnActivationDateStore: activationDateStorage,
+            pirActivationDateStore: activationDateStorage,
+            minimumRefreshInterval: 0,
+            userDefaults: defaults
+        )
+
+        storage.dismissRemoteMessage(with: dismissedMessageID)
+        XCTAssertEqual(storage.storedMessages(), [])
+        XCTAssertNotNil(activationDateStorage.daysSinceActivation())
+
+        await messaging.fetchRemoteMessages()
+
+        XCTAssertTrue(request.didFetchMessages)
+        XCTAssertEqual(storage.storedMessages(), [])
+    }
+
+    func testWhenMessageHasBeenDismissed_AndOtherMessageShouldNotHideBasedOnThat_ThenPresentableMessagesAreNotEmpty() async {
+        let request = MockNetworkProtectionRemoteMessagingRequest()
+        let storage = MockSurveyRemoteMessagingStorage()
+        let activationDateStorage = MockWaitlistActivationDateStore()
+        let dismissedMessageID = "dismissed-message"
+
+        let messages = [
+            mockMessage(id: "123", hideIfInteractedWithMessage: dismissedMessageID)
+        ]
+
+        request.result = .success(messages)
+        activationDateStorage._daysSinceActivation = 10
+
+        let messaging = DefaultSurveyRemoteMessaging(
+            messageRequest: request,
+            messageStorage: storage,
+            accountManager: accountManager,
+            subscriptionFetcher: subscriptionFetcher,
+            vpnActivationDateStore: activationDateStorage,
+            pirActivationDateStore: activationDateStorage,
+            minimumRefreshInterval: 0,
+            userDefaults: defaults
+        )
+
+        storage.dismissRemoteMessage(with: "unrelated-dismissed-message")
+        XCTAssertEqual(storage.storedMessages(), [])
+        XCTAssertNotNil(activationDateStorage.daysSinceActivation())
+
+        await messaging.fetchRemoteMessages()
+
+        XCTAssertTrue(request.didFetchMessages)
+        XCTAssertEqual(storage.storedMessages(), messages)
+    }
+
     private func mockMessage(id: String,
                              subscriptionStatus: String = Subscription.Status.autoRenewable.rawValue,
                              minimumDaysSinceSubscriptionStarted: Int = 0,
                              maximumDaysUntilSubscriptionExpirationOrRenewal: Int = 0,
                              daysSinceVPNEnabled: Int = 0,
                              daysSincePIREnabled: Int = 0,
-                             purchasePlatform: String = "apple") -> SurveyRemoteMessage {
+                             purchasePlatform: String = "apple",
+                             hideIfInteractedWithMessage: String = "") -> SurveyRemoteMessage {
         let remoteMessageJSON = """
         {
             "id": "\(id)",
@@ -243,7 +312,8 @@ final class SurveyRemoteMessagingTests: XCTestCase {
                     "daysSinceVPNEnabled": \(daysSinceVPNEnabled),
                     "daysSincePIREnabled": \(daysSincePIREnabled),
                     "sparkleSubscriptionPurchasePlatforms": ["\(purchasePlatform)"],
-                    "appStoreSubscriptionPurchasePlatforms": ["\(purchasePlatform)"]
+                    "appStoreSubscriptionPurchasePlatforms": ["\(purchasePlatform)"],
+                    "hideIfInteractedWithMessage": ["\(hideIfInteractedWithMessage)"]
             },
             "action": {
                 "actionTitle": "Action 1"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207675127109803/f
Tech Design URL:
CC:

**Description**:

This PR updates the survey implementation to allow hiding messages based on whether other ones have already been dismissed. This is useful for us as we want to never show the subscriber survey to a user who has already seen the exit survey (this was a request from User Insights).

**Steps to test this PR**:
1. Check that CI passes, tests are present to cover all of the new code

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
