### PR TITLE
Pete/feature/pir freemium entry points ux

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -2589,6 +2589,10 @@
 		C17CA7B32B9B5317008EC3C1 /* MockAutofillPopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17CA7B12B9B5317008EC3C1 /* MockAutofillPopoverPresenter.swift */; };
 		C18194592C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194582C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift */; };
 		C181945A2C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194582C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift */; };
+		C18194642C7DF7D600381092 /* FreemiumPIRPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194632C7DF7D600381092 /* FreemiumPIRPresenter.swift */; };
+		C18194652C7DF7D600381092 /* FreemiumPIRPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194632C7DF7D600381092 /* FreemiumPIRPresenter.swift */; };
+		C18194672C7F60E500381092 /* FreemiumPIRPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194662C7F60E500381092 /* FreemiumPIRPresenterTests.swift */; };
+		C18194682C7F60E500381092 /* FreemiumPIRPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194662C7F60E500381092 /* FreemiumPIRPresenterTests.swift */; };
 		C1858CD22C7C971D00C9BEAB /* FreemiumPIRFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1858CD12C7C971D00C9BEAB /* FreemiumPIRFeature.swift */; };
 		C1858CD32C7C971D00C9BEAB /* FreemiumPIRFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1858CD12C7C971D00C9BEAB /* FreemiumPIRFeature.swift */; };
 		C18BF9CC2C73678500ED6B8A /* Freemium in Frameworks */ = {isa = PBXBuildFile; productRef = C18BF9CB2C73678500ED6B8A /* Freemium */; };
@@ -4260,6 +4264,8 @@
 		C17CA7AC2B9B52E6008EC3C1 /* NavigationBarPopoversTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarPopoversTests.swift; sourceTree = "<group>"; };
 		C17CA7B12B9B5317008EC3C1 /* MockAutofillPopoverPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAutofillPopoverPresenter.swift; sourceTree = "<group>"; };
 		C18194582C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIRFeatureTests.swift; sourceTree = "<group>"; };
+		C18194632C7DF7D600381092 /* FreemiumPIRPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIRPresenter.swift; sourceTree = "<group>"; };
+		C18194662C7F60E500381092 /* FreemiumPIRPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIRPresenterTests.swift; sourceTree = "<group>"; };
 		C1858CD12C7C971D00C9BEAB /* FreemiumPIRFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIRFeature.swift; sourceTree = "<group>"; };
 		C1B1CBE02BE1915100B6049C /* DataImportShortcutsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportShortcutsViewModel.swift; sourceTree = "<group>"; };
 		C1D8BE442C1739E70057E426 /* DataBrokerProtectionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionMocks.swift; sourceTree = "<group>"; };
@@ -8507,6 +8513,7 @@
 			isa = PBXGroup;
 			children = (
 				C18194582C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift */,
+				C18194662C7F60E500381092 /* FreemiumPIRPresenterTests.swift */,
 			);
 			path = PIR;
 			sourceTree = "<group>";
@@ -8523,6 +8530,7 @@
 			isa = PBXGroup;
 			children = (
 				C1858CD12C7C971D00C9BEAB /* FreemiumPIRFeature.swift */,
+				C18194632C7DF7D600381092 /* FreemiumPIRPresenter.swift */,
 			);
 			path = PIR;
 			sourceTree = "<group>";
@@ -10144,6 +10152,7 @@
 				3706FB0B293F65D500E42796 /* DefaultBrowserPromptView.swift in Sources */,
 				3706FB0E293F65D500E42796 /* FaviconManager.swift in Sources */,
 				3706FB0F293F65D500E42796 /* ChromiumFaviconsReader.swift in Sources */,
+				C18194652C7DF7D600381092 /* FreemiumPIRPresenter.swift in Sources */,
 				4B0BD7B82A9FE6E600EF609D /* NetworkProtectionOnboardingMenu.swift in Sources */,
 				3706FB10293F65D500E42796 /* SuggestionTableRowView.swift in Sources */,
 				3706FB11293F65D500E42796 /* DownloadsPreferences.swift in Sources */,
@@ -11034,6 +11043,7 @@
 				3706FE73293F661700E42796 /* PermissionManagerMock.swift in Sources */,
 				3706FE74293F661700E42796 /* WebsiteDataStoreMock.swift in Sources */,
 				3706FE75293F661700E42796 /* WebsiteBreakageReportTests.swift in Sources */,
+				C18194682C7F60E500381092 /* FreemiumPIRPresenterTests.swift in Sources */,
 				56D145EF29E6DAD900E3488A /* DataImportProviderTests.swift in Sources */,
 				569277C529DEE09D00B633EF /* ContinueSetUpModelTests.swift in Sources */,
 				3706FE76293F661700E42796 /* MockSecureVault.swift in Sources */,
@@ -11745,6 +11755,7 @@
 				4B723E0D26B0006100E14D75 /* SecureVaultLoginImporter.swift in Sources */,
 				B645D8F629FA95440024461F /* WKProcessPoolExtension.swift in Sources */,
 				9D9AE86B2AA76CF90026E7DC /* LoginItemsManager.swift in Sources */,
+				C18194642C7DF7D600381092 /* FreemiumPIRPresenter.swift in Sources */,
 				857E5AF52A79045800FC0FB4 /* PixelExperiment.swift in Sources */,
 				B6C416A7294A4AE500C4F2E7 /* DuckPlayerTabExtension.swift in Sources */,
 				AA5C1DD5285C780C0089850C /* RecentlyClosedCoordinator.swift in Sources */,
@@ -12512,6 +12523,7 @@
 				EEF53E182950CED5002D78F4 /* JSAlertViewModelTests.swift in Sources */,
 				376C4DB928A1A48A00CC0F5B /* FirePopoverViewModelTests.swift in Sources */,
 				AAEC74B62642CC6A00C2EFBC /* HistoryStoringMock.swift in Sources */,
+				C18194672C7F60E500381092 /* FreemiumPIRPresenterTests.swift in Sources */,
 				AA652CB125DD825B009059CC /* LocalBookmarkStoreTests.swift in Sources */,
 				B630794226731F5400DCEE41 /* WKDownloadMock.swift in Sources */,
 				B6C0B24626E9CB190031CB7F /* RunLoopExtensionTests.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -2589,6 +2589,10 @@
 		C17CA7B32B9B5317008EC3C1 /* MockAutofillPopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17CA7B12B9B5317008EC3C1 /* MockAutofillPopoverPresenter.swift */; };
 		C18194592C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194582C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift */; };
 		C181945A2C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194582C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift */; };
+		C181945C2C7CDCC700381092 /* PromotionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C181945B2C7CDCC700381092 /* PromotionView.swift */; };
+		C181945D2C7CDCC700381092 /* PromotionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C181945B2C7CDCC700381092 /* PromotionView.swift */; };
+		C181945F2C7CDD0E00381092 /* PromotionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C181945E2C7CDD0E00381092 /* PromotionViewModel.swift */; };
+		C18194602C7CDD0E00381092 /* PromotionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C181945E2C7CDD0E00381092 /* PromotionViewModel.swift */; };
 		C18194642C7DF7D600381092 /* FreemiumPIRPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194632C7DF7D600381092 /* FreemiumPIRPresenter.swift */; };
 		C18194652C7DF7D600381092 /* FreemiumPIRPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194632C7DF7D600381092 /* FreemiumPIRPresenter.swift */; };
 		C18194672C7F60E500381092 /* FreemiumPIRPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18194662C7F60E500381092 /* FreemiumPIRPresenterTests.swift */; };
@@ -2601,6 +2605,8 @@
 		C18BF9D22C736C9700ED6B8A /* Freemium in Frameworks */ = {isa = PBXBuildFile; productRef = C18BF9D12C736C9700ED6B8A /* Freemium */; };
 		C1B1CBE12BE1915100B6049C /* DataImportShortcutsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B1CBE02BE1915100B6049C /* DataImportShortcutsViewModel.swift */; };
 		C1B1CBE22BE1915100B6049C /* DataImportShortcutsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B1CBE02BE1915100B6049C /* DataImportShortcutsViewModel.swift */; };
+		C1C405872C7F80E50089DE8A /* PromotionView+FreemiumPIR.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C405862C7F80E50089DE8A /* PromotionView+FreemiumPIR.swift */; };
+		C1C405882C7F80E50089DE8A /* PromotionView+FreemiumPIR.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C405862C7F80E50089DE8A /* PromotionView+FreemiumPIR.swift */; };
 		C1D8BE452C1739E70057E426 /* DataBrokerProtectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D8BE442C1739E70057E426 /* DataBrokerProtectionMocks.swift */; };
 		C1D8BE462C1739EC0057E426 /* DataBrokerProtectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D8BE442C1739E70057E426 /* DataBrokerProtectionMocks.swift */; };
 		C1DAF3B52B9A44860059244F /* AutofillPopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1DAF3B42B9A44860059244F /* AutofillPopoverPresenter.swift */; };
