### PR TITLE
Reset scroll to top when searching

### DIFF
--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -459,7 +459,7 @@ final class BookmarkListViewController: NSViewController {
     private func updateSearchAndExpand(_ folder: BookmarkFolder) {
         showTreeView()
         expandFoldersAndScrollUntil(folder)
-        outlineView.scrollTo(folder)
+        outlineView.scrollToAdjustedPositionInOutlineView(folder)
 
         guard let node = dataSource.treeController.node(representing: folder) else {
             return
@@ -570,7 +570,7 @@ final class BookmarkListViewController: NSViewController {
         }
 
         expandFoldersUntil(node: folderNode)
-        outlineView.scrollTo(folderNode)
+        outlineView.scrollToAdjustedPositionInOutlineView(folderNode)
     }
 
     private func expandFoldersUntil(node: BookmarkNode?) {
@@ -884,7 +884,7 @@ extension BookmarkListViewController: BookmarkSearchMenuItemSelectors {
         }
 
         expandFoldersUntil(node: node)
-        outlineView.scrollTo(node)
+        outlineView.scrollToAdjustedPositionInOutlineView(node)
         outlineView.highlight(node)
     }
 }
@@ -931,6 +931,10 @@ extension BookmarkListViewController: NSSearchFieldDelegate {
             emptyState.isHidden = true
             outlineView.isHidden = false
             outlineView.reloadData()
+
+            if let firstNode = dataSource.treeController.rootNode.childNodes.first {
+                outlineView.scrollTo(firstNode)
+            }
         }
     }
 }

--- a/DuckDuckGo/Bookmarks/View/BookmarksOutlineView.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarksOutlineView.swift
@@ -69,15 +69,21 @@ final class BookmarksOutlineView: NSOutlineView {
         lastRow = rowView
     }
 
-    func scrollTo(_ item: Any) {
+    func scrollTo(_ item: Any, code: ((Int) -> Void)? = nil) {
         let rowIndex = row(forItem: item)
 
         if rowIndex != -1 {
             scrollRowToVisible(rowIndex)
+            code?(rowIndex)
+        }
+    }
 
+    /// Scrolls to the passed node and tries to position it in the second row.
+    func scrollToAdjustedPositionInOutlineView(_ item: Any) {
+        scrollTo(item) { rowIndex in
             if let enclosingScrollView = self.enclosingScrollView {
-                let rowRect = rect(ofRow: rowIndex)
-                let desiredTopPosition = rowRect.origin.y - rowHeight // Adjusted position one row height from the top.
+                let rowRect = self.rect(ofRow: rowIndex)
+                let desiredTopPosition = rowRect.origin.y - self.rowHeight // Adjusted position one row height from the top.
                 let scrollPoint = NSPoint(x: 0, y: desiredTopPosition - enclosingScrollView.contentInsets.top)
                 enclosingScrollView.contentView.scroll(to: scrollPoint)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207887371317358/f
Tech Design URL:
CC:

## Description
When searching is updated, we need to scroll to the top of the list instead of staying in the same scroll position.

![reset-scrolling-search](https://github.com/user-attachments/assets/0723ace4-5226-44a2-975a-2bbe3bab907e)

## Steps to test this PR
1. Open the bookmarks panel view
2. Scroll to the end
3. Start a search
4. The search results should start from the beginning

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
