### PR TITLE
Do not clear search when switching tabs

### DIFF
--- a/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
@@ -64,8 +64,11 @@ final class BookmarkManagementDetailViewController: NSViewController, NSMenuItem
     }
 
     func update(selectionState: BookmarkManagementSidebarViewController.SelectionState) {
-        self.clearSearch()
-        managementDetailViewModel.update(selection: selectionState)
+        if case .folder = selectionState {
+            clearSearch()
+        }
+
+        managementDetailViewModel.update(selection: selectionState, searchQuery: searchBar.stringValue)
         self.selectionState = selectionState
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1207983429775316/f
Tech Design URL:
CC:

**Description**:
When switching tabs, the search query shouldn't be cleared. The search query should only be cleared when the user taps a folder in the sidebar.

**Steps to test this PR**:

**The search query shouldn’t be emptied on switching tabs**
1. Go to the management bookmarks tab
2. Start a search query
3. Switch to another tab
4. Come back to the management bookmarks tab
5. The search should be resumed

**The search query should be cleared by tapping a folder in the sidebar**
1. Go to the management bookmarks tab
2. Start a search query
3. Tap a folder in the sidebar
4. The search should be cleared
5. And the content inside the folder should be shown


**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
