### PR TITLE
Return App Store subscription options only if not nil

### DIFF
--- a/DuckDuckGo/InfoPlist.xcstrings
+++ b/DuckDuckGo/InfoPlist.xcstrings
@@ -7,55 +7,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "DuckDuckGo"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "DuckDuckGo App Store"
+            "value" : "DuckDuckGo"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "DuckDuckGo"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "DuckDuckGo"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "DuckDuckGo"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "DuckDuckGo"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "DuckDuckGo"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "DuckDuckGo"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "DuckDuckGo"
           }
         }

--- a/DuckDuckGo/Localizable.xcstrings
+++ b/DuckDuckGo/Localizable.xcstrings
@@ -27846,7 +27846,7 @@
     },
     "letsmove.alert.message" : {
       "comment" : "Message of the alert shown if the app is launched not from the /Applications folder – suggesting to move it there",
-      "extractionState" : "stale",
+      "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -27906,7 +27906,7 @@
     },
     "letsmove.alert.title" : {
       "comment" : "Title of the alert shown if the app is launched not from the /Applications folder – suggesting to move it there",
-      "extractionState" : "stale",
+      "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -27966,7 +27966,7 @@
     },
     "letsmove.could.not.move" : {
       "comment" : "Error message when moving the app to the /Applications folder failed",
-      "extractionState" : "stale",
+      "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -28026,7 +28026,7 @@
     },
     "letsmove.dont.move.button" : {
       "comment" : "Do Not Move to the /Applications folder button title",
-      "extractionState" : "stale",
+      "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -28086,7 +28086,7 @@
     },
     "letsmove.move.button" : {
       "comment" : "Move the /Applications folder button title",
-      "extractionState" : "stale",
+      "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
           "stringUnit" : {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203936086921904/1207934463147478/f

**Description**:
In case no App Store subscription objects are available we should return a proper `SubscriptionOptions.empty` object. 

**Steps to test this PR**:
From Xcode run App Store scheme and ensure from the debug menu that the app is configured to use App Store on Staging
1. Ensure no Privacy Pro is available from the "..." menu
2. Open Debug -> Subscription -> I Have a Subscription
3. Sing in to active staging subscription via OTP
4. Click "Done" on the success page
5. Ensure that subscription "Welcome" page is loaded

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
