### PR TITLE
Disable password generation for burner windows

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/AutofillTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/AutofillTabExtension.swift
@@ -200,7 +200,7 @@ extension AutofillTabExtension: SecureVaultManagerDelegate {
         var supportedFeatures = ContentScopeFeatureToggles.supportedFeaturesOnMacOS(privacyConfigurationManager.privacyConfig)
 
         if !passwordManagerCoordinator.isEnabled,
-           AutofillNeverPromptWebsitesManager.shared.hasNeverPromptWebsitesFor(domain: domain) {
+           AutofillNeverPromptWebsitesManager.shared.hasNeverPromptWebsitesFor(domain: domain) || isBurner {
             supportedFeatures.passwordGeneration = false
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1207877600791247/f
Tech Design URL:
CC:

**Description**:
Disables password generation in fire windows, avoiding confusion since generated credentials are not currently autosaved in fire windows 

**Steps to test this PR**:
1.  Open a new Fire window and go to https://fill.dev/form/registration-email
2. Confirm the password generation key is not present in the password fields
3. Enter credentials and click Register
4. Confirm credentials were not saved in the password manager 
5. Open a normal window and go to https://fill.dev/form/registration-email to regression test
6. Confirm the password generation key is still present in the password fields
7. Enter an email and select the generated password
8. Before submitting the web form, confirm generated credentials were autosaved in the password manager


**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
