### PR TITLE
fix zoom updated

### DIFF
--- a/DuckDuckGo/Tab/View/WebView.swift
+++ b/DuckDuckGo/Tab/View/WebView.swift
@@ -106,12 +106,6 @@ final class WebView: WKWebView {
             return DefaultZoomValue(rawValue: pageZoom) ?? .percent100
         }
         set {
-            // There are cases where the pageZoom does not reflect the actual display, such as after a command-click on a link.
-            // The API may not trigger a change if the new value is the same as the current value.
-            if pageZoom == newValue.rawValue {
-                // Slightly modify the value to force the API to trigger a change.
-                pageZoom = newValue.rawValue - 0.001
-            }
             pageZoom = newValue.rawValue
         }
     }

--- a/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -184,6 +184,7 @@ final class TabViewModel {
             }
             .store(in: &cancellables)
 
+        // The tab content is updated for every same document navigation as well while we want to update zoom and can be bookmarked only for full navifation. Using it allows for the zoom to be applied immediately and not only when the navigation is ended avoiding a visible change in size
         tab.$hasCommittedContent
             .sink { [weak self] _ in
                 guard let self else { return }

--- a/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -21,6 +21,7 @@ import Cocoa
 import Combine
 import Common
 import WebKit
+import PrivacyDashboard
 
 final class TabViewModel {
 
@@ -281,9 +282,37 @@ final class TabViewModel {
     }
 
     private func subscribeToWebViewDidFinishNavigation() {
-        tab.webViewDidFinishNavigationPublisher.sink { [weak self] in
+        // When a web page finishes loading, wait when the `ContentBlockerRulesUserScript` detects trackers
+        // and adds them to `PrivacyDashboardTabExtension.$privacyInfo.$trackerInfo`.
+        // Map the `$trackerInfo` into a debounced Publisher and play trackers animations
+        // if there were any trackers detected.
+        tab.webViewDidFinishNavigationPublisher.map { [weak tab] in
+            guard let tab,
+                  tab.privacyInfo?.trackerInfo.trackersBlocked.isEmpty ?? true else {
+                // the blocked trackers are already present when the navigation is finished, just return them
+                return Just(tab?.privacyInfo?.trackerInfo).eraseToAnyPublisher()
+            }
+
+            // `Tab(PrivacyDashboardTabExtension).$privacyInfo` is reset on new navigation start.
+            return tab.privacyInfoPublisher.map {
+                guard let trackerInfoPublisher = $0?.$trackerInfo else {
+                    // no TrackerInfo added yet, don‘t publish
+                    return Empty<TrackerInfo?, Never>().eraseToAnyPublisher()
+                }
+                // map the TrackerInfo Publisher and `switchToLatest` to use its Output.
+                return trackerInfoPublisher.map { TrackerInfo?.some($0) }.eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            // debounce detected trackers (if any)
+            .debounce(for: 0.2, scheduler: RunLoop.main)
+            // prepend with existing (empty) TrackerInfo that won‘t trigger the animation but will update the privacy icon
+            .prepend(tab.privacyInfo?.trackerInfo)
+            .eraseToAnyPublisher()
+        }
+        .switchToLatest()
+        .sink { [weak self] trackerInfo in
             guard let self = self else { return }
-            self.sendAnimationTrigger()
+            self.sendAnimationTrigger(trackerInfo: trackerInfo)
         }.store(in: &cancellables)
     }
 
@@ -448,9 +477,9 @@ final class TabViewModel {
 
     private var trackerAnimationTimer: Timer?
 
-    private func sendAnimationTrigger() {
+    private func sendAnimationTrigger(trackerInfo: TrackerInfo?) {
         privacyEntryPointIconUpdateTrigger.send()
-        if self.tab.privacyInfo?.trackerInfo.trackersBlocked.count ?? 0 > 0 {
+        if let trackerInfo, !trackerInfo.trackersBlocked.isEmpty {
             self.trackersAnimationTriggerPublisher.send()
         }
     }

--- a/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -178,9 +178,14 @@ final class TabViewModel {
             .switchToLatest()
             .sink { [weak self] _ in
                 guard let self else { return }
-
                 updateAddressBarStrings()
                 updateFavicon()
+            }
+            .store(in: &cancellables)
+
+        tab.$hasCommittedContent
+            .sink { [weak self] _ in
+                guard let self else { return }
                 updateCanBeBookmarked()
                 updateZoomForWebsite()
             }

--- a/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -284,7 +284,6 @@ final class TabViewModel {
         tab.webViewDidFinishNavigationPublisher.sink { [weak self] in
             guard let self = self else { return }
             self.sendAnimationTrigger()
-            self.updateZoomForWebsite()
         }.store(in: &cancellables)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207686573307971/1208100557904771/f

**Description**: Fix an issue where a cycle of same document navigations are triggered.
This is fixed by updating the zoom on navigationDidCommit rather than on tab content change.
A second step to avoid to reload shield animation on the same page is webViewDidFinishNavigationPublisher updates only when not same-document navigations.

**Steps to test this PR**:
1. go to https://www.realtor.com/realestateandhomes-search/Duluth_MN?view=map&pos=46.955704,-92.397107,46.584657,-91.833761,10.881999999999996&qdm=true and check that the dashboard is not flickering and zooming the page and zooming or viewing the maps works as expected
2. Go to a website zoom in or out then in a new tab visit the same website and check the zoom is at the previously setting value immediately (it’s not adjusted on the go)
3. cmd+click on a link and check that the opened tab with the website has the same zoom
4. Set the zoom on bbc.com
5. go to bbc.co.uk which should reload to bbc.com check that after the reload the zoom is set as expected

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