@@ -4264,10 +4270,13 @@
 		C17CA7AC2B9B52E6008EC3C1 /* NavigationBarPopoversTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarPopoversTests.swift; sourceTree = "<group>"; };
 		C17CA7B12B9B5317008EC3C1 /* MockAutofillPopoverPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAutofillPopoverPresenter.swift; sourceTree = "<group>"; };
 		C18194582C7CA9AB00381092 /* FreemiumPIRFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIRFeatureTests.swift; sourceTree = "<group>"; };
+		C181945B2C7CDCC700381092 /* PromotionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionView.swift; sourceTree = "<group>"; };
+		C181945E2C7CDD0E00381092 /* PromotionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionViewModel.swift; sourceTree = "<group>"; };
 		C18194632C7DF7D600381092 /* FreemiumPIRPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIRPresenter.swift; sourceTree = "<group>"; };
 		C18194662C7F60E500381092 /* FreemiumPIRPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIRPresenterTests.swift; sourceTree = "<group>"; };
 		C1858CD12C7C971D00C9BEAB /* FreemiumPIRFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumPIRFeature.swift; sourceTree = "<group>"; };
 		C1B1CBE02BE1915100B6049C /* DataImportShortcutsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportShortcutsViewModel.swift; sourceTree = "<group>"; };
+		C1C405862C7F80E50089DE8A /* PromotionView+FreemiumPIR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromotionView+FreemiumPIR.swift"; sourceTree = "<group>"; };
 		C1D8BE442C1739E70057E426 /* DataBrokerProtectionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionMocks.swift; sourceTree = "<group>"; };
 		C1DAF3B42B9A44860059244F /* AutofillPopoverPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillPopoverPresenter.swift; sourceTree = "<group>"; };
 		C1E961E72B879E4D001760E1 /* MockAutofillActionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAutofillActionPresenter.swift; sourceTree = "<group>"; };
@@ -6332,6 +6341,7 @@
 				56D145EA29E6C99B00E3488A /* DataImportStatusProviding.swift */,
 				560C3FFE2BCD5A1E00F589CE /* PermanentSurveyManager.swift */,
 				3768D83A2C24C0A8004120AE /* RemoteMessageViewModel.swift */,
+				C181945E2C7CDD0E00381092 /* PromotionViewModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -7879,6 +7889,7 @@
 				85F0FF1227CFAB04001C7C6E /* RecentlyVisitedView.swift */,
 				3768D8372C24BFF5004120AE /* RemoteMessageView.swift */,
 				3707EC492C47E36A00B67CBE /* CloseButton.swift */,
+				C181945B2C7CDCC700381092 /* PromotionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -8531,6 +8542,7 @@
 			children = (
 				C1858CD12C7C971D00C9BEAB /* FreemiumPIRFeature.swift */,
 				C18194632C7DF7D600381092 /* FreemiumPIRPresenter.swift */,
+				C1C405862C7F80E50089DE8A /* PromotionView+FreemiumPIR.swift */,
 			);
 			path = PIR;
 			sourceTree = "<group>";
@@ -10316,6 +10328,7 @@
 				B6BCC5502AFE4F7D002C5499 /* DataImportTypePicker.swift in Sources */,
 				7BAF9E4B2A8A3CC9002D3B6E /* UserDefaults+NetworkProtectionShared.swift in Sources */,
 				B6685E3D29A602D90043D2EE /* ExternalAppSchemeHandler.swift in Sources */,
+				C1C405882C7F80E50089DE8A /* PromotionView+FreemiumPIR.swift in Sources */,
 				B6E1491029A5C30500AAFBE8 /* ContentBlockingTabExtension.swift in Sources */,
 				3706FB82293F65D500E42796 /* PasswordManagementNoteItemView.swift in Sources */,
 				4BF97AD82B43C5B300EB4240 /* NetworkProtectionAppEvents.swift in Sources */,
@@ -10598,6 +10611,7 @@
 				B6F1B02F2BCE6B47005E863C /* TunnelControllerProvider.swift in Sources */,
 				31A83FB62BE28D7D00F74E67 /* UserText+DBP.swift in Sources */,
 				56BA1E832BAC506F001CF69F /* SSLErrorPageUserScript.swift in Sources */,
+				C18194602C7CDD0E00381092 /* PromotionViewModel.swift in Sources */,
 				3706FC31293F65D500E42796 /* PermissionButton.swift in Sources */,
 				9F6434622BEC82B700D2D8A0 /* AttributionPixelHandler.swift in Sources */,
 				3706FC32293F65D500E42796 /* MoreOptionsMenu.swift in Sources */,
@@ -10773,6 +10787,7 @@
 				3706FCA4293F65D500E42796 /* RecentlyClosedMenu.swift in Sources */,
 				4B9DB02D2A983B24000927DB /* WaitlistKeychainStorage.swift in Sources */,
 				EECE10E629DD77E60044D027 /* FeatureFlag.swift in Sources */,
+				C181945D2C7CDCC700381092 /* PromotionView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11652,6 +11667,7 @@
 				3701C9CE29BD040C00305B15 /* FirefoxBerkeleyDatabaseReader.swift in Sources */,
 				37054FCE2876472D00033B6F /* WebViewSnapshotView.swift in Sources */,
 				4BBC16A027C4859400E00A38 /* DeviceAuthenticationService.swift in Sources */,
+				C181945C2C7CDCC700381092 /* PromotionView.swift in Sources */,
 				CB24F70C29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift in Sources */,
 				1DEF3BAD2BD145A9004A2FBA /* AutoClearHandler.swift in Sources */,
 				37CBCA9A2A8966E60050218F /* SyncSettingsAdapter.swift in Sources */,
@@ -12052,6 +12068,7 @@
 				1DDC84FF2B835BC000670238 /* SearchPreferences.swift in Sources */,
 				B693955726F04BEC0015B914 /* MouseOverButton.swift in Sources */,
 				AA61C0D02722159B00E6B681 /* FireInfoViewController.swift in Sources */,
+				C1C405872C7F80E50089DE8A /* PromotionView+FreemiumPIR.swift in Sources */,
 				9D9AE8692AA76CDC0026E7DC /* LoginItem+NetworkProtection.swift in Sources */,
 				9F9C49F92BC7BC970099738D /* BookmarkAllTabsDialogView.swift in Sources */,
 				B64C85422694590B0048FEBE /* PermissionButton.swift in Sources */,
@@ -12114,6 +12131,7 @@
 				85B7184C27677C6500B4277F /* OnboardingViewController.swift in Sources */,
 				4B379C1E27BDB7FF008A968E /* DeviceAuthenticator.swift in Sources */,
 				1456D6E124EFCBC300775049 /* TabBarCollectionView.swift in Sources */,
+				C181945F2C7CDD0E00381092 /* PromotionViewModel.swift in Sources */,
 				4B4D60BF2A0C848A00BCD287 /* NetworkProtection+ConvenienceInitializers.swift in Sources */,
 				7B5A23682C468233007213AC /* ExcludedDomainsViewController.swift in Sources */,
 				BDA7647C2BC497BE00D0400C /* DefaultVPNLocationFormatter.swift in Sources */,

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -284,8 +284,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         networkProtectionSubscriptionEventHandler = NetworkProtectionSubscriptionEventHandler(subscriptionManager: subscriptionManager,
                                                                                               tunnelController: tunnelController,
                                                                                               vpnUninstaller: vpnUninstaller)
-        // Freemium PIR Setup Home View State
-        setupFreemiumPIRHomeViewState()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -721,14 +719,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                    queue: nil) { [weak self] _ in
             self?.autofillPixelReporter?.updateAutofillEnabledStatus(AutofillPreferences().askToSaveUsernamesAndPasswords)
         }
-    }
-
-    /// Decides if we should show the Freemium PIR home view promotion based on:
-    /// 1. It's current state (it's true by default, but set to false if dismissed)
-    /// 2. The Freemium PIR feature state (i.e enabled/disabled)
-    private func setupFreemiumPIRHomeViewState() {
-        let freemiumPIRFeature = DefaultFreemiumPIRFeature(subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager)
-        AppearancePreferences.shared.isHomePagePromotionVisible = (AppearancePreferences.shared.isHomePagePromotionVisible && freemiumPIRFeature.isAvailable)
     }
 }
 

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -284,6 +284,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         networkProtectionSubscriptionEventHandler = NetworkProtectionSubscriptionEventHandler(subscriptionManager: subscriptionManager,
                                                                                               tunnelController: tunnelController,
                                                                                               vpnUninstaller: vpnUninstaller)
+        // Freemium PIR Setup Home View State
+        setupFreemiumPIRHomeViewState()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -719,6 +721,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                    queue: nil) { [weak self] _ in
             self?.autofillPixelReporter?.updateAutofillEnabledStatus(AutofillPreferences().askToSaveUsernamesAndPasswords)
         }
+    }
+
+    /// Decides if we should show the Freemium PIR home view promotion based on:
+    /// 1. It's current state (it's true by default, but set to false if dismissed)
+    /// 2. The Freemium PIR feature state (i.e enabled/disabled)
+    private func setupFreemiumPIRHomeViewState() {
+        let freemiumPIRFeature = DefaultFreemiumPIRFeature(subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager)
+        AppearancePreferences.shared.isHomePagePromotionVisible = (AppearancePreferences.shared.isHomePagePromotionVisible && freemiumPIRFeature.isAvailable)
     }
 }
 

