### PR TITLE
fix print operation crash

### DIFF
--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -1032,13 +1032,14 @@ extension BrowserTabViewController: TabDelegate {
     private class PrintContext {
         let request: PrintDialogRequest
         weak var printPanel: NSWindow?
-        var isAborted = false
+        var shouldRemoveWebView = false
         init(request: PrintDialogRequest) {
             self.request = request
         }
     }
     func runPrintOperation(with request: PrintDialogRequest) -> ModalSheetCancellable? {
-        guard let window = view.window else { return nil }
+        guard let window = view.window,
+              let webView = tabViewModel?.tab.webView else { return nil }
 
         let printOperation = request.parameters
         let didRunSelector = #selector(printOperationDidRun(printOperation:success:contextInfo:))
@@ -1054,10 +1055,25 @@ extension BrowserTabViewController: TabDelegate {
         // get the Print Panel that (hopefully) was added to the window.sheets
         context.printPanel = Set(window.sheets).subtracting(windowSheetsBeforPrintOperation).first
 
-        // when subscribing to another Tab, the sheet will be temporarily closed with response == .abort on the cancellable deinit
-        return ModalSheetCancellable(ownerWindow: window, modalSheet: context.printPanel, returnCode: nil, condition: !context.request.isComplete) {
-            context.isAborted = true
-        }
+        // when subscribing to another Tab, the print dialog will be cancelled on the cancellable deinit
+        return ModalSheetCancellable(ownerWindow: window, modalSheet: context.printPanel, returnCode: .cancel, condition: {
+            guard !context.request.isComplete else { return false }
+
+            // the print operation must complete when the web view is visible
+            // otherwise UI gets broken
+            if webView.window == nil {
+                self.view.addSubview(webView)
+                context.shouldRemoveWebView = true
+            }
+            return true
+
+        }(), cancellationHandler: {
+            if context.shouldRemoveWebView {
+                DispatchQueue.main.async {
+                    webView.removeFromSuperview()
+                }
+            }
+        })
     }
 
     @objc private func printOperationDidRun(printOperation: NSPrintOperation, success: Bool, contextInfo: UnsafeMutableRawPointer?) {
@@ -1066,13 +1082,6 @@ extension BrowserTabViewController: TabDelegate {
             return
         }
         let context = Unmanaged<PrintContext>.fromOpaque(contextInfo).takeRetainedValue()
-
-        // don‘t submit the query when tab is switched
-        if context.isAborted { return }
-        if let window = view.window, let printPanel = context.printPanel, window.sheets.contains(printPanel) {
-            window.endSheet(printPanel)
-        }
-
         context.request.submit(success)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204912272578138/1206088437501881/f

**Description**:
- fixes crash when a print operation is tried to start for a 2nd time

**Steps to test this PR**:
1. Launch print operation (cmd+p)
2. Drag an (html) file onto the browser icon so a new tab is opened
3. Switch to the original printed tab, validate there‘s no crash and ui controls work, print again should work; print to pdf should work

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
