### PR TITLE
Stop VPN is no longer guarded by the VPN feature gatekeeper

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
@@ -74,10 +74,6 @@ final class NetworkProtectionIPCTunnelController {
     // MARK: - Login Items Manager
 
     private func enableLoginItems() async throws {
-        guard try await featureGatekeeper.canStartVPN() else {
-            throw RequestError.notAuthorizedToEnableLoginItem
-        }
-
         do {
             try loginItemsManager.throwingEnableLoginItems(LoginItemsManager.networkProtectionLoginItems, log: .networkProtection)
         } catch {
@@ -103,6 +99,10 @@ extension NetworkProtectionIPCTunnelController: TunnelController {
         }
 
         do {
+            guard try await featureGatekeeper.canStartVPN() else {
+                throw RequestError.notAuthorizedToEnableLoginItem
+            }
+
             try await enableLoginItems()
 
             knownFailureStore.reset()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1207992369875462/f

## Description

Changes the code so that stopping the tunnel can't be prevented by `VPNFeatureGatekeeper`.

## Testing

You'll need to [enable PrivacyPro](https://app.asana.com/0/1202500774821704/1207149361119036/f).
- Hint: it's easier in Sparkle builds.
- Let me know if you need help here.

The same test can be used to validate the fix here, and validate the original issue in `main`, depending on which branch you test in.

1. Change [this method](https://github.com/duckduckgo/macos-browser/blob/a03e3d658f69c6f9d8ceb0228f035b6dd8dc613c/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift#L68) to always return `false`.
2. Run the app and start the VPN from the browser.
3. Stop the VPN, it should work.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
