### PR TITLE
SERP version flag removed

### DIFF
--- a/DuckDuckGo/Tab/Navigation/SerpHeadersNavigationResponder.swift
+++ b/DuckDuckGo/Tab/Navigation/SerpHeadersNavigationResponder.swift
@@ -18,13 +18,11 @@
 
 import Navigation
 import Foundation
-import Common
 
 struct SerpHeadersNavigationResponder: NavigationResponder {
 
     static let headers = [
-        "X-DuckDuckGo-Client": "macOS",
-        "X-Version": "\(AppVersion().versionAndBuildNumber)"
+        "X-DuckDuckGo-Client": "macOS"
     ]
 
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/69071770703008/1207852553348970/f
Tech Design URL:
CC:

**Description**:
Removal of the SERP header flag containing the app version.

**Steps to test this PR**:
1. Navigate to duckduckgo.com
2. Open Developer Tools
3. Trigger a search
4. Verify the `X-Version` header field is no longer in the request

**Before**
<img width="612" alt="Screenshot 2024-07-19 at 10 02 07" src="https://github.com/user-attachments/assets/e933c919-6b6c-44c7-bc99-89044a904923">


**After** 
<img width="713" alt="Screenshot 2024-07-19 at 12 09 53" src="https://github.com/user-attachments/assets/f4d09d9d-cace-407a-9452-800661aca872">

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
