### PR TITLE
Disable automatic updates for the DEBUG configuration

### DIFF
--- a/DuckDuckGo/Updates/UpdateController.swift
+++ b/DuckDuckGo/Updates/UpdateController.swift
@@ -151,14 +151,15 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
         updater = SPUStandardUpdaterController(updaterDelegate: self, userDriverDelegate: self)
         shouldShowManualUpdateDialog = false
 
-#if DEBUG
-        updater.updater.automaticallyChecksForUpdates = false
-        updater.updater.updateCheckInterval = 0
-#endif
-
         if updater.updater.automaticallyDownloadsUpdates != areAutomaticUpdatesEnabled {
             updater.updater.automaticallyDownloadsUpdates = areAutomaticUpdatesEnabled
         }
+
+#if DEBUG
+        updater.updater.automaticallyChecksForUpdates = false
+        updater.updater.automaticallyDownloadsUpdates = false
+        updater.updater.updateCheckInterval = 0
+#endif
 
         checkForUpdateInBackground()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1148564399326804/1207885307862391/f
Tech Design URL:
CC:

**Description**:
Making sure automatic updates aren't applied in the DEBUG configuration when running the app from Xcode

**Steps to test this PR**:
1. Manually downgrade the version and build number of the app in `Version.xcconfig` and` BuildNumber.xcconfig`
1. Run the app and go to Settings -> About
2. Wait a minute and make sure the app won't finish loading of the new update
3. Restart the app multiple times and make sure the version and build number are the same

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
