### PR TITLE
remove references to obsolete FBConfig

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13740,7 +13740,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 190.0.0;
+				version = 190.0.1;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "ac53011582abcca4aefd66f15308332273eecb49",
+        "revision" : "245750c9ca559813307641e819fb27c6d294339f",
         "version" : "190.0.1"
       }
     },

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
         "revision" : "ac53011582abcca4aefd66f15308332273eecb49",
-        "version" : "190.0.0"
+        "version" : "190.0.1"
       }
     },
     {

--- a/DuckDuckGo/Application/AppConfigurationURLProvider.swift
+++ b/DuckDuckGo/Application/AppConfigurationURLProvider.swift
@@ -58,7 +58,6 @@ struct AppConfigurationURLProvider: ConfigurationURLProviding {
         case .surrogates: return URL(string: "https://staticcdn.duckduckgo.com/surrogates.txt")!
         case .trackerDataSet: return URL(string: "https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json")!
         // In archived repo, to be refactored shortly (https://staticcdn.duckduckgo.com/useragents/social_ctp_configuration.json)
-        case .FBConfig: return URL(string: "https://staticcdn.duckduckgo.com/useragents/")!
         case .remoteMessagingConfig: return RemoteMessagingClient.Constants.endpoint
         }
     }

--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -51,7 +51,6 @@ public struct UserDefaultsWrapper<T> {
         case configStorageBloomFilterExclusionsEtag = "config.storage.bloomfilter.exclusions.etag"
         case configStorageSurrogatesEtag = "config.storage.surrogates.etag"
         case configStoragePrivacyConfigurationEtag = "config.storage.privacyconfiguration.etag"
-        case configFBConfigEtag = "config.storage.fbconfig.etag"
         case configStorageRemoteMessagingConfigEtag = "config.storage.remotemessagingconfig.etag"
 
         case configLastInstalled = "config.last.installed"

--- a/DuckDuckGo/Configuration/ConfigurationStore.swift
+++ b/DuckDuckGo/Configuration/ConfigurationStore.swift
@@ -31,7 +31,6 @@ final class ConfigurationStore: ConfigurationStoring {
         .surrogates: "surrogates.txt",
         .privacyConfiguration: "macos-config.json",
         .trackerDataSet: "tracker-radar.json",
-        .FBConfig: "social_ctp_configuration.json",
         .remoteMessagingConfig: "remote-messaging-config.json"
     ]
 
@@ -55,9 +54,6 @@ final class ConfigurationStore: ConfigurationStoring {
     @UserDefaultsWrapper(key: .configStoragePrivacyConfigurationEtag, defaultValue: nil)
     private var privacyConfigurationEtag: String?
 
-    @UserDefaultsWrapper(key: .configFBConfigEtag, defaultValue: nil)
-    private var FBConfigEtag: String?
-
     @UserDefaultsWrapper(key: .configStorageRemoteMessagingConfigEtag, defaultValue: nil)
     private var remoteMessagingConfigEtag: String?
 
@@ -71,7 +67,6 @@ final class ConfigurationStore: ConfigurationStoring {
         case .surrogates: return surrogatesEtag
         case .trackerDataSet: return trackerRadarEtag
         case .privacyConfiguration: return privacyConfigurationEtag
-        case .FBConfig: return FBConfigEtag
         case .remoteMessagingConfig: return remoteMessagingConfigEtag
         }
     }
@@ -92,7 +87,6 @@ final class ConfigurationStore: ConfigurationStoring {
         case .surrogates: surrogatesEtag = etag
         case .trackerDataSet: trackerRadarEtag = etag
         case .privacyConfiguration: privacyConfigurationEtag = etag
-        case .FBConfig: FBConfigEtag = etag
         case .remoteMessagingConfig: remoteMessagingConfigEtag = etag
         }
     }
@@ -126,7 +120,6 @@ final class ConfigurationStore: ConfigurationStoring {
         Logger.config.info("surrogatesEtag \(self.surrogatesEtag ?? "", privacy: .public)")
         Logger.config.info("trackerRadarEtag \(self.trackerRadarEtag ?? "", privacy: .public)")
         Logger.config.info("privacyConfigurationEtag \(self.privacyConfigurationEtag ?? "", privacy: .public)")
-        Logger.config.info("FBConfigEtag \(self.FBConfigEtag ?? "", privacy: .public)")
         Logger.config.info("remoteMessagingConfig \(self.remoteMessagingConfigEtag ?? "", privacy: .public)")
     }
 

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "190.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "190.0.1"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),
     ],

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "190.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "190.0.1"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.3"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "190.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "190.0.1"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [

--- a/UnitTests/AppDelegate/AppConfigurationURLProviderTests.swift
+++ b/UnitTests/AppDelegate/AppConfigurationURLProviderTests.swift
@@ -28,7 +28,6 @@ final class AppConfigurationURLProviderTests: XCTestCase {
         XCTAssertEqual(AppConfigurationURLProvider().url(for: .privacyConfiguration).absoluteString, "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json")
         XCTAssertEqual(AppConfigurationURLProvider().url(for: .surrogates).absoluteString, "https://staticcdn.duckduckgo.com/surrogates.txt")
         XCTAssertEqual(AppConfigurationURLProvider().url(for: .trackerDataSet).absoluteString, "https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json")
-        XCTAssertEqual(AppConfigurationURLProvider().url(for: .FBConfig).absoluteString, "https://staticcdn.duckduckgo.com/useragents/")
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1171671347221384/1208194339440141/f
Tech Design URL:
CC:

**Description**: Remove all references to the obsolete FBConfig file, which has been replaced by the shared privacy config

**Steps to test this PR**:
1.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
