### PR TITLE
Fix issue sending the duckPlayerWatchOnYoutube pixel

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -307,8 +307,7 @@ extension DuckPlayerTabExtension: NavigationResponder {
 
         // “Watch in YouTube” selected
         // when currently displayed content is the Duck Player and loading a YouTube URL, don‘t override it
-        if navigationAction.targetFrame?.url.isDuckPlayer == true,
-           navigationAction.targetFrame?.url.youtubeVideoID == videoID {
+        if didUserSelectWatchInYoutubeFromDuckPlayer(navigationAction, preferences: preferences, videoID: videoID) {
             PixelKit.fire(GeneralPixel.duckPlayerWatchOnYoutube)
             return .next
 
@@ -342,6 +341,11 @@ extension DuckPlayerTabExtension: NavigationResponder {
         }
 
         return .next
+    }
+
+    private func didUserSelectWatchInYoutubeFromDuckPlayer(_ navigationAction: NavigationAction, preferences: DuckPlayerPreferences, videoID: String) -> Bool {
+        let url = preferences.duckPlayerOpenInNewTab ? navigationAction.sourceFrame.url : navigationAction.targetFrame?.url
+        return url?.isDuckPlayer == true && url?.youtubeVideoID == videoID
     }
 
     func didCommit(_ navigation: Navigation) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207252092703676/1208089112886056/f
Tech Design URL:
CC:

**Description**:
Fix issue sending the watch on youtube pixel

**Steps to test this PR**:
1. Check settings, set open Duck Player in new tab to false
2. Open a video in Duck Player, click in watch in youtube
3. Check if the pixel duckPlayerWatchOnYoutube was fired
4. Check settings, set open Duck Player in new tab to true
5. Open a video in Duck Player, click in watch in youtube
6. Check if the pixel duckPlayerWatchOnYoutube was fired