### PR TITLE
fix search pixel

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -280,11 +280,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ = DownloadListCoordinator.shared
         _ = RecentlyClosedCoordinator.shared
 
-        PixelExperiment.install()
-
         if LocalStatisticsStore().atb == nil {
             AppDelegate.firstLaunchDate = Date()
             // MARK: Enable pixel experiments here
+            PixelExperiment.install()
         }
         AtbAndVariantCleanup.cleanup()
         DefaultVariantManager().assignVariantIfNeeded { _ in

--- a/DuckDuckGo/Statistics/Experiment/PixelExperiment.swift
+++ b/DuckDuckGo/Statistics/Experiment/PixelExperiment.swift
@@ -208,8 +208,7 @@ final internal class PixelExperimentLogic {
     }
 
     func fireSerpPixel() {
-        guard allocatedCohort != nil, let cohort else { return }
-        PixelKit.fire(GeneralPixel.serp(cohort: cohort.rawValue), frequency: .standard, includeAppVersionParameter: false)
+        PixelKit.fire(GeneralPixel.serp(cohort: cohort?.rawValue), frequency: .standard, includeAppVersionParameter: false)
     }
 
     func fireOnboardingHomeButtonEnabledPixel() {

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -29,7 +29,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case compileRulesWait(onboardingShown: OnboardingShown, waitTime: CompileRulesWaitTime, result: WaitResult)
     case launchInitial(cohort: String)
 
-    case serp(cohort: String)
+    case serp(cohort: String?)
     case serpInitial(cohort: String)
     case serpDay21to27(cohort: String)
 
@@ -1005,6 +1005,7 @@ enum GeneralPixel: PixelKitEventV2 {
             return [PixelKit.Parameters.experimentCohort: cohort]
 
         case .serp(let cohort):
+            guard let cohort else { return [:] }
             return [PixelKit.Parameters.experimentCohort: cohort]
 
         case .serpInitial(let cohort):


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1199230911884351/1207784623692350/f

Description: Will fire the pixel even when no cohort present

Steps to test this PR:

Run the following commands defaults delete com.duckduckgo.macos.browser.debug pixel.experiment.installed defaults ``delete com.duckduckgo.macos.browser.debug pixel.experiment.cohort
2 try a search and check m_mac_navigation_search is fired with no cohort
3 clean the default build
4 In MainWindowController comment out lines 67 - 77 and 80
5 Run the app go through the onboarding and do a search
6 check check m_mac_navigation_search is fired with an associated cohort (oa / ob)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
