### PR TITLE
Fixes an issue reporting the last extension version run

### DIFF
--- a/DuckDuckGoVPN/NetworkExtensionController.swift
+++ b/DuckDuckGoVPN/NetworkExtensionController.swift
@@ -49,10 +49,10 @@ extension NetworkExtensionController {
 
     func activateSystemExtension(waitingForUserApproval: @escaping () -> Void) async throws {
 #if NETP_SYSTEM_EXTENSION
-        let extensionVersion = try await systemExtensionManager.activate(
-            waitingForUserApproval: waitingForUserApproval)
+        if let extensionVersion = try await systemExtensionManager.activate(waitingForUserApproval: waitingForUserApproval) {
 
-        NetworkProtectionLastVersionRunStore(userDefaults: defaults).lastExtensionVersionRun = extensionVersion
+            NetworkProtectionLastVersionRunStore(userDefaults: defaults).lastExtensionVersionRun = extensionVersion
+        }
 
         try await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
 #endif

--- a/LocalPackages/SystemExtensionManager/Sources/SystemExtensionManager/SystemExtensionManager.swift
+++ b/LocalPackages/SystemExtensionManager/Sources/SystemExtensionManager/SystemExtensionManager.swift
@@ -44,9 +44,9 @@ public struct SystemExtensionManager {
         self.workspace = workspace
     }
 
-    /// - Returns: The system extension version.
-    /// 
-    public func activate(waitingForUserApproval: @escaping () -> Void) async throws -> String {
+    /// - Returns: The system extension version when it's updated, otherwise `nil`.
+    ///
+    public func activate(waitingForUserApproval: @escaping () -> Void) async throws -> String? {
         /// Documenting a workaround for the issue discussed in https://app.asana.com/0/0/1205275221447702/f
         ///     Background: For a lot of users, the system won't show the system-extension-blocked alert if there's a previous request
         ///         to activate the extension.  You can see active requests in your console using command `systemextensionsctl list`.
@@ -71,7 +71,7 @@ public struct SystemExtensionManager {
 
         try await activationRequest.submit()
 
-        return activationRequest.version ?? "unknown"
+        return activationRequest.version
     }
 
     public func deactivate() async throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1207785443093297/f

## Description

There's an issue where metadata keeps reporting the last extension version run as "unknown".

This issue happens because we always overwrite the last extension version run in the metadata, but it's only provided to us on update.  We should change the logic to only change the last extension version when it's present and ignore it otherwise.

## Testing

Please note: debug builds always replace the last extension run - this is a difference in macOS to make testing easier - so it's hard to test this naturally.  We'll instead force the scenario.

1. Run the app once.
2. Start the VPN.
3. Debug menu > VPN > Log Feedback Metadata to Console

Check in Xcode's console that you see something like this:

```
"appInfo" : {
    "appVersion" : "1.96.0.219",
    "lastExtensionVersionRun" : "1.96.0.217",
    "isInApplicationsDirectory" : true,
    "isInternalUser" : true,
    "lastAgentVersionRun" : "1.96.0.219"
  },
```

4. Change [this line](https://github.com/duckduckgo/macos-browser/blob/68ef9c60448b9478e898d5525b5b65099de84053/LocalPackages/SystemExtensionManager/Sources/SystemExtensionManager/SystemExtensionManager.swift#L74) to force-return `nil`.
5. Change `MARKETING_VERSION` in `Version.xcconfig`.  This is just to check that we don't write a new value.
6. Run the app again and start the VPN.
7. Debug menu > VPN > Log Feedback Metadata to Console

Check in Xcode that you still see `1.96.0.217` for the extension version run.  This means that if we return `nil` in that method it won't overwrite the previously available

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
