### PR TITLE
Fix trackers animation

### DIFF
--- a/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -21,6 +21,7 @@ import Cocoa
 import Combine
 import Common
 import WebKit
+import PrivacyDashboard
 
 final class TabViewModel {
 
@@ -281,9 +282,32 @@ final class TabViewModel {
     }
 
     private func subscribeToWebViewDidFinishNavigation() {
-        tab.webViewDidFinishNavigationPublisher.sink { [weak self] in
+        // When a web page finishes loading, wait when the `ContentBlockerRulesUserScript` detects trackers
+        // and adds them to `PrivacyDashboardTabExtension.$privacyInfo.$trackerInfo`.
+        // Map the `$trackerInfo` into a debounced Publisher and play trackers animations
+        // if there were any trackers detected.
+        tab.webViewDidFinishNavigationPublisher.map { [weak tab] in
+            guard let tab else { return Empty<TrackerInfo?, Never>().eraseToAnyPublisher() }
+
+            // `Tab(PrivacyDashboardTabExtension).$privacyInfo` is reset on new navigation start.
+            return tab.privacyInfoPublisher.map {
+                guard let trackerInfoPublisher = $0?.$trackerInfo else {
+                    // no TrackerInfo added yet
+                    return Just(TrackerInfo?.none).eraseToAnyPublisher()
+                }
+                // map the TrackerInfo Publisher and `switchToLatest` to use its Output.
+                return trackerInfoPublisher.map { TrackerInfo?.some($0) }.eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            // prepend existing TrackerInfo if set before the navigation finishes.
+            .prepend(tab.privacyInfo?.trackerInfo)
+            .debounce(for: 0.2, scheduler: RunLoop.main)
+            .eraseToAnyPublisher()
+        }
+        .switchToLatest()
+        .sink { [weak self] trackerInfo in
             guard let self = self else { return }
-            self.sendAnimationTrigger()
+            self.sendAnimationTrigger(trackerInfo: trackerInfo)
         }.store(in: &cancellables)
     }
 
@@ -448,9 +472,9 @@ final class TabViewModel {
 
     private var trackerAnimationTimer: Timer?
 
-    private func sendAnimationTrigger() {
+    private func sendAnimationTrigger(trackerInfo: TrackerInfo?) {
         privacyEntryPointIconUpdateTrigger.send()
-        if self.tab.privacyInfo?.trackerInfo.trackersBlocked.count ?? 0 > 0 {
+        if let trackerInfo, !trackerInfo.trackersBlocked.isEmpty {
             self.trackersAnimationTriggerPublisher.send()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208145681456113/f

**Description**:
- Follow-up after https://github.com/duckduckgo/macos-browser/pull/3140
- Add a threshold for the trackers to be detected after navigation is finished and play the trackers animation afterwards to fix the animation not played if trackers are detected after the navigation is finished

**Steps to test this PR**:
1. Open tripadvisor.com, validate trackers animation is played
2. Navigate to other websites like google.com, http://permission.site, https://permission.site, then back to tripadvisor.com, validate the red dot is displayed for HTTP and the privacy dashboard info is updated accordingly on the websites

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
