### PR TITLE
Fix Sync E2E tests crashing

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -389,7 +389,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setUpAutofillPixelReporter()
 
 #if SPARKLE
-        updateController.checkNewApplicationVersion()
+        if NSApp.runType != .uiTests {
+            updateController.checkNewApplicationVersion()
+        }
 #endif
 
         remoteMessagingClient?.startRefreshingRemoteMessages()

--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -259,11 +259,14 @@ final class MoreOptionsMenu: NSMenu {
 
     private func addUpdateItem() {
 #if SPARKLE
-        if let update = Application.appDelegate.updateController.latestUpdate,
-           !update.isInstalled {
-            addItem(UpdateMenuItemFactory.menuItem(for: update))
-            addItem(NSMenuItem.separator())
+        guard NSApp.runType != .uiTests,
+            let update = Application.appDelegate.updateController.latestUpdate,
+            !update.isInstalled
+        else {
+            return
         }
+        addItem(UpdateMenuItemFactory.menuItem(for: update))
+        addItem(NSMenuItem.separator())
 #endif
     }
 

--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenuButton.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenuButton.swift
@@ -47,7 +47,9 @@ final class MoreOptionsMenuButton: MouseOverButton {
         super.awakeFromNib()
 
 #if SPARKLE
-        updateController = Application.appDelegate.updateController
+        if NSApp.runType != .uiTests {
+            updateController = Application.appDelegate.updateController
+        }
 #endif
         subscribeToUpdateInfo()
     }

--- a/DuckDuckGo/Updates/ReleaseNotesTabExtension.swift
+++ b/DuckDuckGo/Updates/ReleaseNotesTabExtension.swift
@@ -80,6 +80,9 @@ final class ReleaseNotesTabExtension: NavigationResponder {
 
     @MainActor
     private func setUpScript(for url: URL?) {
+        guard NSApp.runType != .uiTests else {
+            return
+        }
         let updateController = Application.appDelegate.updateController!
         Publishers.CombineLatest(updateController.isUpdateBeingLoadedPublisher, updateController.latestUpdatePublisher)
             .receive(on: DispatchQueue.main)

--- a/DuckDuckGo/Updates/ReleaseNotesUserScript.swift
+++ b/DuckDuckGo/Updates/ReleaseNotesUserScript.swift
@@ -62,6 +62,9 @@ final class ReleaseNotesUserScript: NSObject, Subfeature {
     }
 
     public func onUpdate() {
+        guard NSApp.runType != .uiTests else {
+            return
+        }
         guard let webView = webView else {
             return assertionFailure("Could not access webView")
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207860806206145/f

**Description**:
This change fixes UpdateController usage so that it's not references in UI tests runs.

**Steps to test this PR**:
Verify that [this Sync E2E UI Tests run](https://github.com/duckduckgo/macos-browser/actions/runs/10031255346) and [this UI tests run](https://github.com/duckduckgo/macos-browser/actions/runs/10031256773) are green.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
