### PR TITLE
Add pixel for DuckPlayer settings

### DIFF
--- a/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift
@@ -19,6 +19,7 @@
 import Foundation
 import Combine
 import BrowserServicesKit
+import PixelKit
 
 protocol DuckPlayerPreferencesPersistor {
     /// The persistor hadles raw Bool values but each one translates into a DuckPlayerMode:
@@ -62,6 +63,11 @@ final class DuckPlayerPreferences: ObservableObject {
     var duckPlayerAutoplay: Bool {
         didSet {
             persistor.duckPlayerAutoplay = duckPlayerAutoplay
+            if duckPlayerAutoplay {
+                PixelKit.fire(GeneralPixel.duckPlayerAutoplaySettingsOn)
+            } else {
+                PixelKit.fire(GeneralPixel.duckPlayerAutoplaySettingsOff)
+            }
         }
     }
 

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -126,6 +126,8 @@ enum GeneralPixel: PixelKitEventV2 {
     case duckPlayerSettingNeverSettings
     case duckPlayerSettingBackToDefault
     case duckPlayerWatchOnYoutube
+    case duckPlayerAutoplaySettingsOn
+    case duckPlayerAutoplaySettingsOff
 
     // Dashboard
     case dashboardProtectionAllowlistAdd(triggerOrigin: String?)
@@ -573,7 +575,10 @@ enum GeneralPixel: PixelKitEventV2 {
             return "m_mac_duck-player_setting_back-to-default"
         case .duckPlayerWatchOnYoutube:
             return "m_mac_duck-player_watch_on_youtube"
-
+        case .duckPlayerAutoplaySettingsOn:
+            return "duckplayer_mac_autoplay_setting-on"
+        case .duckPlayerAutoplaySettingsOff:
+            return "duckplayer_mac_autoplay_setting-off"
         case .dashboardProtectionAllowlistAdd:
             return "m_mac_mp_wla"
         case .dashboardProtectionAllowlistRemove:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201011656765697/1207677983109068/f

**Description**:
Add pixel for DuckPlayer autoplay settings

**Steps to test this PR**:
1. Change this to return true: https://github.com/duckduckgo/macos-browser/blob/7577a09a15950c298f4a3ec1461657a2af700707/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift#L69
2. Check if the pixel is correctly sent when you turn the autoplay settings on and off
