### PR TITLE
Revert "xattr command removed from the restarting script"

### DIFF
--- a/DuckDuckGo/Updates/AppRestarter.swift
+++ b/DuckDuckGo/Updates/AppRestarter.swift
@@ -35,10 +35,11 @@ final class AppRestarter: AppRestarting {
             return
         }
 
+        let preOpenCmd = "/usr/bin/xattr -d -r com.apple.quarantine \(shellQuotedString(destinationPath))"
         let openCmd = "/usr/bin/open \(shellQuotedString(destinationPath))"
 
         let script = """
-        (while /bin/kill -0 \(pid) >&/dev/null; do /bin/sleep 0.1; done; \(openCmd)) &
+        (while /bin/kill -0 \(pid) >&/dev/null; do /bin/sleep 0.1; done; \(preOpenCmd); \(openCmd)) &
         """
 
         let task = Process()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1148564399326804/1207945245157372/f

**Description**:
This reverts commit 8f59f09f6f74b2090c8306940bc13d3c80de2377.
It wasn't confirmed that xattr command is causing the macOS warning dialog. On the other hand, it negatively influenced the update by introducing a file verification.

**Steps to test this PR**:

1. Change the build number and version number to lower numbers (Version.xcconfig, BuildNumber.xcconfig)

1. Change the implementation of configureUpdater() in UpdateController.swift:
```
    private func configureUpdater() {
        // The default configuration of Sparkle updates is in Info.plist
        updater = SPUStandardUpdaterController(updaterDelegate: self, userDriverDelegate: self)
        shouldShowManualUpdateDialog = false

        if updater.updater.automaticallyDownloadsUpdates != areAutomaticUpdatesEnabled {
            updater.updater.automaticallyDownloadsUpdates = areAutomaticUpdatesEnabled
        }

#if DEBUG
//        updater.updater.automaticallyChecksForUpdates = false
//        updater.updater.automaticallyDownloadsUpdates = false
//        updater.updater.updateCheckInterval = 0
#endif

        checkForUpdateInBackground()
    }
```
1. Run the app
1. Wait until the app loads a new update
1. Use "Restart to Update" button (either in settings, right menu or Release Notes page)
1. Make sure the app is restarted and the new app session has higher version and build number (DuckDuckGo -> About DuckDuckGo)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
