### PR TITLE
Improve scrolling after search or show in folder

### DIFF
--- a/DuckDuckGo/Bookmarks/View/BookmarksOutlineView.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarksOutlineView.swift
@@ -77,7 +77,7 @@ final class BookmarksOutlineView: NSOutlineView {
 
             if let enclosingScrollView = self.enclosingScrollView {
                 let rowRect = rect(ofRow: rowIndex)
-                let desiredTopPosition = rowRect.origin.y - 28 // Adjusted position 28 pixels from the top, one cell height.
+                let desiredTopPosition = rowRect.origin.y - rowHeight // Adjusted position one row height from the top.
                 let scrollPoint = NSPoint(x: 0, y: desiredTopPosition - enclosingScrollView.contentInsets.top)
                 enclosingScrollView.contentView.scroll(to: scrollPoint)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207887370745939/f
Tech Design URL:
CC:

## Description
After a search, when you tap on a folder or the ’Show in Folder’ action (for bookmarks and folders), it scrolls to it, but the bookmark appears at the bottom.

Now this has been improved; we will try to position the selected bookmark at the second row when that action happens.

![improvement-scrolling](https://github.com/user-attachments/assets/8b536bf2-b558-4221-893c-1d00ede7b770)

**Steps to test this PR**:
**Tapping folder on search**
1. Open the bookmarks panel
2. Search for a folder and tap it
3. The folder should be located in the second position (if there is space for it)

**Tapping the ’Show in Folder’ menu action**
1. Open the bookmarks panel
2. Search for a folder or bookmark and right tap it
3. The bookmark or folder should be located in the second position (if there is space for it)

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
