### PR TITLE
Pushes a tentative fix for the media permissions crash

### DIFF
--- a/DuckDuckGo/Permissions/Model/PermissionModel.swift
+++ b/DuckDuckGo/Permissions/Model/PermissionModel.swift
@@ -226,7 +226,7 @@ final class PermissionModel {
     // MARK: - WebView delegated methods
 
     // Called before requestMediaCapturePermissionFor: to validate System Permissions
-    func checkUserMediaPermission(for url: URL, mainFrameURL: URL, decisionHandler: @escaping (String, Bool) -> Void) {
+    func checkUserMediaPermission(for url: URL?, mainFrameURL: URL?, decisionHandler: @escaping (String, Bool) -> Void) {
         // If media capture is denied in the System Preferences, reflect it in the current permissions
         // AVCaptureDevice.authorizationStatus(for:mediaType) is swizzled to determine requested media type
         // otherwise WebView won't call any other delegate methods if System Permission is denied

--- a/DuckDuckGo/Tab/Model/Tab+UIDelegate.swift
+++ b/DuckDuckGo/Tab/Model/Tab+UIDelegate.swift
@@ -176,11 +176,11 @@ extension Tab: WKUIDelegate, PrintingUserScriptDelegate {
 
     @objc(_webView:checkUserMediaPermissionForURL:mainFrameURL:frameIdentifier:decisionHandler:)
     func webView(_ webView: WKWebView,
-                 checkUserMediaPermissionFor url: URL,
-                 mainFrameURL: URL,
+                 checkUserMediaPermissionFor url: NSURL?,
+                 mainFrameURL: NSURL?,
                  frameIdentifier: UInt64,
                  decisionHandler: @escaping (String, Bool) -> Void) {
-        self.permissions.checkUserMediaPermission(for: url, mainFrameURL: mainFrameURL, decisionHandler: decisionHandler)
+        self.permissions.checkUserMediaPermission(for: url as? URL, mainFrameURL: mainFrameURL as? URL, decisionHandler: decisionHandler)
     }
 
     // https://github.com/WebKit/WebKit/blob/995f6b1595611c934e742a4f3a9af2e678bc6b8d/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h#L147


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203108348835387/1207988315342624/f

## Description

Tentative fix for media permissions crash.

## Testing

1. Make sure that your Camera permissions are reset for the debug build you're testing on in System Settings > Privacy & Security > Camera.  If they're not, you need to delete the debug build and check back that any permissions set are gone.
2. Place a breakpoint in https://github.com/duckduckgo/macos-browser/blob/02caf5ec1ce7cae2f736e106771afb0950664ab0/DuckDuckGo/Tab/Model/Tab%2BUIDelegate.swift#L183
3. Run the app, and open meet.google.com
4. Start an instant meeting, it should trigger your breakpoint
5. Look at the stack trace and select frame 1 (the one that starts with `@objc`, which is auto generated).

<img width="358" alt="Screenshot 2024-08-06 at 12 57 00 PM" src="https://github.com/user-attachments/assets/a8cfe2c0-00a4-48d5-a539-7aafc22b91cf">

6. Looking at the code, make sure you don't see any call to `unconditionallyBridgeFromObjectiveC`.  These are the calls you must NOT see:

<img width="925" alt="Screenshot 2024-08-06 at 12 27 48 PM" src="https://github.com/user-attachments/assets/c9d797f8-9e9e-4781-a852-8acae3ed1e5c">

7. Let the code continue executing and make sure permissions work fine.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
