### PR TITLE
Update CI test report to avoid reporting successful retries as failures

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,6 +135,7 @@ jobs:
       with:
         check_name: "Test Report: Shell Scripts"
         report_paths: 'bats-tests.xml'
+        check_retries: true
 
   tests:
     name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,7 +135,6 @@ jobs:
       with:
         check_name: "Test Report: Shell Scripts"
         report_paths: 'bats-tests.xml'
-        check_retries: true
 
   tests:
     name: Test
@@ -298,6 +297,7 @@ jobs:
       with:
         check_name: "Test Report: ${{ matrix.flavor }}"
         report_paths: '${{ matrix.flavor }}*.xml'
+        check_retries: true
 
     - name: Update Asana with failed unit tests
       if: always() # always run even if the previous step fails

--- a/IntegrationTests/PrivacyDashboard/PrivacyDashboardIntegrationTests.swift
+++ b/IntegrationTests/PrivacyDashboard/PrivacyDashboardIntegrationTests.swift
@@ -61,7 +61,7 @@ class PrivacyDashboardIntegrationTests: XCTestCase {
             .switchToLatest()
             .filter { $0.trackersBlocked.count > 0 }
             .map { $0.trackers.count }
-            .timeout(10)
+            .timeout(30)
             .first()
             .promise()
 

--- a/IntegrationTests/PrivacyDashboard/PrivacyDashboardIntegrationTests.swift
+++ b/IntegrationTests/PrivacyDashboard/PrivacyDashboardIntegrationTests.swift
@@ -61,7 +61,7 @@ class PrivacyDashboardIntegrationTests: XCTestCase {
             .switchToLatest()
             .filter { $0.trackersBlocked.count > 0 }
             .map { $0.trackers.count }
-            .timeout(30)
+            .timeout(10)
             .first()
             .promise()
 
@@ -77,7 +77,7 @@ class PrivacyDashboardIntegrationTests: XCTestCase {
             .switchToLatest()
             .filter { $0.trackersBlocked.count == 0 }
             .map { $0.trackers.count }
-            .timeout(30)
+            .timeout(10)
             .first()
             .promise()
         _=await tab.setUrl(URL.testsServer, source: .link)?.result

--- a/IntegrationTests/PrivacyDashboard/PrivacyDashboardIntegrationTests.swift
+++ b/IntegrationTests/PrivacyDashboard/PrivacyDashboardIntegrationTests.swift
@@ -77,7 +77,7 @@ class PrivacyDashboardIntegrationTests: XCTestCase {
             .switchToLatest()
             .filter { $0.trackersBlocked.count == 0 }
             .map { $0.trackers.count }
-            .timeout(10)
+            .timeout(30)
             .first()
             .promise()
         _=await tab.setUrl(URL.testsServer, source: .link)?.result


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1208174218141374/f
Tech Design URL:
CC:

**Description**:

This PR updates the test report action to set `check_retries` to true, which will avoid reporting a failure when a test fails and then succeeds upon a retry.

**Steps to test this PR**:
1. Check that CI is green
2. Check that the diff matches the [action documentation](https://github.com/mikepenz/action-junit-report)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
