### PR TITLE
Migrate asana-upload from GHA action to fastlane

### DIFF
--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -352,6 +352,8 @@ jobs:
 
     - name: Upload DMG to Asana
       if: ${{ env.upload-to == 'asana' }}
+      env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
       run: |
         bundle exec fastlane run asana_upload \
           file_name:"${{ github.workspace }}/duckduckgo-${{ env.app-version }}.dmg" \

--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -352,11 +352,10 @@ jobs:
 
     - name: Upload DMG to Asana
       if: ${{ env.upload-to == 'asana' }}
-      uses: ./.github/actions/asana-upload
-      with:
-        access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-        file-name: ${{ github.workspace }}/duckduckgo-${{ env.app-version }}.dmg
-        task-id: ${{ steps.task-id.outputs.asana_task_id }}
+      run: |
+        bundle exec fastlane run asana_upload \
+          file_name:"${{ github.workspace }}/duckduckgo-${{ env.app-version }}.dmg" \
+          task_id:"${{ steps.task-id.outputs.asana_task_id }}" 
 
   mattermost:
 

--- a/.github/workflows/migration-test-asana-asana-upload.yml
+++ b/.github/workflows/migration-test-asana-asana-upload.yml
@@ -1,0 +1,26 @@
+name: Migration Test - Asana Upload
+
+on: 
+  push:
+  workflow_dispatch:
+
+jobs:
+  test:
+
+    name: Test
+
+    runs-on: macos-14
+
+    steps:
+ 
+    - name: Check out the code
+      uses: actions/checkout@v4
+
+    - name: Set up fastlane
+      run: bundle install
+
+    - name: Test asana_upload
+      run: |
+        bundle exec fastlane run asana_upload \
+          file_name:"Gemfile" \
+          task_id:"${{ 1208189657535242 }}" 

--- a/.github/workflows/migration-test-asana-asana-upload.yml
+++ b/.github/workflows/migration-test-asana-asana-upload.yml
@@ -20,6 +20,8 @@ jobs:
       run: bundle install
 
     - name: Test asana_upload
+      env:
+        ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
       run: |
         bundle exec fastlane run asana_upload \
           file_name:"Gemfile" \

--- a/.github/workflows/migration-test-asana-asana-upload.yml
+++ b/.github/workflows/migration-test-asana-asana-upload.yml
@@ -25,4 +25,4 @@ jobs:
       run: |
         bundle exec fastlane run asana_upload \
           file_name:"Gemfile" \
-          task_id:"${{ 1208189657535242 }}" 
+          task_id:"1208189657535242" 

--- a/.github/workflows/publish_dmg_release.yml
+++ b/.github/workflows/publish_dmg_release.yml
@@ -345,6 +345,8 @@ jobs:
       - name: Upload patch to the Asana task
         id: upload-patch
         if: success()
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
         run: |
           bundle exec fastlane run asana_upload \
             file_name:"${{ env.SPARKLE_DIR }}/${{ steps.appcast.outputs.appcast-patch-name }}" \
@@ -353,6 +355,8 @@ jobs:
       - name: Upload old appcast file to the Asana task
         id: upload-old-appcast
         if: success()
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
         run: |
           bundle exec fastlane run asana_upload \
             file_name:"${{ env.OLD_APPCAST_NAME }}" \
@@ -361,6 +365,8 @@ jobs:
       - name: Upload release notes to the Asana task
         id: upload-release-notes
         if: success()
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
         run: |
           bundle exec fastlane run asana_upload \
             file_name:"${{ env.RELEASE_NOTES_FILE }}" \

--- a/.github/workflows/publish_dmg_release.yml
+++ b/.github/workflows/publish_dmg_release.yml
@@ -345,29 +345,26 @@ jobs:
       - name: Upload patch to the Asana task
         id: upload-patch
         if: success()
-        uses: ./.github/actions/asana-upload
-        with:
-          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          file-name: ${{ env.SPARKLE_DIR }}/${{ steps.appcast.outputs.appcast-patch-name }}
-          task-id: ${{ steps.create-task.outputs.new-task-id }}
+        run: |
+          bundle exec fastlane run asana_upload \
+            file_name:"${{ env.SPARKLE_DIR }}/${{ steps.appcast.outputs.appcast-patch-name }}" \
+            task_id:"${{ steps.create-task.outputs.new-task-id }}" 
 
       - name: Upload old appcast file to the Asana task
         id: upload-old-appcast
         if: success()
-        uses: ./.github/actions/asana-upload
-        with:
-          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          file-name: ${{ env.OLD_APPCAST_NAME }}
-          task-id: ${{ steps.create-task.outputs.new-task-id }}
+        run: |
+          bundle exec fastlane run asana_upload \
+            file_name:"${{ env.OLD_APPCAST_NAME }}" \
+            task_id:"${{ steps.create-task.outputs.new-task-id }}" 
   
       - name: Upload release notes to the Asana task
         id: upload-release-notes
         if: success()
-        uses: ./.github/actions/asana-upload
-        with:
-          access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          file-name: ${{ env.RELEASE_NOTES_FILE }}
-          task-id: ${{ steps.create-task.outputs.new-task-id }}
+        run: |
+          bundle exec fastlane run asana_upload \
+            file_name:"${{ env.RELEASE_NOTES_FILE }}" \
+            task_id:"${{ steps.create-task.outputs.new-task-id }}" 
         
       - name: Report status
         if: always()

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 5d267b66e9c63f879eecbb4ae1f40cb42547026e
-  tag: 0.2.0
+  revision: fcbc84820345dea381e53ba9bd036c4baae531a6
+  branch: jacek/asana-upload
   specs:
     fastlane-plugin-ddg_apple_automation (0.2.0)
 
@@ -231,4 +231,4 @@ DEPENDENCIES
   httparty
 
 BUNDLED WITH
-   2.4.19
+   2.4.4

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '0.2.0'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', branch: 'jacek/asana-upload'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201392122292466/1208137627434497/f

**Description**:
This change adds new lane that replaces asana-upload action

**Steps to test this PR**:
1. Verify that CI is green.
2. Verify that [this test workflow](https://github.com/duckduckgo/macos-browser/actions/runs/10634872292/job/29483218551) completes successfully. Verify that [this Asana task](https://app.asana.com/0/1201392122292466/1208189657535242) task has 1 attachment. This workflow is here only to demonstrate that the fastlane action works, even though it only mimicks how other upload steps look like.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
