### PR TITLE
fix fire animation

### DIFF
--- a/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -146,7 +146,7 @@ final class MainWindowController: NSWindowController {
         NSApplication.shared.mainMenuTyped.autoupdatingMenusForUserPrevention.forEach { $0.autoenablesItems = !prevented }
         NSApplication.shared.mainMenuTyped.menuItemsForUserPrevention.forEach { $0.isEnabled = !prevented }
 
-        guard forBurning == true else { return }
+        guard forBurning else { return }
         if prevented {
              window?.styleMask.remove(.closable)
              mainViewController.view.makeMeFirstResponder()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204186595873227/1207713238908140/f

**Description**: Fixes the fire button animation. It seems that when we lock the UI for the animation we need to remove the close button from the window

**Steps to test this PR**:
1. ./clean-app.sh debug or ./clean-app.sh review
2. Either run the review version of the app or comment out lines 68 to 77 and line 80 from MainWindowController
3. Go through the onboarding and check the UI is locked but the close window button is active
4. Use the fire button and check the animation is shown as expected

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