--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1272,4 +1272,7 @@ struct UserText {
     // Comment: "Progress view title when completing the purchase"
     static let completingPurchaseTitle = "Completing purchase..."
 
+    // Key: "freemium.pir.menu.item"
+    // Comment: "Title for Freemium Personal Information Removal (Scan-Only) item in the options menu"
+    static let freemiumPIROptionsMenuItem = "Personal Information Scan"
 }

--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1275,4 +1275,12 @@ struct UserText {
     // Key: "freemium.pir.menu.item"
     // Comment: "Title for Freemium Personal Information Removal (Scan-Only) item in the options menu"
     static let freemiumPIROptionsMenuItem = "Personal Information Scan"
+
+    // Key: "home.page.promotion.freemium.pir.description"
+    // Comment: "Description for the Freemium PIR Home Page Promotion"
+    static let homePagPromotionFreemiumPIRDescription = "Find your personal information from sites that store and sell it."
+
+    // Key: "home.page.promotion.freemium.pir.button.title"
+    // Comment: "Title for the Freemium PIR Home Page Promotion Button"
+    static let homePagPromotionFreemiumPIRButtonTitle = "Scan"
 }

--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1278,9 +1278,9 @@ struct UserText {
 
     // Key: "home.page.promotion.freemium.pir.description"
     // Comment: "Description for the Freemium PIR Home Page Promotion"
-    static let homePagPromotionFreemiumPIRDescription = "Find your personal information from sites that store and sell it."
+    static let homePagePromotionFreemiumPIRDescription = "Find your personal information from sites that store and sell it."
 
     // Key: "home.page.promotion.freemium.pir.button.title"
     // Comment: "Title for the Freemium PIR Home Page Promotion Button"
-    static let homePagPromotionFreemiumPIRButtonTitle = "Scan"
+    static let homePagePromotionFreemiumPIRButtonTitle = "Scan"
 }

