### PR TITLE
Improve PIR entitlements update handling

### DIFF
--- a/DuckDuckGo/DBP/DataBrokerProtectionSubscriptionEventHandler.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionSubscriptionEventHandler.swift
@@ -66,7 +66,7 @@ final class DataBrokerProtectionSubscriptionEventHandler {
         }
 
         let hasEntitlements = entitlements.contains { entitlement in
-            entitlement.product == .networkProtection
+            entitlement.product == .dataBrokerProtection
         }
 
         Task {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203108348835387/1207931179710630/f

## Description

Fixes an assertion failure and removes the fail surface of entitlement updates.

## Testing:

1. Enable PIR, make it run
2. Add a breakpoint to [this line](https://github.com/duckduckgo/macos-browser/blob/a23ed86134afa344baa425890a499e850a3c5713/DuckDuckGo/DBP/DataBrokerProtectionSubscriptionEventHandler.swift#L62).
3. Follow the instructions from https://app.asana.com/0/1202500774821704/1206828215382050/f to revoke PIR entitlements from your account.
4. When giving focus back to the app you should see the breakpoint hit.  Step through the code to ensure the entitlement change is properly handled.
5. Grant back entitlements and check the change is properly handled again.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
