### PR TITLE
Automatically add Asana task to macOS App Board

### DIFF
--- a/.github/workflows/pr_task_url.yml
+++ b/.github/workflows/pr_task_url.yml
@@ -19,45 +19,45 @@ jobs:
       task_in_project: ${{ steps.check-board-membership.outputs.task_in_project }}
 
     steps:
-      - name: Get Task ID
-        id: get-task-id
-        env:
-          BODY: ${{ github.event.pull_request.body }}
-        run: |
-          task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
-            | sed -E 's|.*https://(.*)|\1|' \
-            | cut -d '/' -f 4)
-          echo "task_id=$task_id" >> $GITHUB_OUTPUT
+    - name: Get Task ID
+      id: get-task-id
+      env:
+        BODY: ${{ github.event.pull_request.body }}
+      run: |
+        task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
+          | sed -E 's|.*https://(.*)|\1|' \
+          | cut -d '/' -f 4)
+        echo "task_id=$task_id" >> $GITHUB_OUTPUT
 
-      - name: Check App Board Project Membership
-        id: check-board-membership
-        env:
-          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          ASANA_PROJECT_ID: ${{ vars.MACOS_APP_BOARD_ASANA_PROJECT_ID }}
-        run: |
-          project_ids="$(curl -fLSs "https://app.asana.com/api/1.0/tasks/${{ steps.get-task-id.outputs.task_id }}?opt_fields=projects" \
-            -H "Authorization: Bearer ${{ env.ASANA_ACCESS_TOKEN }}" \
-            | jq -r .data.projects[].gid)"
+    - name: Check App Board Project Membership
+      id: check-board-membership
+      env:
+        ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+        ASANA_PROJECT_ID: ${{ vars.MACOS_APP_BOARD_ASANA_PROJECT_ID }}
+      run: |
+        project_ids="$(curl -fLSs "https://app.asana.com/api/1.0/tasks/${{ steps.get-task-id.outputs.task_id }}?opt_fields=projects" \
+          -H "Authorization: Bearer ${{ env.ASANA_ACCESS_TOKEN }}" \
+          | jq -r .data.projects[].gid)"
 
-          if grep -q "\b${{ env.ASANA_PROJECT_ID }}\b" <<< $project_ids; then
-            echo "task_in_project=1" >> $GITHUB_OUTPUT
-          else
-            echo "task_in_project=0" >> $GITHUB_OUTPUT
-          fi
+        if grep -q "\b${{ env.ASANA_PROJECT_ID }}\b" <<< $project_ids; then
+          echo "task_in_project=1" >> $GITHUB_OUTPUT
+        else
+          echo "task_in_project=0" >> $GITHUB_OUTPUT
+        fi
 
-      - name: Add Task to the App Board Project
-        id: add-task-to-project
-        if: ${{ github.event.action == 'opened' && steps.check-board-membership.outputs.task_in_project == '0' }}
-        env:
-          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          ASANA_PROJECT_ID: ${{ vars.MACOS_APP_BOARD_ASANA_PROJECT_ID }}
-          ASANA_PR_SECTION_ID: ${{ vars.MACOS_APP_BOARD_PR_SECTION_ID }}
-        run: |
-          curl -fLSs -X POST "https://app.asana.com/api/1.0/tasks/${{ steps.get-task-id.outputs.task_id }}/addProject" \
-            -H "Authorization: Bearer ${{ env.ASANA_ACCESS_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            --output /dev/null \
-            -d "{\"data\": {\"project\": \"${{ env.ASANA_PROJECT_ID }}\", \"section\": \"${{ env.ASANA_PR_SECTION_ID }}\"}}"
+    - name: Add Task to the App Board Project
+      id: add-task-to-project
+      if: ${{ github.event.action == 'opened' && steps.check-board-membership.outputs.task_in_project == '0' }}
+      env:
+        ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+        ASANA_PROJECT_ID: ${{ vars.MACOS_APP_BOARD_ASANA_PROJECT_ID }}
+        ASANA_PR_SECTION_ID: ${{ vars.MACOS_APP_BOARD_PR_SECTION_ID }}
+      run: |
+        curl -fLSs -X POST "https://app.asana.com/api/1.0/tasks/${{ steps.get-task-id.outputs.task_id }}/addProject" \
+          -H "Authorization: Bearer ${{ env.ASANA_ACCESS_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          --output /dev/null \
+          -d "{\"data\": {\"project\": \"${{ env.ASANA_PROJECT_ID }}\", \"section\": \"${{ env.ASANA_PR_SECTION_ID }}\"}}"
 
   # When reviewer is assigned create a subtask in Asana if not existing already
   create-asana-pr-subtask-if-needed:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1207934571176259/f

**Description**:
Remove "bot: not in app board" label and message to remind PR author to add the task to app board,
and have the task automatically added to the app board when PR is created.

**Steps to test this PR**:
1. Verify that the linked task was added to the macOS App Board by Dax the Duck.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
