### PR TITLE
Bump BSK (sets Privacy Dashboard to 5.0.0)

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13437,8 +13437,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "mgurgel/bump-privacy-dashboard-5_0_0";
-				kind = branch;
+				kind = exactVersion;
+				version = 181.1.0;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "449b0dce6ea26e3d905ddd346b5498d28eebac3f",
-        "version" : "181.0.1"
+        "revision" : "ff87c19636bce8baa34b7984defa779c083f9ce9",
+        "version" : "181.1.0"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "181.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "181.1.0"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),
     ],

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "181.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "181.1.0"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.3"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "181.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "181.1.0"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206594217596623/1207921337238325/f
CC: @shakyShane 

**Description**:

Bumps BSK version to adopt version 5.0.0 of Privacy Dashboard with changes to the gray state

Parent task: https://app.asana.com/0/72649045549333/1207737672183274/f

TL;DR: Introduces a new green state to the Privacy Dashboard for when nothing is blocked and only affiliated domains are allowlisted. Updates the copy of the existing gray state. **There are no changes on the native side.**

**Steps to test this PR**:

Repeat the steps for each of the sites in the table below:

1. Visit [URL]
2. Open Privacy Dashboard
3. Check that dashboard screen is similar to [Screenshot]
4. Check that [Things to note] are all true
5. Click dashboard nav links (e.g. "Connection is encrypted", "Third party requests loaded") to check that they're working

| URL | Screenshot | Things to note |
| - | - | - |
| https://ebay.de | <img width="387" alt="Screenshot 2024-08-01 at 15 37 45" src="https://github.com/user-attachments/assets/33fbf5ec-9f96-4a50-94ba-0edd34a4761e">| - Icon shows green checkmark<br> - "No Tracking Requests Found" nav link is NOT visible |
| https://amazon.co.uk |<img width="388" alt="Screenshot 2024-08-01 at 15 38 45" src="https://github.com/user-attachments/assets/e64c06d7-b04b-4380-892b-35e9c30473ff">| - Icon shows red exclamation icon<br> - "No Tracking Requests Found" nav link is NOT visible |
| https://reddit.com |<img width="388" alt="Screenshot 2024-08-01 at 15 35 45" src="https://github.com/user-attachments/assets/6f9a515f-8803-41d6-9836-710d9e9a0cf9">| - Icon shows grey info icon<br> - "No Tracking Requests Found" nav link is NOT visible |
| https://cnn.com |<img width="387" alt="Screenshot 2024-08-01 at 15 37 30" src="https://github.com/user-attachments/assets/1bf93213-50e6-4d1d-987e-020dc44dfdea">| - Multiple blocked icons shown<br> - "Requests Blocked from Loading" nav link IS visible |

### Notes
If any of the sites below do not show the expected screens, try refreshing the page, as trackers may be loaded alternately on reload. If the issue persists, please comment below with which sites had a mismatch. It doesn't mean the dashboard is broken, but it does mean I'll have to find a different site to test that screen. Different platforms may load different blockers, which leads to the dashboard not always showing the same status across all platforms and device configurations.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
