### PR TITLE
Add new parameter to duck player pixel

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -343,11 +343,13 @@ extension DuckPlayerTabExtension: NavigationResponder {
         if navigation.url.isDuckPlayer {
             let setting = duckPlayer.mode == .enabled ? "always" : "default"
             let newTabSettings = preferences.duckPlayerOpenInNewTab ? "true" : "false"
+            let autoplay = preferences.duckPlayerAutoplay ? "true" : "false"
 
             PixelKit.fire(GeneralPixel.duckPlayerDailyUniqueView,
                           frequency: .legacyDaily,
                           withAdditionalParameters: ["setting": setting,
-                                                     "newtab": newTabSettings])
+                                                     "newtab": newTabSettings,
+                                                     "autoplay": autoplay])
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1207766311130546/f

**Description**:
Add new parameter to duck player pixel

**Steps to test this PR**:
⚠️  Set yourself as internal user
1. Run DuckPlayer, check if the duckPlayerDailyUniqueView pixel is sent using the corresponding autoplay parameter
2. Change the autoplay settings and check if the pixel sends the correct value
