### PR TITLE
Fix goBack/goForward for same-document navigation history

### DIFF
--- a/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -341,7 +341,7 @@ extension URL {
     }
 
     var isExternalSchemeLink: Bool {
-        return ![.https, .http, .about, .file, .blob, .data, .ftp, .javascript].contains(navigationalScheme)
+        return ![.https, .http, .about, .file, .blob, .data, .ftp, .javascript, .duck].contains(navigationalScheme)
     }
 
     // MARK: - DuckDuckGo

--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -618,7 +618,7 @@ protocol NewWindowPolicyDecisionMaker {
     @MainActor
     @discardableResult
     func goBack() -> ExpectedNavigation? {
-        guard canGoBack else {
+        guard canGoBack, let backItem = webView.backForwardList.backItem else {
             if canBeClosedWithBack {
                 delegate?.closeTab(self)
             }
@@ -626,7 +626,7 @@ protocol NewWindowPolicyDecisionMaker {
         }
 
         userInteractionDialog = nil
-        let navigation = webView.navigator()?.goBack(withExpectedNavigationType: .backForward(distance: -1))
+        let navigation = webView.navigator()?.go(to: backItem, withExpectedNavigationType: .backForward(distance: -1))
         // update TabContent source to .historyEntry on navigation
         navigation?.appendResponder(willStart: { [weak self] navigation in
             guard let self,
@@ -640,10 +640,10 @@ protocol NewWindowPolicyDecisionMaker {
     @MainActor
     @discardableResult
     func goForward() -> ExpectedNavigation? {
-        guard canGoForward else { return nil }
+        guard canGoForward, let forwardItem = webView.backForwardList.forwardItem else { return nil }
 
         userInteractionDialog = nil
-        let navigation = webView.navigator()?.goForward(withExpectedNavigationType: .backForward(distance: 1))
+        let navigation = webView.navigator()?.go(to: forwardItem, withExpectedNavigationType: .backForward(distance: 1))
         // update TabContent source to .historyEntry on navigation
         navigation?.appendResponder(willStart: { [weak self] navigation in
             guard let self,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202406491309510/1207645682318770/f

**Description**:
- fix back/forward navigation for same-document navigation history stack
- fix duck:// address navigation cancellation due to handling in External Scheme handler

**Steps to test this PR**:
1. Open a new tab
2. Go to https://github.com/duckduckgo/macos-browser
3. Navigate to Pull Requests
4. Click back button, expected: User lands on https://github.com/duckduckgo/macos-browser
5. Click back again -> new tab
6. Click forward -> https://github.com/duckduckgo/macos-browser
7. Click forward -> pull requests

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
