### PR TITLE
Fix address bar queries when doing math expressions

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13473,7 +13473,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 185.0.1;
+				version = 185.1.1;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "1354d1aec247fd569c69744bb2722f24e16f0bfb",
-        "version" : "185.0.1"
+        "revision" : "c92b86502e0ea852ea3669e7c5e06e265becb4a8",
+        "version" : "185.1.1"
       }
     },
     {
@@ -75,7 +75,7 @@
     {
       "identity" : "lottie-spm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-spm.git",
+      "location" : "https://github.com/airbnb/lottie-spm",
       "state" : {
         "revision" : "1d29eccc24cc8b75bff9f6804155112c0ffc9605",
         "version" : "4.4.3"

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "185.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "185.1.1"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),
     ],

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "185.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "185.1.1"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.3"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "185.0.1"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "185.1.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [

--- a/UnitTests/Common/Extensions/URLExtensionTests.swift
+++ b/UnitTests/Common/Extensions/URLExtensionTests.swift
@@ -57,7 +57,8 @@ final class URLExtensionTests: XCTestCase {
             ("http://💩.la:8080 ", "http://xn--ls8h.la:8080"),
             ("http:// 💩.la:8080 ", "https://duckduckgo.com/?q=http%3A%2F%2F%20%F0%9F%92%A9.la%3A8080"),
             ("https://xn--ls8h.la/path/to/resource", "https://xn--ls8h.la/path/to/resource"),
-            ("1.4/3.4", "https://duckduckgo.com/?q=1.4%2F3.4")
+            ("1.4/3.4", "https://duckduckgo.com/?q=1.4%2F3.4"),
+            ("16385-12228.72", "https://duckduckgo.com/?q=16385-12228.72")
         ]
 
         for (string, expected) in data {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208002970105121/f
Tech Design URL:
CC:


**Description**:
This pull request introduces a change on how we check for valid hostnames. The current regurlar expression had an issue where some mathematical expressions where valid hostnames.

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/952

**Steps to test this PR**:
1. Open the app
2. Put 16385-12228.75 in the address bar
3. This should do a search on our SERP instead of trying to open a webpage
4. Test other usual web sites URLs and check those are working.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?