### PR TITLE
Filter out inaccessible tasks from release

### DIFF
--- a/scripts/update_asana_for_release.sh
+++ b/scripts/update_asana_for_release.sh
@@ -56,7 +56,10 @@ get_task_id() {
 	if [[ "$url" =~ ${task_url_regex} ]]; then
 		local task_id="${BASH_REMATCH[1]}"
 		local http_code
-		http_code=$(curl -fLSs "${asana_api_url}/tasks/${task_id}?opt_fields=gid" -H "Authorization: Bearer ${ASANA_ACCESS_TOKEN}" --write-out '%{http_code}' --output /dev/null)
+		http_code="$(curl -fLSs "${asana_api_url}/tasks/${task_id}?opt_fields=gid" \
+			-H "Authorization: Bearer ${ASANA_ACCESS_TOKEN}" \
+			--write-out '%{http_code}' \
+			--output /dev/null)"
 		if [[ "$http_code" -eq 200 ]]; then
 			echo "${task_id}"
 		else


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208036161861761/f
Tech Design URL:
CC:

**Description**:
When a task is deleted or private, we will remove it from the release, given that it will make it fail.

**Steps to test this PR**:
I tested this by using an internal release and adding an `exit 0` on line `279` (to ensure the script doesn’t move forward). I added a delete task to the release and tested the id that wasn’t part of the `task_ids` array.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
