### PR TITLE
Add and Throw Explicit Errors for DB Migration Failure Points

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
@@ -23,7 +23,6 @@ import GRDB
 
 enum DataBrokerProtectionDatabaseErrors: Error {
     case elementNotFound
-    case migrationFailureIntegrityCheck
 }
 
 protocol DataBrokerProtectionDatabaseProvider: SecureStorageDatabaseProvider {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206488453854252/1207802624568506/f

**Description**: The PIR v3 migration can fail at three points:
1. Orphaned Record Cleanup
2. Table Recreation
3. Final Foreign Key Violation Check

Currently, we throw an explicit error for #3, which is observable via Pixels. We should also throw explicit errors for #1 and #2. This PR adds these new errors.

**Steps to test this PR**:
1. N/A - This simply throws explicit errors for existing possible error paths

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
