### PR TITLE
Check doubleValue vs scheduling config retry error instead of Int.max

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OperationPreferredDateCalculator.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/OperationPreferredDateCalculator.swift
@@ -101,14 +101,11 @@ struct OperationPreferredDateCalculator {
         let pastTries = historyEvents.filter { $0.isError }.count
         let doubleValue = pow(2.0, Double(pastTries))
 
-        // Check if the double value is within the range of Int before converting
-        let intValue: Int
-        if doubleValue > Double(Int.max) {
-            intValue = Int.max
+        if doubleValue > Double(schedulingConfig.retryError) {
+            return schedulingConfig.retryError.hoursToSeconds
         } else {
-            intValue = Int(doubleValue)
+            let intValue = Int(doubleValue)
+            return intValue.hoursToSeconds
         }
-
-        return min(intValue, schedulingConfig.retryError).hoursToSeconds
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1207696952542904/f
Tech Design URL:
CC:

**Description**:
There seems to be a crash with calculating the preferred run date. This is weird because, from the error logs, `doubleValue` seems to be either infinity or NaN. 

The infinity is already covered with tests. The double value cannot be a NaN because `pastTries` is never negative. I’m wondering if we are seeing an error when a user in 1.94.0 is running an old version of the background agent.

I’ve changed the logic. Now, we check against the `retryError` value from the JSON file. We only parsed the value to `Int` when we knew it was smaller than the `retryError` value, which we configure ourselves.

**Steps to test this PR**:
There is not much to test here because tests are still the same. 