### PR TITLE
Disable flaky print test in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: PR Checks
 
-on: 
+on:
   push:
     branches: [ main, "release/**" ]
   pull_request:
@@ -170,6 +170,14 @@ jobs:
 
     - name: Run integration tests
       run: |
+        brew install xmlstarlet
+        xmlstarlet ed -i '/Scheme/LaunchAction/EnvironmentVariables/EnvironmentVariable[1]' -t elem -n "EnvironmentVariable" \
+          -i '/Scheme/LaunchAction/EnvironmentVariables/EnvironmentVariable[1]' -t attr -n "key" -v "CI" \
+          -i '/Scheme/LaunchAction/EnvironmentVariables/EnvironmentVariable[1]' -t attr -n "value" -v "1" \
+          -i '/Scheme/LaunchAction/EnvironmentVariables/EnvironmentVariable[1]' -t attr -n "isEnabled" -v "YES" \
+          "DuckDuckGo.xcodeproj/xcshareddata/xcschemes/Integration Tests.xcscheme" > updated-integration-tests.xcscheme
+        mv -f updated-integration-tests.xcscheme "DuckDuckGo.xcodeproj/xcshareddata/xcschemes/Integration Tests.xcscheme"
+
         set -o pipefail && xcodebuild test \
           -scheme "${{ matrix.scheme }}" \
           -derivedDataPath "DerivedData" \
@@ -371,7 +379,7 @@ jobs:
           npm run rebuild-autoconsent
       - name: Verify clean tree
         run: |
-          git update-index --refresh 
+          git update-index --refresh
           git diff-index --quiet HEAD --
 
   create-asana-task:

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1148,6 +1148,10 @@
 		4B25377A2A11C01700610219 /* UserText+NetworkProtectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4D607C2A0B29FA00BCD287 /* UserText+NetworkProtectionExtensions.swift */; };
 		4B29759728281F0900187C4E /* FirefoxEncryptionKeyReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B29759628281F0900187C4E /* FirefoxEncryptionKeyReader.swift */; };
 		4B2975992828285900187C4E /* FirefoxKeyReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2975982828285900187C4E /* FirefoxKeyReaderTests.swift */; };
+		4B2C795C2C5AAFF200A240CC /* TestExecutionUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2C795B2C5AAFEC00A240CC /* TestExecutionUtilities.swift */; };
+		4B2C795D2C5AAFF200A240CC /* TestExecutionUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2C795B2C5AAFEC00A240CC /* TestExecutionUtilities.swift */; };
+		4B2C795E2C5AAFF300A240CC /* TestExecutionUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2C795B2C5AAFEC00A240CC /* TestExecutionUtilities.swift */; };
+		4B2C795F2C5AAFF400A240CC /* TestExecutionUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2C795B2C5AAFEC00A240CC /* TestExecutionUtilities.swift */; };
 		4B2D06292A11C0C900DE1F49 /* Bundle+VPN.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4D605E2A0B29FA00BCD287 /* Bundle+VPN.swift */; };
 		4B2D062A2A11C0C900DE1F49 /* NetworkProtectionOptionKeyExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4D605F2A0B29FA00BCD287 /* NetworkProtectionOptionKeyExtension.swift */; };
 		4B2D062C2A11C0E100DE1F49 /* Networking in Frameworks */ = {isa = PBXBuildFile; productRef = 4B2D062B2A11C0E100DE1F49 /* Networking */; };
@@ -3227,6 +3231,7 @@
 		4B25376F2A11BF8B00610219 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		4B29759628281F0900187C4E /* FirefoxEncryptionKeyReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxEncryptionKeyReader.swift; sourceTree = "<group>"; };
 		4B2975982828285900187C4E /* FirefoxKeyReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxKeyReaderTests.swift; sourceTree = "<group>"; };
+		4B2C795B2C5AAFEC00A240CC /* TestExecutionUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestExecutionUtilities.swift; sourceTree = "<group>"; };
 		4B2D06392A11CFBB00DE1F49 /* DuckDuckGo VPN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DuckDuckGo VPN.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B2D06642A132F3A00DE1F49 /* NetworkProtectionAppExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NetworkProtectionAppExtension.entitlements; sourceTree = "<group>"; };
 		4B2D06692A13318400DE1F49 /* DuckDuckGo VPN App Store.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DuckDuckGo VPN App Store.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6958,6 +6963,7 @@
 				376718FE28E58504003A2A15 /* YoutubePlayer */,
 				4BE344EC2B2376AE003FC223 /* VPNFeedbackForm */,
 				AA585D96248FD31400E9A3E2 /* Info.plist */,
