### PR TITLE
one-click Fire Button setting

### DIFF
--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -67,6 +67,7 @@ public struct UserDefaultsWrapper<T> {
         case loginDetectionEnabled = "fireproofing.login-detection-enabled"
         case autoClearEnabled = "preferences.auto-clear-enabled"
         case warnBeforeClearingEnabled = "preferences.warn-before-clearing-enabled"
+        case oneClickFireButton = "preferences.one-click-fire-button"
         case gpcEnabled = "preferences.gpc-enabled"
         case selectedDownloadLocationKey = "preferences.download-location"
         case lastUsedCustomDownloadLocation = "preferences.custom-last-used-download-location"

--- a/DuckDuckGo/Fire/View/FireCoordinator.swift
+++ b/DuckDuckGo/Fire/View/FireCoordinator.swift
@@ -17,6 +17,7 @@
 //
 
 import Cocoa
+import PixelKit
 
 @MainActor
 final class FireCoordinator {
@@ -46,16 +47,25 @@ final class FireCoordinator {
 
         if waitForOpening {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1/3) {
-                showFirePopover(relativeTo: mainViewController.tabBarViewController.fireButton,
-                                tabCollectionViewModel: mainViewController.tabCollectionViewModel)
+                continueFireButtonActionAfterOpeningWindow(positioningView: mainViewController.tabBarViewController.fireButton,
+                                                           tabCollectionViewModel: mainViewController.tabCollectionViewModel)
             }
         } else {
-            showFirePopover(relativeTo: mainViewController.tabBarViewController.fireButton,
-                            tabCollectionViewModel: mainViewController.tabCollectionViewModel)
+            continueFireButtonActionAfterOpeningWindow(positioningView: mainViewController.tabBarViewController.fireButton,
+                                                       tabCollectionViewModel: mainViewController.tabCollectionViewModel)
         }
     }
 
-    static func showFirePopover(relativeTo positioningView: NSView, tabCollectionViewModel: TabCollectionViewModel) {
+    private static func continueFireButtonActionAfterOpeningWindow(positioningView: NSView, tabCollectionViewModel: TabCollectionViewModel) {
+        if DataClearingPreferences.shared.oneClickFireButton {
+            PixelKit.fire(GeneralPixel.fireButton(option: .allSites))
+            fireViewModel.fire.burnAll()
+        } else {
+            showFirePopover(relativeTo: positioningView, tabCollectionViewModel: tabCollectionViewModel)
+        }
+    }
+
+    private static func showFirePopover(relativeTo positioningView: NSView, tabCollectionViewModel: TabCollectionViewModel) {
         guard !(firePopover?.isShown ?? false) else {
             firePopover?.close()
             return

--- a/DuckDuckGo/Fire/View/FirePopoverViewController.swift
+++ b/DuckDuckGo/Fire/View/FirePopoverViewController.swift
@@ -258,7 +258,6 @@ final class FirePopoverViewController: NSViewController {
     @IBAction func clearButtonAction(_ sender: Any) {
         delegate?.firePopoverViewControllerDidClear(self)
         firePopoverViewModel.burn()
-
     }
 
     @IBAction func cancelButtonAction(_ sender: Any) {

--- a/DuckDuckGo/Preferences/Model/DataClearingPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/DataClearingPreferences.swift
@@ -50,6 +50,13 @@ final class DataClearingPreferences: ObservableObject, PreferencesTabOpening {
         isWarnBeforeClearingEnabled.toggle()
     }
 
+    @Published
+    var oneClickFireButton: Bool {
+        didSet {
+            persistor.oneClickFireButton = oneClickFireButton
+        }
+    }
+
     @MainActor
     func presentManageFireproofSitesDialog() {
         let fireproofDomainsWindowController = FireproofDomainsViewController.create().wrappedInWindowController()
@@ -69,6 +76,7 @@ final class DataClearingPreferences: ObservableObject, PreferencesTabOpening {
         isLoginDetectionEnabled = persistor.loginDetectionEnabled
         isAutoClearEnabled = persistor.autoClearEnabled
         isWarnBeforeClearingEnabled = persistor.warnBeforeClearingEnabled
+        oneClickFireButton = persistor.oneClickFireButton
     }
 
     private var persistor: FireButtonPreferencesPersistor
@@ -77,6 +85,7 @@ final class DataClearingPreferences: ObservableObject, PreferencesTabOpening {
 protocol FireButtonPreferencesPersistor {
     var loginDetectionEnabled: Bool { get set }
     var autoClearEnabled: Bool { get set }
+    var oneClickFireButton: Bool { get set }
     var warnBeforeClearingEnabled: Bool { get set }
 }
 
@@ -91,6 +100,8 @@ struct FireButtonPreferencesUserDefaultsPersistor: FireButtonPreferencesPersisto
     @UserDefaultsWrapper(key: .warnBeforeClearingEnabled, defaultValue: false)
     var warnBeforeClearingEnabled: Bool
 
+    @UserDefaultsWrapper(key: .oneClickFireButton, defaultValue: false)
+    var oneClickFireButton: Bool
 }
 
 extension Notification.Name {

--- a/DuckDuckGo/Preferences/View/PreferencesDataClearingView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesDataClearingView.swift
@@ -28,7 +28,7 @@ extension Preferences {
         var body: some View {
             PreferencePane(UserText.dataClearing) {
 
-                // SECTION 1: Automatically Clear Data
+                // SECTION: Automatically Clear Data
                 PreferencePaneSection(UserText.autoClear) {
 
                     PreferencePaneSubSection {
@@ -41,7 +41,19 @@ extension Preferences {
 
                 }
 
-                // SECTION 2: Fireproof Site
+                // SECTION: Fire Window
+                PreferencePaneSection(UserText.dataClearing) {
+
+                    PreferencePaneSubSection {
+                        ToggleMenuItem("One-click Fire button", isOn: $model.oneClickFireButton)
+                        VStack(alignment: .leading, spacing: 1) {
+                            TextMenuItemCaption("When active hitting the Fire Button will clear data with no extra dialogs")
+                        }
+                    }
+
+                }
+
+                // SECTION: Fireproof Site
                 PreferencePaneSection(UserText.fireproofSites) {
 
                     PreferencePaneSubSection {
@@ -63,5 +75,12 @@ extension Preferences {
 
             }
         }
+    }
+}
+
+#Preview {
+    ScrollView {
+        Preferences.DataClearingView(model: .shared)
+            .padding()
     }
 }

--- a/UnitTests/Preferences/DataClearingPreferencesTests.swift
+++ b/UnitTests/Preferences/DataClearingPreferencesTests.swift
@@ -24,6 +24,7 @@ class MockFireButtonPreferencesPersistor: FireButtonPreferencesPersistor {
     var autoClearEnabled: Bool = false
     var warnBeforeClearingEnabled: Bool = false
     var loginDetectionEnabled: Bool = false
+    var oneClickFireButton: Bool = false
 
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204517122485752/1204517122517075/f

**Description**:
- Add setting to make the Fire Button one-click shot

**Steps to test this PR**:
1. Open Settings->Data Clearing in 2 windows
2. Activate one-click Fire Button setting, validate it‘s changed in both windows
3. Click the fire button – fire animation should run instantly removing all data

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
