### PR TITLE
Fix no results selector for people-background-check.com

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Resources/JSON/people-background-check.com.json
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Resources/JSON/people-background-check.com.json
@@ -18,7 +18,7 @@
           "actionType": "extract",
           "id": "06e575b5-ac64-4bf5-b5e7-6e39e5a474fb",
           "selector": ".b-pfl-list",
-          "noResultsSelector": "//h3[contains(text(), 'No people found'] | //div[@id='results_container' and contains(text(), 'Not found')]",
+          "noResultsSelector": "//h3[contains(text(), 'No people found')] | //div[@id='results_container' and contains(text(), 'Not found')]",
           "profile": {
             "name": {
               "selector": ".name"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207688988935131/f
Tech Design URL:
CC:

**Description**:
Found an invalid xpath selector here.

**Steps to test this PR**:
1.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
