### PR TITLE
Add Show In Folder action to bookmarks management search

### DIFF
--- a/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
@@ -23,6 +23,7 @@ protocol BookmarkManagementDetailViewControllerDelegate: AnyObject {
 
     func bookmarkManagementDetailViewControllerDidSelectFolder(_ folder: BookmarkFolder)
     func bookmarkManagementDetailViewControllerDidStartSearching()
+    func bookmarkManagementDetailViewControllerShowInFolder(_ folder: BookmarkFolder)
 
 }
 
@@ -563,7 +564,7 @@ extension BookmarkManagementDetailViewController: BookmarkTableCellViewDelegate 
             return
         }
 
-        guard let contextMenu = ContextualMenu.menu(for: [bookmark], target: self) else { return }
+        guard let contextMenu = ContextualMenu.menu(for: [bookmark], target: self, forSearch: managementDetailViewModel.isSearching) else { return }
         contextMenu.popUpAtMouseLocation(in: view)
     }
 
@@ -588,7 +589,7 @@ extension BookmarkManagementDetailViewController: NSMenuDelegate {
         let (item, parent) = fetchEntityAndParent(at: row)
 
         if let item {
-            return ContextualMenu.menu(for: item, parentFolder: parent)
+            return ContextualMenu.menu(for: item, parentFolder: parent, forSearch: managementDetailViewModel.isSearching)
         } else {
             return nil
         }
@@ -758,6 +759,22 @@ extension BookmarkManagementDetailViewController: BookmarkMenuItemSelectors {
         bookmarkManager.remove(objectsWithUUIDs: uuids)
     }
 
+}
+
+extension BookmarkManagementDetailViewController: BookmarkSearchMenuItemSelectors {
+    func showInFolder(_ sender: NSMenuItem) {
+        guard let baseBookmark = sender.representedObject as? BaseBookmarkEntity else {
+            assertionFailure("Failed to retrieve Bookmark from Show in Folder context menu item")
+            return
+        }
+
+        if let bookmark = baseBookmark as? Bookmark,
+            let folder = managementDetailViewModel.searchForParent(bookmark: bookmark) {
+            delegate?.bookmarkManagementDetailViewControllerShowInFolder(folder)
+        } else if let folder = baseBookmark as? BookmarkFolder {
+            delegate?.bookmarkManagementDetailViewControllerShowInFolder(folder)
+        }
+    }
 }
 
 // MARK: - Search field delegate

--- a/DuckDuckGo/Bookmarks/View/BookmarkManagementSidebarViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkManagementSidebarViewController.swift
@@ -194,6 +194,17 @@ final class BookmarkManagementSidebarViewController: NSViewController {
         }
     }
 
+    func showBookmarkInFolder(_ folder: BookmarkFolder) {
+        guard let node = dataSource.treeController.node(representing: folder) else {
+            return
+        }
+
+        let path = BookmarkNode.Path(node: node)
+        outlineView.revealAndSelect(nodePath: path)
+        outlineView.scrollToAdjustedPositionInOutlineView(node)
+        outlineView.highlight(node)
+    }
+
     private func reloadData() {
         let selectedNodes = self.selectedNodes
         dataSource.reloadData(with: .manual)

--- a/DuckDuckGo/Bookmarks/View/BookmarkManagementSplitViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkManagementSplitViewController.swift
@@ -94,6 +94,10 @@ extension BookmarkManagementSplitViewController: BookmarkManagementDetailViewCon
         sidebarViewController.selectBookmarksFolder()
     }
 
+    func bookmarkManagementDetailViewControllerShowInFolder(_ folder: BookmarkFolder) {
+        sidebarViewController.showBookmarkInFolder(folder)
+    }
+
 }
 
 #if DEBUG

--- a/DuckDuckGo/Bookmarks/ViewModel/BookmarkManagementDetailViewModel.swift
+++ b/DuckDuckGo/Bookmarks/ViewModel/BookmarkManagementDetailViewModel.swift
@@ -31,6 +31,10 @@ final class BookmarkManagementDetailViewModel {
     private var searchQuery = ""
     private(set) var visibleBookmarks = [BaseBookmarkEntity]()
 
+    var isSearching: Bool {
+        !searchQuery.isBlank
+    }
+
     init(bookmarkManager: BookmarkManager) {
         self.bookmarkManager = bookmarkManager
     }
@@ -70,6 +74,14 @@ final class BookmarkManagementDetailViewModel {
         default:
             return (visibleBookmarks[safe: row], nil)
         }
+    }
+
+    func searchForParent(bookmark: Bookmark) -> BookmarkFolder? {
+        guard let parentID = bookmark.parentFolderUUID else {
+            return nil
+        }
+
+        return bookmarkManager.getBookmarkFolder(withId: parentID)
     }
 
     // MARK: - Drag and drop


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1207983429775315/f
Tech Design URL:
CC:

## Description
Adds the ’Show in Folder’ action to search


### Acceptance criteria
**AC1**
Given a user in the management bookmarks page and doing a search
When the user right-taps a folder or a bookmark, or uses the three-dot menu
Then, in the menu a 'Show in Folder' option appears

**AC2**
Given a user in a search in the management bookmarks page
When the user selects the 'Show in Folder' option from a Folder
Then the sidebar selects the folder in the tree view
And expands any parent folder

**AC3**
Given a user in a search in the management bookmarks page
When the user selects the 'Show in Folder' option from a Bookmark
Then the sidebar selects the parent folder of the bookmark in the tree view
And expands any parent folder

### Demo

https://github.com/user-attachments/assets/58113ab7-a9b5-4f07-b261-e38781153cfd

## Steps to test this PR
1. Open the Bookmarks Manager
2. Check the acceptance criteria are met

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