+				4B2C795B2C5AAFEC00A240CC /* TestExecutionUtilities.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -10932,6 +10938,7 @@
 				B60C6F8529B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */,
 				567DA94629E95C3F008AC5EE /* YoutubeOverlayUserScriptTests.swift in Sources */,
 				9F0660742BECC71200B8EEF1 /* SubscriptionAttributionPixelHandlerTests.swift in Sources */,
+				4B2C795D2C5AAFF200A240CC /* TestExecutionUtilities.swift in Sources */,
 				9FBD847B2BB3EC3300220859 /* MockAttributionOriginProvider.swift in Sources */,
 				3706FE82293F661700E42796 /* MockStatisticsStore.swift in Sources */,
 				9FBD84712BB3DD8400220859 /* MockAttributionsPixelHandler.swift in Sources */,
@@ -10956,6 +10963,7 @@
 				3706FEA1293F662100E42796 /* TestNavigationDelegate.swift in Sources */,
 				B6EC37DF29B5D05A001ACE79 /* DownloadsIntegrationTests.swift in Sources */,
 				B6EC37FD29B83E99001ACE79 /* TestsURLExtension.swift in Sources */,
+				4B2C795F2C5AAFF400A240CC /* TestExecutionUtilities.swift in Sources */,
 				B603973529BEF86200902A34 /* HTTPSUpgradeIntegrationTests.swift in Sources */,
 				B644B44029D57299003FA9AB /* SuggestionLoadingMock.swift in Sources */,
 				1D8B7D6B2A38BF060045C6F6 /* FireproofDomainsStoreMock.swift in Sources */,
@@ -11000,6 +11008,7 @@
 				4B1AD8E225FC390B00261379 /* EncryptionMocks.swift in Sources */,
 				B6EC37FC29B83E99001ACE79 /* TestsURLExtension.swift in Sources */,
 				B6DA06E22913AEDC00225DE2 /* TestNavigationDelegate.swift in Sources */,
+				4B2C795E2C5AAFF300A240CC /* TestExecutionUtilities.swift in Sources */,
 				B603973429BEF86200902A34 /* HTTPSUpgradeIntegrationTests.swift in Sources */,
 				4B1AD91725FC46FB00261379 /* CoreDataEncryptionTests.swift in Sources */,
 				B644B43F29D57298003FA9AB /* SuggestionLoadingMock.swift in Sources */,
@@ -12351,6 +12360,7 @@
 				9FBD84702BB3DD8400220859 /* MockAttributionsPixelHandler.swift in Sources */,
 				4B117F7D276C0CB5002F3D8C /* LocalStatisticsStoreTests.swift in Sources */,
 				378205F62837CBA800D1D4AA /* SavedStateMock.swift in Sources */,
+				4B2C795C2C5AAFF200A240CC /* TestExecutionUtilities.swift in Sources */,
 				3783F92329432E1800BCA897 /* WebViewTests.swift in Sources */,
 				EA8AE76A279FBDB20078943E /* ClickToLoadTDSTests.swift in Sources */,
 				B63ED0DA26AE7AF400A9DAD1 /* PermissionManagerMock.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/Integration Tests.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/Integration Tests.xcscheme
@@ -34,6 +34,18 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_DT_MODE"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "DEBUG"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/IntegrationTests/Tab/TabContentTests.swift
+++ b/IntegrationTests/Tab/TabContentTests.swift
@@ -76,6 +76,10 @@ class TabContentTests: XCTestCase {
 
     @MainActor
     func testWhenPDFContextMenuPrintChosen_printDialogOpens() async throws {
+        try disableInCI()
+
+        XCTFail("Testing that this is really disabled in CI")
+
         let pdfUrl = Bundle(for: Self.self).url(forResource: "test", withExtension: "pdf")!
         // open Tab with PDF
         let tab = Tab(content: .url(pdfUrl, credential: nil, source: .userEntered("")))

--- a/UnitTests/TestExecutionUtilities.swift
+++ b/UnitTests/TestExecutionUtilities.swift
@@ -1,0 +1,26 @@
+//
+//  TestExecutionUtilities.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+func disableInCI() throws {
+    if ProcessInfo.processInfo.environment["CI"] != nil {
+        throw XCTSkip("This test is disabled in CI.")
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207944978627752/f
Tech Design URL:
CC:

**Description**:

This PR adds a `disableInCI` function that is available from unit and integration test suites. It checks for the CI environment and calls XCTSkip if the environment condition is met.

This is a draft PR as I'd like to add a comment for the disabled test, as well as check that there isn't already a better place to put the disable function. Also, I've added a hardcoded failure into the print function to check for sure that the skip is working.

**Steps to test this PR**:
1. Check that CI passes

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