--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -146,6 +146,7 @@ public struct UserDefaultsWrapper<T> {
         case homePageIsRecentActivityVisible = "home.page.is.recent.activity.visible"
         case homePageIsFirstSession = "home.page.is.first.session"
         case homePagePromotionVisible = "home.page.promotion.visible"
+        case homePagePromotionDidDismiss = "home.page.promotion.did.dismiss"
 
         case appIsRelaunchingAutomatically = "app-relaunching-automatically"
 

--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -145,6 +145,7 @@ public struct UserDefaultsWrapper<T> {
         case homePageIsContinueSetupVisible = "home.page.is.continue.setup.visible"
         case homePageIsRecentActivityVisible = "home.page.is.recent.activity.visible"
         case homePageIsFirstSession = "home.page.is.first.session"
+        case homePagePromotionVisible = "home.page.promotion.visible"
 
         case appIsRelaunchingAutomatically = "app-relaunching-automatically"
 

--- a/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -34,6 +34,7 @@ final class DBPHomeViewController: NSViewController {
     private let pixelHandler: EventMapping<DataBrokerProtectionPixels> = DataBrokerProtectionPixelsHandler()
     private var currentChildViewController: NSViewController?
     private var observer: NSObjectProtocol?
+    private var freemiumPIRFeature: FreemiumPIRFeature
 
     private let prerequisiteVerifier: DataBrokerPrerequisitesStatusVerifier
     private lazy var errorViewController: DataBrokerProtectionErrorViewController = {
@@ -69,9 +70,12 @@ final class DBPHomeViewController: NSViewController {
             })
     }()
 
-    init(dataBrokerProtectionManager: DataBrokerProtectionManager, prerequisiteVerifier: DataBrokerPrerequisitesStatusVerifier = DefaultDataBrokerPrerequisitesStatusVerifier()) {
+    init(dataBrokerProtectionManager: DataBrokerProtectionManager,
+         prerequisiteVerifier: DataBrokerPrerequisitesStatusVerifier = DefaultDataBrokerPrerequisitesStatusVerifier(),
+         freemiumPIRFeature: FreemiumPIRFeature) {
         self.dataBrokerProtectionManager = dataBrokerProtectionManager
         self.prerequisiteVerifier = prerequisiteVerifier
+        self.freemiumPIRFeature = freemiumPIRFeature
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -93,7 +97,7 @@ final class DBPHomeViewController: NSViewController {
     override func viewDidAppear() {
         super.viewDidAppear()
 
-        if !dataBrokerProtectionManager.isUserAuthenticated() {
+        if !dataBrokerProtectionManager.isUserAuthenticated() && !freemiumPIRFeature.isAvailable {
             assertionFailure("This UI should never be presented if the user is not authenticated")
             closeUI()
         }

--- a/DuckDuckGo/Freemium/PIR/FreemiumPIRPresenter.swift
+++ b/DuckDuckGo/Freemium/PIR/FreemiumPIRPresenter.swift
@@ -1,0 +1,53 @@
+//
+//  FreemiumPIRPresenter.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Conforming types provide functionality to show Freemium PIR
+protocol FreemiumPIRPresenter {
+    func showFreemiumPIR(didOnboard: Bool, windowControllerManager: WindowControllersManagerProtocol?)
+}
+
+/// Default implementation of `FreemiumPIRPresenter`
+struct DefaultFreemiumPIRPresenter: FreemiumPIRPresenter {
+
+    @MainActor
+    /// Displays Freemium PIR
+    /// If the `didOnboard` parameter is true, opens PIR directly
+    /// If the `didOnboard` parameter is false, opens Freemium PIR onboarding
+    /// - Parameter didOnboard: Bool indicating if the user has onboarded already
+    func showFreemiumPIR(didOnboard: Bool, windowControllerManager: WindowControllersManagerProtocol? = nil) {
+
+        let windowControllerManager = windowControllerManager ?? WindowControllersManager.shared
+
+        if didOnboard {
+            windowControllerManager.showTab(with: .dataBrokerProtection)
+        } else  {
+            // TODO: - Onboard (i.e Ts and Cs)
+            showFreemiumPIROnboarding()
+        }
+    }
+}
+
+private extension DefaultFreemiumPIRPresenter {
+
+    @MainActor
+    func showFreemiumPIROnboarding() {
+        // TODO: - Show onboarding if we decide to do this
+    }
+}

--- a/DuckDuckGo/Freemium/PIR/PromotionView+FreemiumPIR.swift
+++ b/DuckDuckGo/Freemium/PIR/PromotionView+FreemiumPIR.swift
@@ -21,8 +21,8 @@ import Foundation
 extension PromotionViewModel {
     static func freemiumPIRPromotion(proceedAction: @escaping () -> Void, closeAction: @escaping () -> Void) -> PromotionViewModel {
 
-        let description = UserText.homePagPromotionFreemiumPIRDescription
-        let actionButtonText = UserText.homePagPromotionFreemiumPIRButtonTitle
+        let description = UserText.homePagePromotionFreemiumPIRDescription
+        let actionButtonText = UserText.homePagePromotionFreemiumPIRButtonTitle
 
         return PromotionViewModel(image: .gift96,
                                   description: description,

--- a/DuckDuckGo/Freemium/PIR/PromotionView+FreemiumPIR.swift
+++ b/DuckDuckGo/Freemium/PIR/PromotionView+FreemiumPIR.swift
@@ -21,8 +21,8 @@ import Foundation
 extension PromotionViewModel {
     static func freemiumPIRPromotion(proceedAction: @escaping () -> Void, closeAction: @escaping () -> Void) -> PromotionViewModel {
 
-        let description = "Find your personal information from sites that store and sell it."
-        let actionButtonText = "Scan"
+        let description = UserText.homePagPromotionFreemiumPIRDescription
+        let actionButtonText = UserText.homePagPromotionFreemiumPIRButtonTitle
 
         return PromotionViewModel(image: .gift96,
                                   description: description,

--- a/DuckDuckGo/Freemium/PIR/PromotionView+FreemiumPIR.swift
+++ b/DuckDuckGo/Freemium/PIR/PromotionView+FreemiumPIR.swift
@@ -20,7 +20,7 @@ import Foundation
 
 extension PromotionViewModel {
     static func freemiumPIRPromotion(proceedAction: @escaping () -> Void, closeAction: @escaping () -> Void) -> PromotionViewModel {
-        
+
         let description = "Find your personal information from sites that store and sell it."
         let actionButtonText = "Scan"
 

--- a/DuckDuckGo/Freemium/PIR/PromotionView+FreemiumPIR.swift
+++ b/DuckDuckGo/Freemium/PIR/PromotionView+FreemiumPIR.swift
@@ -1,0 +1,33 @@
+//
+//  PromotionView+FreemiumPIR.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension PromotionViewModel {
+    static func freemiumPIRPromotion(proceedAction: @escaping () -> Void, closeAction: @escaping () -> Void) -> PromotionViewModel {
+        
+        let description = "Find your personal information from sites that store and sell it."
+        let actionButtonText = "Scan"
+
+        return PromotionViewModel(image: .gift96,
+                                  description: description,
+                                  proceedButtonText: actionButtonText,
+                                  proceedAction: proceedAction,
+                                  closeAction: closeAction)
+    }
+}

--- a/DuckDuckGo/HomePage/Model/PromotionViewModel.swift
+++ b/DuckDuckGo/HomePage/Model/PromotionViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  PromotionViewModel.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension HomePage.Models {
+
+    /// Model for a `PromotionView` type
+    final class PromotionViewModel: ObservableObject {
+
+        let image: ImageResource
+        let description: String
+        let proceedButtonText: String
+        let proceedAction: () -> Void
+        let closeAction: () -> Void
+
+        init(image: ImageResource, description: String, proceedButtonText: String, proceedAction: @escaping () -> Void, closeAction: @escaping () -> Void) {
+            self.image = image
+            self.description = description
+            self.proceedButtonText = proceedButtonText
+            self.proceedAction = proceedAction
+            self.closeAction = closeAction
+        }
+    }
+}

--- a/DuckDuckGo/HomePage/View/HomePageView.swift
+++ b/DuckDuckGo/HomePage/View/HomePageView.swift
@@ -65,6 +65,10 @@ extension HomePage.Views {
                         Group {
                             remoteMessage()
 
+                            PromotionView()
+                                .padding(.bottom, 16)
+                                .visibility(model.isHomePagePromotionVisible ? .visible : .gone)
+
                             if includingContinueSetUpCards {
                                 ContinueSetUpView()
                                     .visibility(model.isContinueSetUpVisible ? .visible : .gone)

--- a/DuckDuckGo/HomePage/View/HomePageViewController.swift
+++ b/DuckDuckGo/HomePage/View/HomePageViewController.swift
@@ -32,6 +32,7 @@ final class HomePageViewController: NSViewController {
     private let historyCoordinating: HistoryCoordinating
     private let fireViewModel: FireViewModel
     private let onboardingViewModel: OnboardingViewModel
+    private let freemiumPIRFeature: FreemiumPIRFeature
     private var freemiumPIRUserState: FreemiumPIRUserState
     private let freemiumPIRPresenter: FreemiumPIRPresenter
 
@@ -68,6 +69,7 @@ final class HomePageViewController: NSViewController {
          accessibilityPreferences: AccessibilityPreferences = AccessibilityPreferences.shared,
          appearancePreferences: AppearancePreferences = AppearancePreferences.shared,
          defaultBrowserPreferences: DefaultBrowserPreferences = DefaultBrowserPreferences.shared,
+         freemiumPIRFeature: FreemiumPIRFeature,
          freemiumPIRUserState: FreemiumPIRUserState,
          freemiumPIRPresenter: FreemiumPIRPresenter = DefaultFreemiumPIRPresenter()) {
 
@@ -79,6 +81,7 @@ final class HomePageViewController: NSViewController {
         self.accessibilityPreferences = accessibilityPreferences
         self.appearancePreferences = appearancePreferences
         self.defaultBrowserPreferences = defaultBrowserPreferences
+        self.freemiumPIRFeature = freemiumPIRFeature
         self.freemiumPIRUserState = freemiumPIRUserState
         self.freemiumPIRPresenter = freemiumPIRPresenter
 
@@ -123,6 +126,8 @@ final class HomePageViewController: NSViewController {
             PixelKit.fire(GeneralPixel.newTabInitial, frequency: .legacyInitial)
         }
         subscribeToHistory()
+
+        setPromotionViewVisibilityState()
     }
 
     override func viewDidAppear() {
@@ -206,16 +211,20 @@ final class HomePageViewController: NSViewController {
         })
     }
 
-    func createPromotionModel() -> PromotionViewModel {
+    private func setPromotionViewVisibilityState() {
+        appearancePreferences.isHomePagePromotionVisible = (!appearancePreferences.didDismissHomePagePromotion && freemiumPIRFeature.isAvailable)
+    }
+
+    private func createPromotionModel() -> PromotionViewModel {
         return PromotionViewModel.freemiumPIRPromotion { [weak self] in
             // TODO: Remove this
             self?.freemiumPIRUserState.didOnboard = true
             // ------
             self?.freemiumPIRPresenter.showFreemiumPIR(didOnboard: self?.freemiumPIRUserState.didOnboard ?? false,
                                                        windowControllerManager: WindowControllersManager.shared)
-            self?.appearancePreferences.isHomePagePromotionVisible = false
+            self?.appearancePreferences.didDismissHomePagePromotion = true
         } closeAction: { [weak self] in
-            self?.appearancePreferences.isHomePagePromotionVisible = false
+            self?.appearancePreferences.didDismissHomePagePromotion = true
         }
     }
 

--- a/DuckDuckGo/HomePage/View/PromotionView.swift
+++ b/DuckDuckGo/HomePage/View/PromotionView.swift
@@ -17,6 +17,7 @@
 //
 
 import SwiftUI
+import SwiftUIExtensions
 
 typealias PromotionViewModel = HomePage.Models.PromotionViewModel
 
@@ -34,21 +35,15 @@ extension HomePage.Views {
 
                 imageView
 
-                Spacer(minLength: 4)
-
                 descriptionView
 
-                Spacer(minLength: 4)
-
                 proceedButtonView
-
-                Spacer(minLength: 4)
 
                 closeButton
 
             }
-            .padding([.horizontal], 16)
-            .padding([.vertical], 16)
+            .padding([.horizontal], 24)
+            .padding([.vertical], 14)
             .background(Color.blackWhite3)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .onHover { isHovering in
@@ -72,8 +67,12 @@ extension HomePage.Views {
                 Text(viewModel.proceedButtonText)
                     .padding([.horizontal], 16)
                     .padding([.vertical], 5)
+                    .font(.system(size: 13).bold())
+
             }
-                .controlSize(.large)
+                .buttonStyle(DefaultActionButtonStyle(enabled: true))
+                .cornerRadius(8)
+                .padding(.horizontal, 8)
         }
 
         private var closeButton: some View {
@@ -81,7 +80,7 @@ extension HomePage.Views {
                 viewModel.closeAction()
             }
             .visibility(isHovering ? .visible : .invisible)
-            .padding(6)
+            .padding(.trailing, 8)
         }
     }
 }

--- a/DuckDuckGo/HomePage/View/PromotionView.swift
+++ b/DuckDuckGo/HomePage/View/PromotionView.swift
@@ -1,0 +1,92 @@
+//
+//  PromotionView.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+typealias PromotionViewModel = HomePage.Models.PromotionViewModel
+
+extension HomePage.Views {
+
+    /// A `PromotionView` is intended to be displayed on the new tab home page, and used to promote a feature, product etc
+    struct PromotionView: View {
+
+        @EnvironmentObject var viewModel: PromotionViewModel
+
+        @State var isHovering = false
+
+        var body: some View {
+            HStack(spacing: 8) {
+
+                imageView
+
+                Spacer(minLength: 4)
+
+                descriptionView
+
+                Spacer(minLength: 4)
+
+                proceedButtonView
+
+                Spacer(minLength: 4)
+
+                closeButton
+
+            }
+            .padding([.horizontal], 16)
+            .padding([.vertical], 16)
+            .background(Color.blackWhite3)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .onHover { isHovering in
+                self.isHovering = isHovering
+            }
+        }
+
+        private var imageView: some View {
+            Image(viewModel.image)
+                .resizable()
+                .frame(width: 48, height: 48)
+        }
+
+        private var descriptionView: some View {
+            Text(viewModel.description)
+                .font(.system(size: 13))
+        }
+
+        private var proceedButtonView: some View {
+            Button(action: viewModel.proceedAction) {
+                Text(viewModel.proceedButtonText)
+                    .padding([.horizontal], 16)
+                    .padding([.vertical], 5)
+            }
+                .controlSize(.large)
+        }
+
+        private var closeButton: some View {
+            CloseButton(icon: .close) {
+                viewModel.closeAction()
+            }
+            .visibility(isHovering ? .visible : .invisible)
+            .padding(6)
+        }
+    }
+}
+
+#Preview {
+    return HomePage.Views.PromotionView()
+        .environmentObject(PromotionViewModel.freemiumPIRPromotion(proceedAction: {}, closeAction: {}))
+}

--- a/DuckDuckGo/Menus/MainMenu.swift
+++ b/DuckDuckGo/Menus/MainMenu.swift
@@ -601,6 +601,7 @@ final class MainMenu: NSMenu {
                 NSMenuItem(title: "Show Save Credentials Popover", action: #selector(MainViewController.showSaveCredentialsPopover))
                 NSMenuItem(title: "Show Credentials Saved Popover", action: #selector(MainViewController.showCredentialsSavedPopover))
                 NSMenuItem(title: "Show Pop Up Window", action: #selector(MainViewController.showPopUpWindow))
+                NSMenuItem(title: "Reset Home View Promotion State", action: #selector(MainViewController.showHomePromotionView))
             }
             NSMenuItem(title: "Remote Configuration") {
                 customConfigurationUrlMenuItem

--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -973,6 +973,11 @@ extension MainViewController {
     @objc func showPageResources(_ sender: Any?) {
         getActiveTabAndIndex()?.tab.webView.showPageSource()
     }
+
+    // MARK: - Debug Menu
+    @objc func showHomePromotionView(_ sender: Any?) {
+        AppearancePreferences.shared.isHomePagePromotionVisible = true
+    }
 }
 
 extension MainViewController: NSMenuItemValidation {

--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -23,6 +23,7 @@ import BrowserServicesKit
 import PixelKit
 import NetworkProtection
 import Subscription
+import Freemium
 
 protocol OptionsButtonMenuDelegate: AnyObject {
 
@@ -58,6 +59,9 @@ final class MoreOptionsMenu: NSMenu {
     private lazy var sharingMenu: NSMenu = SharingMenu(title: UserText.shareMenuItem)
     private var accountManager: AccountManager { subscriptionManager.accountManager }
     private let subscriptionManager: SubscriptionManager
+    private let freemiumPIRUserState: FreemiumPIRUserState
+    private let freemiumPIRFeature: FreemiumPIRFeature
+    private let freemiumPIRPresenter: FreemiumPIRPresenter
 
     private let vpnFeatureGatekeeper: VPNFeatureGatekeeper
     private let subscriptionFeatureAvailability: SubscriptionFeatureAvailability
@@ -73,7 +77,10 @@ final class MoreOptionsMenu: NSMenu {
          subscriptionFeatureAvailability: SubscriptionFeatureAvailability = DefaultSubscriptionFeatureAvailability(),
          sharingMenu: NSMenu? = nil,
          internalUserDecider: InternalUserDecider,
-         subscriptionManager: SubscriptionManager) {
+         subscriptionManager: SubscriptionManager,
+         freemiumPIRUserState: FreemiumPIRUserState,
+         freemiumPIRFeature: FreemiumPIRFeature,
+         freemiumPIRPresenter: FreemiumPIRPresenter = DefaultFreemiumPIRPresenter()) {
 
         self.tabCollectionViewModel = tabCollectionViewModel
         self.emailManager = emailManager
@@ -82,6 +89,9 @@ final class MoreOptionsMenu: NSMenu {
         self.subscriptionFeatureAvailability = subscriptionFeatureAvailability
         self.internalUserDecider = internalUserDecider
         self.subscriptionManager = subscriptionManager
+        self.freemiumPIRUserState = freemiumPIRUserState
+        self.freemiumPIRFeature = freemiumPIRFeature
+        self.freemiumPIRPresenter = freemiumPIRPresenter
 
         super.init(title: "")
 
@@ -130,7 +140,7 @@ final class MoreOptionsMenu: NSMenu {
 
         addItem(NSMenuItem.separator())
 
-        addSubscriptionItems()
+        addSubscriptionAndFreemiumPIRItems()
 
         addPageItems()
 
@@ -245,6 +255,10 @@ final class MoreOptionsMenu: NSMenu {
         actionDelegate?.optionsButtonMenuRequestedIdentityTheftRestoration(self)
     }
 
+    @objc func openFreemiumPIR(_ sender: NSMenuItem) {
+        freemiumPIRPresenter.showFreemiumPIR(didOnboard: freemiumPIRUserState.didOnboard, windowControllerManager: WindowControllersManager.shared)
+    }
+
     @objc func findInPage(_ sender: NSMenuItem) {
         tabCollectionViewModel.selectedTabViewModel?.showFindInPage()
     }
@@ -313,6 +327,13 @@ final class MoreOptionsMenu: NSMenu {
         addItem(NSMenuItem.separator())
     }
 
+    private func addSubscriptionAndFreemiumPIRItems() {
+        addSubscriptionItems()
+        addFreemiumPIRItem()
+
+        addItem(NSMenuItem.separator())
+    }
+
     private func addSubscriptionItems() {
         guard subscriptionFeatureAvailability.isFeatureAvailable else { return }
 
@@ -330,15 +351,24 @@ final class MoreOptionsMenu: NSMenu {
             // Do not add for App Store when purchase not available in the region
             if !shouldHideDueToNoProduct() {
                 addItem(privacyProItem)
-                addItem(NSMenuItem.separator())
             }
         } else {
             privacyProItem.submenu = SubscriptionSubMenu(targeting: self,
                                                          subscriptionFeatureAvailability: DefaultSubscriptionFeatureAvailability(),
                                                          accountManager: accountManager)
             addItem(privacyProItem)
-            addItem(NSMenuItem.separator())
         }
+    }
+
+    private func addFreemiumPIRItem() {
+        guard freemiumPIRFeature.isAvailable else { return }
+
+        let freemiumPIRItem = NSMenuItem(title: UserText.freemiumPIROptionsMenuItem).withImage(.dbpIcon)
+
+        freemiumPIRItem.target = self
+        freemiumPIRItem.action = #selector(openFreemiumPIR(_:))
+
+        addItem(freemiumPIRItem)
     }
 
     private func addPageItems() {

--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -59,9 +59,10 @@ final class MoreOptionsMenu: NSMenu {
     private lazy var sharingMenu: NSMenu = SharingMenu(title: UserText.shareMenuItem)
     private var accountManager: AccountManager { subscriptionManager.accountManager }
     private let subscriptionManager: SubscriptionManager
-    private let freemiumPIRUserState: FreemiumPIRUserState
+    private var freemiumPIRUserState: FreemiumPIRUserState
     private let freemiumPIRFeature: FreemiumPIRFeature
     private let freemiumPIRPresenter: FreemiumPIRPresenter
+    private let appearancePreferences: AppearancePreferences
 
     private let vpnFeatureGatekeeper: VPNFeatureGatekeeper
     private let subscriptionFeatureAvailability: SubscriptionFeatureAvailability
@@ -80,7 +81,8 @@ final class MoreOptionsMenu: NSMenu {
          subscriptionManager: SubscriptionManager,
          freemiumPIRUserState: FreemiumPIRUserState,
          freemiumPIRFeature: FreemiumPIRFeature,
-         freemiumPIRPresenter: FreemiumPIRPresenter = DefaultFreemiumPIRPresenter()) {
+         freemiumPIRPresenter: FreemiumPIRPresenter = DefaultFreemiumPIRPresenter(),
+         appearancePreferences: AppearancePreferences = .shared) {
 
         self.tabCollectionViewModel = tabCollectionViewModel
         self.emailManager = emailManager
@@ -92,6 +94,7 @@ final class MoreOptionsMenu: NSMenu {
         self.freemiumPIRUserState = freemiumPIRUserState
         self.freemiumPIRFeature = freemiumPIRFeature
         self.freemiumPIRPresenter = freemiumPIRPresenter
+        self.appearancePreferences = appearancePreferences
 
         super.init(title: "")
 
@@ -256,7 +259,12 @@ final class MoreOptionsMenu: NSMenu {
     }
 
     @objc func openFreemiumPIR(_ sender: NSMenuItem) {
+
+        // TODO: Remove this
+        freemiumPIRUserState.didOnboard = true
+        // ------
         freemiumPIRPresenter.showFreemiumPIR(didOnboard: freemiumPIRUserState.didOnboard, windowControllerManager: WindowControllersManager.shared)
+        appearancePreferences.isHomePagePromotionVisible = false
     }
 
     @objc func findInPage(_ sender: NSMenuItem) {

--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -27,6 +27,7 @@ import NetworkProtectionIPC
 import NetworkProtectionUI
 import Subscription
 import SubscriptionUI
+import Freemium
 
 final class NavigationBarViewController: NSViewController {
 
@@ -271,11 +272,16 @@ final class NavigationBarViewController: NSViewController {
 
     @IBAction func optionsButtonAction(_ sender: NSButton) {
         let internalUserDecider = NSApp.delegateTyped.internalUserDecider
+        let freemiumPIRUserState = DefaultFreemiumPIRUserState(userDefaults: .dbp, accountManager: subscriptionManager.accountManager)
+        let freemiumPIRFeature = DefaultFreemiumPIRFeature(subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager)
         let menu = MoreOptionsMenu(tabCollectionViewModel: tabCollectionViewModel,
                                    passwordManagerCoordinator: PasswordManagerCoordinator.shared,
                                    vpnFeatureGatekeeper: DefaultVPNFeatureGatekeeper(subscriptionManager: subscriptionManager),
                                    internalUserDecider: internalUserDecider,
-                                   subscriptionManager: subscriptionManager)
+                                   subscriptionManager: subscriptionManager,
+                                   freemiumPIRUserState: freemiumPIRUserState,
+                                   freemiumPIRFeature: freemiumPIRFeature)
+
         menu.actionDelegate = self
         let location = NSPoint(x: -menu.size.width + sender.bounds.width, y: sender.bounds.height + 4)
         menu.popUp(positioning: nil, at: location, in: sender)

--- a/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
+++ b/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
@@ -29,7 +29,7 @@ protocol AppearancePreferencesPersistor {
     var isFavoriteVisible: Bool { get set }
     var isContinueSetUpVisible: Bool { get set }
     var isRecentActivityVisible: Bool { get set }
-    var isHomePagePromotionVisible: Bool { get set }
+    var didDismissHomePagePromotion: Bool { get set }
     var showBookmarksBar: Bool { get set }
     var bookmarksBarAppearance: BookmarksBarAppearance { get set }
     var homeButtonPosition: HomeButtonPosition { get set }
@@ -54,8 +54,8 @@ struct AppearancePreferencesUserDefaultsPersistor: AppearancePreferencesPersisto
     @UserDefaultsWrapper(key: .homePageIsRecentActivityVisible, defaultValue: true)
     var isRecentActivityVisible: Bool
 
-    @UserDefaultsWrapper(key: .homePagePromotionVisible, defaultValue: true)
-    var isHomePagePromotionVisible: Bool
+    @UserDefaultsWrapper(key: .homePagePromotionDidDismiss, defaultValue: false)
+    var didDismissHomePagePromotion: Bool
 
     @UserDefaultsWrapper(key: .showBookmarksBar, defaultValue: false)
     var showBookmarksBar: Bool
@@ -229,9 +229,12 @@ final class AppearancePreferences: ObservableObject {
         return privacyConfig.isEnabled(featureKey: .newTabContinueSetUp) && osVersion.majorVersion >= 12
     }
 
-    @Published var isHomePagePromotionVisible: Bool {
+    @Published var isHomePagePromotionVisible: Bool = false
+
+    @Published var didDismissHomePagePromotion: Bool {
         didSet {
-            persistor.isHomePagePromotionVisible = isHomePagePromotionVisible
+            isHomePagePromotionVisible = !didDismissHomePagePromotion
+            persistor.didDismissHomePagePromotion = didDismissHomePagePromotion
         }
     }
 
@@ -250,7 +253,7 @@ final class AppearancePreferences: ObservableObject {
         showBookmarksBar = persistor.showBookmarksBar
         bookmarksBarAppearance = persistor.bookmarksBarAppearance
         homeButtonPosition = persistor.homeButtonPosition
-        isHomePagePromotionVisible = persistor.isHomePagePromotionVisible
+        didDismissHomePagePromotion = persistor.didDismissHomePagePromotion
     }
 
     private var persistor: AppearancePreferencesPersistor

--- a/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
+++ b/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
@@ -29,6 +29,7 @@ protocol AppearancePreferencesPersistor {
     var isFavoriteVisible: Bool { get set }
     var isContinueSetUpVisible: Bool { get set }
     var isRecentActivityVisible: Bool { get set }
+    var isHomePagePromotionVisible: Bool { get set }
     var showBookmarksBar: Bool { get set }
     var bookmarksBarAppearance: BookmarksBarAppearance { get set }
     var homeButtonPosition: HomeButtonPosition { get set }
@@ -52,6 +53,9 @@ struct AppearancePreferencesUserDefaultsPersistor: AppearancePreferencesPersisto
 
     @UserDefaultsWrapper(key: .homePageIsRecentActivityVisible, defaultValue: true)
     var isRecentActivityVisible: Bool
+
+    @UserDefaultsWrapper(key: .homePagePromotionVisible, defaultValue: true)
+    var isHomePagePromotionVisible: Bool
 
     @UserDefaultsWrapper(key: .showBookmarksBar, defaultValue: false)
     var showBookmarksBar: Bool
@@ -225,6 +229,12 @@ final class AppearancePreferences: ObservableObject {
         return privacyConfig.isEnabled(featureKey: .newTabContinueSetUp) && osVersion.majorVersion >= 12
     }
 
+    @Published var isHomePagePromotionVisible: Bool {
+        didSet {
+            persistor.isHomePagePromotionVisible = isHomePagePromotionVisible
+        }
+    }
+
     func updateUserInterfaceStyle() {
         NSApp.appearance = currentThemeName.appearance
     }
@@ -240,6 +250,7 @@ final class AppearancePreferences: ObservableObject {
         showBookmarksBar = persistor.showBookmarksBar
         bookmarksBarAppearance = persistor.bookmarksBarAppearance
         homeButtonPosition = persistor.homeButtonPosition
+        isHomePagePromotionVisible = persistor.isHomePagePromotionVisible
     }
 
     private var persistor: AppearancePreferencesPersistor

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -675,8 +675,11 @@ final class BrowserTabViewController: NSViewController {
     private func homePageViewControllerCreatingIfNeeded() -> HomePageViewController {
         return homePageViewController ?? {
             let subscriptionManager = Application.appDelegate.subscriptionManager
+            let freemiumPIRFeature = DefaultFreemiumPIRFeature(subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager)
             let freemiumPIRUserState = DefaultFreemiumPIRUserState(userDefaults: .dbp, accountManager: subscriptionManager.accountManager)
-            let homePageViewController = HomePageViewController(tabCollectionViewModel: tabCollectionViewModel, bookmarkManager: bookmarkManager, freemiumPIRUserState: freemiumPIRUserState)
+            let homePageViewController = HomePageViewController(tabCollectionViewModel: tabCollectionViewModel, bookmarkManager: bookmarkManager,
+                                                                freemiumPIRFeature: freemiumPIRFeature,
+                                                                freemiumPIRUserState: freemiumPIRUserState)
             self.homePageViewController = homePageViewController
             return homePageViewController
         }()

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -687,7 +687,9 @@ final class BrowserTabViewController: NSViewController {
     var dataBrokerProtectionHomeViewController: DBPHomeViewController?
     private func dataBrokerProtectionHomeViewControllerCreatingIfNeeded() -> DBPHomeViewController {
         return dataBrokerProtectionHomeViewController ?? {
-            let dataBrokerProtectionHomeViewController = DBPHomeViewController(dataBrokerProtectionManager: DataBrokerProtectionManager.shared)
+            let subscriptionManager = Application.appDelegate.subscriptionManager
+            let freemiumPIRFeature = DefaultFreemiumPIRFeature(subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager)
+            let dataBrokerProtectionHomeViewController = DBPHomeViewController(dataBrokerProtectionManager: DataBrokerProtectionManager.shared, freemiumPIRFeature: freemiumPIRFeature)
             self.dataBrokerProtectionHomeViewController = dataBrokerProtectionHomeViewController
             return dataBrokerProtectionHomeViewController
         }()

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -24,6 +24,7 @@ import SwiftUI
 import WebKit
 import Subscription
 import PixelKit
+import Freemium
 
 final class BrowserTabViewController: NSViewController {
 
@@ -673,7 +674,9 @@ final class BrowserTabViewController: NSViewController {
     var homePageViewController: HomePageViewController?
     private func homePageViewControllerCreatingIfNeeded() -> HomePageViewController {
         return homePageViewController ?? {
-            let homePageViewController = HomePageViewController(tabCollectionViewModel: tabCollectionViewModel, bookmarkManager: bookmarkManager)
+            let subscriptionManager = Application.appDelegate.subscriptionManager
+            let freemiumPIRUserState = DefaultFreemiumPIRUserState(userDefaults: .dbp, accountManager: subscriptionManager.accountManager)
+            let homePageViewController = HomePageViewController(tabCollectionViewModel: tabCollectionViewModel, bookmarkManager: bookmarkManager, freemiumPIRUserState: freemiumPIRUserState)
             self.homePageViewController = homePageViewController
             return homePageViewController
         }()

--- a/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -31,6 +31,7 @@ protocol WindowControllersManagerProtocol {
     func register(_ windowController: MainWindowController)
     func unregister(_ windowController: MainWindowController)
 
+    func showTab(with content: Tab.TabContent)
 }
 
 @MainActor

--- a/LocalPackages/Freemium/Sources/Freemium/FreemiumPIRUserState.swift
+++ b/LocalPackages/Freemium/Sources/Freemium/FreemiumPIRUserState.swift
@@ -28,15 +28,19 @@ public protocol FreemiumPIRUserState {
 /// Default implementation of `FreemiumPIRUserState`. `UserDefaults` is used as underlying storage.
 public final class DefaultFreemiumPIRUserState: FreemiumPIRUserState {
 
+    private enum Keys {
+        static let didOnboard = "macos.browser.freemium.pir.did.onboard"
+    }
+
     private let userDefaults: UserDefaults
     private let accountManager: AccountManager
     private let key = "macos.browser.freemium.pir.did.onboard"
 
     public var didOnboard: Bool {
         get {
-            userDefaults.bool(forKey: key)
+            userDefaults.bool(forKey: Keys.didOnboard)
         } set {
-            userDefaults.set(newValue, forKey: key)
+            userDefaults.set(newValue, forKey: Keys.didOnboard)
         }
     }
 

--- a/UnitTests/Freemium/PIR/FreemiumPIRPresenterTests.swift
+++ b/UnitTests/Freemium/PIR/FreemiumPIRPresenterTests.swift
@@ -42,7 +42,7 @@ final class FreemiumPIRPresenterTests: XCTestCase {
         // When
         sut.showFreemiumPIR(didOnboard: false, windowControllerManager: mockWindowControllerManager)
         // Then
-        XCTAssertEqual(mockWindowControllerManager.showTabContent, Tab.Content.dataBrokerProtection)
+        XCTAssertEqual(mockWindowControllerManager.showTabContent, Tab.Content.none)
     }
 }
 

--- a/UnitTests/Freemium/PIR/FreemiumPIRPresenterTests.swift
+++ b/UnitTests/Freemium/PIR/FreemiumPIRPresenterTests.swift
@@ -1,0 +1,66 @@
+//
+//  FreemiumPIRPresenterTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+import Combine
+
+final class FreemiumPIRPresenterTests: XCTestCase {
+
+    private var mockWindowControllerManager: MockWindowControllerManager!
+    private var sut = DefaultFreemiumPIRPresenter()
+
+    @MainActor
+    func testWhenCallShowFreemiumPIRAndDidOnboardThenShowPIRTabIsCalled() async throws {
+        // Given
+        mockWindowControllerManager = MockWindowControllerManager()
+        // When
+        sut.showFreemiumPIR(didOnboard: true, windowControllerManager: mockWindowControllerManager)
+        // Then
+        XCTAssertEqual(mockWindowControllerManager.showTabContent, Tab.Content.dataBrokerProtection)
+    }
+
+    @MainActor
+    func testWhenCallShowFreemiumPIRAndDidNotOnboardThenShowPIRTabIsNotCalled() async throws {
+        // Given
+        mockWindowControllerManager = MockWindowControllerManager()
+        // When
+        sut.showFreemiumPIR(didOnboard: false, windowControllerManager: mockWindowControllerManager)
+        // Then
+        XCTAssertEqual(mockWindowControllerManager.showTabContent, Tab.Content.dataBrokerProtection)
+    }
+}
+
+private final class MockWindowControllerManager: WindowControllersManagerProtocol {
+
+    var showTabContent: Tab.Content = .none
+
+    var pinnedTabsManager: PinnedTabsManager = PinnedTabsManager()
+
+    var didRegisterWindowController: PassthroughSubject<(MainWindowController), Never> = PassthroughSubject<(MainWindowController), Never>()
+
+    var didUnregisterWindowController: PassthroughSubject<(MainWindowController), Never> = PassthroughSubject<(MainWindowController), Never>()
+
+    func register(_ windowController: MainWindowController) {}
+
+    func unregister(_ windowController: MainWindowController) {}
+
+    func showTab(with content: Tab.TabContent) {
+        showTabContent = content
+    }
+}

--- a/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -38,6 +38,11 @@ final class MoreOptionsMenuTests: XCTestCase {
 
     var subscriptionManager: SubscriptionManagerMock!
 
+    private var mockFreemiumPIRFeatureFlagger = MockFreemiumPIRFeatureFlagger()
+    private var mockFreemiumPIRPresenter = MockFreemiumPIRPresenter()
+    private var freemiumPIRFeature: DefaultFreemiumPIRFeature!
+    private var mockFreemiumPIRUserState = MockFreemiumPIRUserState()
+
     var moreOptionsMenu: MoreOptionsMenu!
 
     @MainActor
@@ -63,6 +68,8 @@ final class MoreOptionsMenuTests: XCTestCase {
                                                                                                   purchasePlatform: .appStore),
                                                       canPurchase: false)
 
+        freemiumPIRFeature = DefaultFreemiumPIRFeature(featureFlagger: mockFreemiumPIRFeatureFlagger, subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager)
+
     }
 
     @MainActor
@@ -84,10 +91,15 @@ final class MoreOptionsMenuTests: XCTestCase {
                                                                                                                isSubscriptionPurchaseAllowed: true),
                                           sharingMenu: NSMenu(),
                                           internalUserDecider: internalUserDecider,
-                                          subscriptionManager: subscriptionManager)
+                                          subscriptionManager: subscriptionManager,
+                                          freemiumPIRUserState: mockFreemiumPIRUserState,
+                                          freemiumPIRFeature: freemiumPIRFeature,
+                                          freemiumPIRPresenter: mockFreemiumPIRPresenter)
 
         moreOptionsMenu.actionDelegate = capturingActionDelegate
     }
+
+    // MARK: - Subscription & Freemium
 
     private func mockAuthentication() {
         subscriptionManager.accountManager.storeAuthToken(token: "")
@@ -128,9 +140,10 @@ final class MoreOptionsMenuTests: XCTestCase {
     }
 
     @MainActor
-    func testThatMoreOptionMenuHasTheExpectedItemsWhenUnauthenticatedAndCanPurchaseSubscription() {
+    func testThatMoreOptionMenuHasTheExpectedItemsWhenUnauthenticatedAndCanPurchaseSubscriptionAndFreemiumPIRFeatureFlagDisabled() {
         subscriptionManager.canPurchase = true
         subscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
+        mockFreemiumPIRFeatureFlagger.isEnabled = false
 
         setupMoreOptionsMenu()
 
@@ -159,8 +172,42 @@ final class MoreOptionsMenuTests: XCTestCase {
     }
 
     @MainActor
-    func testThatMoreOptionMenuHasTheExpectedItemsWhenSubscriptionIsActive() {
+    func testThatMoreOptionMenuHasTheExpectedItemsWhenUnauthenticatedAndFreemiumPIRFeatureFlagEnabled() {
+        subscriptionManager.canPurchase = true
+        subscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
+        mockFreemiumPIRFeatureFlagger.isEnabled = true
+
+        setupMoreOptionsMenu()
+
+        XCTAssertFalse(subscriptionManager.accountManager.isUserAuthenticated)
+        XCTAssertTrue(subscriptionManager.canPurchase)
+
+        XCTAssertEqual(moreOptionsMenu.items[0].title, UserText.sendFeedback)
+        XCTAssertTrue(moreOptionsMenu.items[1].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[2].title, UserText.plusButtonNewTabMenuItem)
+        XCTAssertEqual(moreOptionsMenu.items[3].title, UserText.newWindowMenuItem)
+        XCTAssertEqual(moreOptionsMenu.items[4].title, UserText.newBurnerWindowMenuItem)
+        XCTAssertTrue(moreOptionsMenu.items[5].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[6].title, UserText.zoom)
+        XCTAssertTrue(moreOptionsMenu.items[7].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[8].title, UserText.bookmarks)
+        XCTAssertEqual(moreOptionsMenu.items[9].title, UserText.downloads)
+        XCTAssertEqual(moreOptionsMenu.items[10].title, UserText.passwordManagementTitle)
+        XCTAssertTrue(moreOptionsMenu.items[11].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[12].title, UserText.emailOptionsMenuItem)
+        XCTAssertTrue(moreOptionsMenu.items[13].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[14].title, UserText.subscriptionOptionsMenuItem)
+        XCTAssertFalse(moreOptionsMenu.items[14].hasSubmenu)
+        XCTAssertEqual(moreOptionsMenu.items[15].title, UserText.freemiumPIROptionsMenuItem)
+        XCTAssertTrue(moreOptionsMenu.items[16].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[17].title, UserText.mainMenuHelp)
+        XCTAssertEqual(moreOptionsMenu.items[18].title, UserText.settings)
+    }
+
+    @MainActor
+    func testThatMoreOptionMenuHasTheExpectedItemsWhenSubscriptionIsActiveAndFreemiumPIRFeatureFlagDisabled() {
         mockAuthentication()
+        mockFreemiumPIRFeatureFlagger.isEnabled = false
 
         setupMoreOptionsMenu()
 
@@ -192,6 +239,81 @@ final class MoreOptionsMenuTests: XCTestCase {
         XCTAssertTrue(moreOptionsMenu.items[15].isSeparatorItem)
         XCTAssertEqual(moreOptionsMenu.items[16].title, UserText.mainMenuHelp)
         XCTAssertEqual(moreOptionsMenu.items[17].title, UserText.settings)
+    }
+
+    @MainActor
+    func testThatMoreOptionMenuHasTheExpectedItemsWhenSubscriptionIsActiveAndFreemiumPIRFeatureFlagEnabled() {
+        mockAuthentication()
+        mockFreemiumPIRFeatureFlagger.isEnabled = true
+
+        setupMoreOptionsMenu()
+
+        XCTAssertTrue(subscriptionManager.accountManager.isUserAuthenticated)
+
+        XCTAssertEqual(moreOptionsMenu.items[0].title, UserText.sendFeedback)
+        XCTAssertTrue(moreOptionsMenu.items[1].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[2].title, UserText.plusButtonNewTabMenuItem)
+        XCTAssertEqual(moreOptionsMenu.items[3].title, UserText.newWindowMenuItem)
+        XCTAssertEqual(moreOptionsMenu.items[4].title, UserText.newBurnerWindowMenuItem)
+        XCTAssertTrue(moreOptionsMenu.items[5].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[6].title, UserText.zoom)
+        XCTAssertTrue(moreOptionsMenu.items[7].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[8].title, UserText.bookmarks)
+        XCTAssertEqual(moreOptionsMenu.items[9].title, UserText.downloads)
+        XCTAssertEqual(moreOptionsMenu.items[10].title, UserText.passwordManagementTitle)
+        XCTAssertTrue(moreOptionsMenu.items[11].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[12].title, UserText.emailOptionsMenuItem)
+        XCTAssertTrue(moreOptionsMenu.items[13].isSeparatorItem)
+
+        XCTAssertEqual(moreOptionsMenu.items[14].title, UserText.subscriptionOptionsMenuItem)
+        XCTAssertTrue(moreOptionsMenu.items[14].hasSubmenu)
+        XCTAssertEqual(moreOptionsMenu.items[14].submenu?.items[0].title, UserText.networkProtection)
+        XCTAssertEqual(moreOptionsMenu.items[14].submenu?.items[1].title, UserText.dataBrokerProtectionOptionsMenuItem)
+        XCTAssertEqual(moreOptionsMenu.items[14].submenu?.items[2].title, UserText.identityTheftRestorationOptionsMenuItem)
+        XCTAssertTrue(moreOptionsMenu.items[14].submenu!.items[3].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[14].submenu?.items[4].title, UserText.subscriptionSettingsOptionsMenuItem)
+
+        XCTAssertTrue(moreOptionsMenu.items[15].isSeparatorItem)
+        XCTAssertEqual(moreOptionsMenu.items[16].title, UserText.mainMenuHelp)
+        XCTAssertEqual(moreOptionsMenu.items[17].title, UserText.settings)
+    }
+
+    @MainActor
+    func testWhenClickingFreemiumPIROptionAndDidNotOnboardThenFreemiumPresenterIsCalledWithDidNotOnboardState() throws {
+        // Given
+        subscriptionManager.canPurchase = true
+        subscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
+        mockFreemiumPIRFeatureFlagger.isEnabled = true
+        mockFreemiumPIRUserState.didOnboard = false
+        setupMoreOptionsMenu()
+
+        let freemiumItemIndex = try XCTUnwrap(moreOptionsMenu.indexOfItem(withTitle: UserText.freemiumPIROptionsMenuItem))
+
+        // When
+        moreOptionsMenu.performActionForItem(at: freemiumItemIndex)
+
+        // Then
+        XCTAssertTrue(mockFreemiumPIRPresenter.didCallShowFreemium)
+        XCTAssertFalse(mockFreemiumPIRPresenter.didOnboardState)
+    }
+
+    @MainActor
+    func testWhenClickingFreemiumPIROptionAndDidOnboardThenFreemiumPresenterIsCalledWithDidOnboardState() throws {
+        // Given
+        subscriptionManager.canPurchase = true
+        subscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
+        mockFreemiumPIRFeatureFlagger.isEnabled = true
+        mockFreemiumPIRUserState.didOnboard = true
+        setupMoreOptionsMenu()
+
+        let freemiumItemIndex = try XCTUnwrap(moreOptionsMenu.indexOfItem(withTitle: UserText.freemiumPIROptionsMenuItem))
+
+        // When
+        moreOptionsMenu.performActionForItem(at: freemiumItemIndex)
+
+        // Then
+        XCTAssertTrue(mockFreemiumPIRPresenter.didCallShowFreemium)
+        XCTAssertTrue(mockFreemiumPIRPresenter.didOnboardState)
     }
 
     // MARK: Zoom
@@ -273,5 +395,23 @@ final class NetworkProtectionVisibilityMock: VPNFeatureGatekeeper {
 
     func disableIfUserHasNoAccess() async {
         // Intentional no-op
+    }
+}
+
+private final class MockFreemiumPIRFeature: FreemiumPIRFeature {
+    var featureAvailable = false
+
+    var isAvailable: Bool {
+        featureAvailable
+    }
+}
+
+private final class MockFreemiumPIRPresenter: FreemiumPIRPresenter {
+    var didCallShowFreemium = false
+    var didOnboardState = false
+
+    func showFreemiumPIR(didOnboard: Bool, windowControllerManager: WindowControllersManagerProtocol? = nil) {
+        didCallShowFreemium = true
+        didOnboardState = didOnboard
     }
 }

--- a/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -294,7 +294,7 @@ final class MoreOptionsMenuTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mockFreemiumPIRPresenter.didCallShowFreemium)
-        XCTAssertFalse(mockFreemiumPIRPresenter.didOnboardState)
+        XCTAssertTrue(mockFreemiumPIRPresenter.didOnboardState)
     }
 
     @MainActor

--- a/UnitTests/Preferences/AppearancePreferencesTests.swift
+++ b/UnitTests/Preferences/AppearancePreferencesTests.swift
@@ -31,7 +31,7 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
     var showBookmarksBar: Bool
     var bookmarksBarAppearance: BookmarksBarAppearance
     var homeButtonPosition: HomeButtonPosition
-    var isHomePagePromotionVisible: Bool
+    var didDismissHomePagePromotion: Bool
 
     init(
         showFullURL: Bool = false,
@@ -43,7 +43,7 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
         showBookmarksBar: Bool = true,
         bookmarksBarAppearance: BookmarksBarAppearance = .alwaysOn,
         homeButtonPosition: HomeButtonPosition = .right,
-        isHomePagePromotionVisible: Bool = true
+        didDismissHomePagePromotion: Bool = true
     ) {
         self.showFullURL = showFullURL
         self.currentThemeName = currentThemeName
@@ -54,7 +54,7 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
         self.showBookmarksBar = showBookmarksBar
         self.bookmarksBarAppearance = bookmarksBarAppearance
         self.homeButtonPosition = homeButtonPosition
-        self.isHomePagePromotionVisible = isHomePagePromotionVisible
+        self.didDismissHomePagePromotion = didDismissHomePagePromotion
     }
 }
 

--- a/UnitTests/Preferences/AppearancePreferencesTests.swift
+++ b/UnitTests/Preferences/AppearancePreferencesTests.swift
@@ -21,6 +21,7 @@ import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
 struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
+
     var isFavoriteVisible: Bool
     var isContinueSetUpVisible: Bool
     var isRecentActivityVisible: Bool
@@ -30,6 +31,7 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
     var showBookmarksBar: Bool
     var bookmarksBarAppearance: BookmarksBarAppearance
     var homeButtonPosition: HomeButtonPosition
+    var isHomePagePromotionVisible: Bool
 
     init(
         showFullURL: Bool = false,
@@ -40,7 +42,8 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
         isRecentActivityVisible: Bool = true,
         showBookmarksBar: Bool = true,
         bookmarksBarAppearance: BookmarksBarAppearance = .alwaysOn,
-        homeButtonPosition: HomeButtonPosition = .right
+        homeButtonPosition: HomeButtonPosition = .right,
+        isHomePagePromotionVisible: Bool = true
     ) {
         self.showFullURL = showFullURL
         self.currentThemeName = currentThemeName
@@ -51,6 +54,7 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
         self.showBookmarksBar = showBookmarksBar
         self.bookmarksBarAppearance = bookmarksBarAppearance
         self.homeButtonPosition = homeButtonPosition
+        self.isHomePagePromotionVisible = isHomePagePromotionVisible
     }
 }
 

--- a/UnitTests/RecentlyClosed/RecentlyClosedCoordinatorTests.swift
+++ b/UnitTests/RecentlyClosed/RecentlyClosedCoordinatorTests.swift
@@ -88,7 +88,6 @@ private extension RecentlyClosedWindow {
 }
 
 private final class WindowControllersManagerMock: WindowControllersManagerProtocol {
-
     var pinnedTabsManager = PinnedTabsManager(tabCollection: .init())
 
     var didRegisterWindowController = PassthroughSubject<(MainWindowController), Never>()
@@ -96,4 +95,6 @@ private final class WindowControllersManagerMock: WindowControllersManagerProtoc
 
     func register(_ windowController: MainWindowController) {}
     func unregister(_ windowController: MainWindowController) {}
+
+    func showTab(with content: DuckDuckGo_Privacy_Browser.Tab.TabContent) { }
 }

--- a/UnitTests/Sync/Mocks/MockAppearancePreferencesPersistor.swift
+++ b/UnitTests/Sync/Mocks/MockAppearancePreferencesPersistor.swift
@@ -43,5 +43,5 @@ class MockAppearancePreferencesPersistor: AppearancePreferencesPersistor {
 
     var bookmarksBarAppearance: BookmarksBarAppearance = .alwaysOn
 
-    var isHomePagePromotionVisible = true
+    var didDismissHomePagePromotion = true
 }

--- a/UnitTests/Sync/Mocks/MockAppearancePreferencesPersistor.swift
+++ b/UnitTests/Sync/Mocks/MockAppearancePreferencesPersistor.swift
@@ -43,4 +43,5 @@ class MockAppearancePreferencesPersistor: AppearancePreferencesPersistor {
 
     var bookmarksBarAppearance: BookmarksBarAppearance = .alwaysOn
 
+    var isHomePagePromotionVisible = true
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208161235633538/f

**Description**: This **PR to the feature branch** includes the following UX changes relating to Freemium PIR:

1. Adds a ‘Personal Information Scan’ item to the more options menu
2. Adds a new `PromotionView` type, used to display a banner on the new tab page to promote Freemium PIR
3. Adds logic to display/hide the new tab page banner
4. Opens PIR from both new Freemium PIR entry points
5. Adds a debug menu item to reset the new tab page display state (because once it’s dismissed for a user, it won’t be displayed again)

Notes:
* The PFR for this work is still on-going and so exact designs etc. are subject to change. This PR intends to set the foundation which we can iterate on later
* This is a PR to a feature branch, these changes are not going to production yet

**Testing Pre-requisites**:
1. Be an internal user
2. Sign out of Privacy Pro subscription (app settings -> Privacy Pro -> Remove from this device)

**Steps to test this PR**:
1. Launch the browser
3. Confirm the new tab page banner is present
4. Confirm the  ‘Personal Information Scan’  more options menu item is present
5. Click the ’Scan’ button on the new tab page banner
6. Ensure the banner is dismissed and PIR tab is opened
7. Reset the new tab page banner state using the debug menu: Debug -> UI Triggers -> Reset Home View Promotion State
8. 4. Click the ’X’ button on the new tab page banner
9. Ensure the banner is dismissed
10. Reset the new tab page banner state using the debug menu: Debug -> UI Triggers -> Reset Home View Promotion State
11. Select ‘Personal Information Scan’ from the more options menu
12. 5. Ensure the new tab page banner is dismissed and PIR tab is opened

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
