### PR TITLE
DuckPlayer contingency messages pixels 

### DIFF
--- a/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift
@@ -120,6 +120,7 @@ final class DuckPlayerPreferences: ObservableObject {
     @MainActor
     func openLearnMoreContingencyURL() {
         guard let url = duckPlayerContingencyHandler.learnMoreURL else { return }
+        PixelKit.fire(NonStandardEvent(GeneralPixel.duckPlayerContingencyLearnMoreClicked))
         WindowControllersManager.shared.show(url: url, source: .ui, newTab: true)
     }
 

--- a/DuckDuckGo/Preferences/View/PreferencesDuckPlayerView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesDuckPlayerView.swift
@@ -25,6 +25,9 @@ extension Preferences {
 
     struct DuckPlayerView: View {
         @ObservedObject var model: DuckPlayerPreferences
+        /// The ContingencyMessageView may be redrawn multiple times in the onAppear method if the user changes tabs.
+        /// This property ensures that the associated action is only triggered once per viewing session, preventing redundant executions.
+        @State private var hasFiredSettingsDisplayedPixel = false
 
         var duckPlayerModeBinding: Binding<DuckPlayerMode> {
             .init {
@@ -54,6 +57,12 @@ extension Preferences {
                             model.openLearnMoreContingencyURL()
                         }
                         .frame(width: 512)
+                        .onAppear {
+                            if !hasFiredSettingsDisplayedPixel {
+                                PixelKit.fire(NonStandardEvent(GeneralPixel.duckPlayerContingencySettingsDisplayed))
+                                hasFiredSettingsDisplayedPixel = true
+                            }
+                        }
                     }
                 }
 

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -130,6 +130,8 @@ enum GeneralPixel: PixelKitEventV2 {
     case duckPlayerAutoplaySettingsOff
     case duckPlayerNewTabSettingsOn
     case duckPlayerNewTabSettingsOff
+    case duckPlayerContingencySettingsDisplayed
+    case duckPlayerContingencyLearnMoreClicked
 
     // Dashboard
     case dashboardProtectionAllowlistAdd(triggerOrigin: String?)
@@ -604,6 +606,10 @@ enum GeneralPixel: PixelKitEventV2 {
             return "duckplayer_mac_newtab_setting-on"
         case .duckPlayerNewTabSettingsOff:
             return "duckplayer_mac_newtab_setting-off"
+        case .duckPlayerContingencySettingsDisplayed:
+            return "duckplayer_mac_contingency_settings-displayed"
+        case .duckPlayerContingencyLearnMoreClicked:
+            return "duckplayer_mac_contingency_learn-more-clicked"
         case .dashboardProtectionAllowlistAdd:
             return "m_mac_mp_wla"
         case .dashboardProtectionAllowlistRemove:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1208023423226061/f
Tech Design URL:

**Description**:
Add pixels for contingency message on duck player

**Steps to test this PR**:
1. Display the contingency message with the steps in https://github.com/duckduckgo/iOS/pull/3190
2. See if the pixels are fired when UI is shown and when the learn more button is clicked


