### PR TITLE
Bug: Disable boomark reordering when searching

### DIFF
--- a/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
@@ -54,14 +54,6 @@ final class BookmarkDragDropManager {
         }
     }
 
-    func validateDropWhileInSearchMode(_ info: NSDraggingInfo, to destination: Any) -> (destinationFolder: BookmarkFolder?, operation: NSDragOperation) {
-        if let destinationFolder = destination as? BookmarkFolder {
-            return (destinationFolder, .move)
-        }
-
-        return (nil, .none)
-    }
-
     private func validateMove(for draggedBookmarks: Set<PasteboardBookmark>, destination: Any) -> Bool? {
         guard !draggedBookmarks.isEmpty else { return nil }
         guard destination is BookmarkFolder || destination is PseudoFolder else { return false }

--- a/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
@@ -54,6 +54,14 @@ final class BookmarkDragDropManager {
         }
     }
 
+    func validateDropWhileInSearchMode(_ info: NSDraggingInfo, to destination: Any) -> (destinationFolder: BookmarkFolder?, operation: NSDragOperation) {
+        if let destinationFolder = destination as? BookmarkFolder {
+            return (destinationFolder, .move)
+        }
+
+        return (nil, .none)
+    }
+
     private func validateMove(for draggedBookmarks: Set<PasteboardBookmark>, destination: Any) -> Bool? {
         guard !draggedBookmarks.isEmpty else { return nil }
         guard destination is BookmarkFolder || destination is PseudoFolder else { return false }

--- a/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
@@ -265,10 +265,10 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
 
         let destination = destinationNode.isRoot ? PseudoFolder.bookmarks : destinationNode.representedObject
 
-        if isSearching {
-            let result = dragDropManager.validateDropWhileInSearchMode(info, to: destination)
-            self.dragDestinationFolder = result.destinationFolder
-            return result.operation
+        guard !isSearching || destination is BookmarkFolder else { return .none }
+
+        if let destinationFolder = destination as? BookmarkFolder {
+            self.dragDestinationFolder = destinationFolder
         }
 
         let operation = dragDropManager.validateDrop(info, to: destination)

--- a/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
@@ -264,6 +264,13 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
         }
 
         let destination = destinationNode.isRoot ? PseudoFolder.bookmarks : destinationNode.representedObject
+
+        if isSearching {
+            let result = dragDropManager.validateDropWhileInSearchMode(info, to: destination)
+            self.dragDestinationFolder = result.destinationFolder
+            return result.operation
+        }
+
         let operation = dragDropManager.validateDrop(info, to: destination)
         self.dragDestinationFolder = (operation == .none || item == nil) ? nil : destinationNode.representedObject as? BookmarkFolder
 

--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -451,7 +451,7 @@ final class BookmarkListViewController: NSViewController {
         expandFoldersAndScrollUntil(folder)
         outlineView.scrollToAdjustedPositionInOutlineView(folder)
 
-        guard let node = treeController.node(representing: folder) else { return }
+        guard let node = treeController.findNodeWithId(representing: folder) else { return }
 
         outlineView.highlight(node)
     }

--- a/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
@@ -473,7 +473,13 @@ extension BookmarkManagementDetailViewController: NSTableViewDelegate, NSTableVi
                    proposedRow row: Int,
                    proposedDropOperation dropOperation: NSTableView.DropOperation) -> NSDragOperation {
         let destination = destination(for: dropOperation, at: row)
-        return dragDropManager.validateDrop(info, to: destination)
+
+        if isSearching {
+            let result = dragDropManager.validateDropWhileInSearchMode(info, to: destination)
+            return result.operation
+        } else {
+            return dragDropManager.validateDrop(info, to: destination)
+        }
     }
 
     func tableView(_ tableView: NSTableView, acceptDrop info: NSDraggingInfo, row: Int, dropOperation: NSTableView.DropOperation) -> Bool {

--- a/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
@@ -474,12 +474,9 @@ extension BookmarkManagementDetailViewController: NSTableViewDelegate, NSTableVi
                    proposedDropOperation dropOperation: NSTableView.DropOperation) -> NSDragOperation {
         let destination = destination(for: dropOperation, at: row)
 
-        if isSearching {
-            let result = dragDropManager.validateDropWhileInSearchMode(info, to: destination)
-            return result.operation
-        } else {
-            return dragDropManager.validateDrop(info, to: destination)
-        }
+        guard !isSearching || destination is BookmarkFolder else { return .none }
+
+        return dragDropManager.validateDrop(info, to: destination)
     }
 
     func tableView(_ tableView: NSTableView, acceptDrop info: NSDraggingInfo, row: Int, dropOperation: NSTableView.DropOperation) -> Bool {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208204239267626/f
Tech Design URL:
CC:

**Description**:
- Fix a bug where bookmark reordering was possible during search (both in the panel and the manager)
- Fix a bug where the folder was not correctly highlighted after being tapped in the bookmarks panel

**Steps to test this PR**:
1. Start a search (either in the bookmarks manager o panel)
2. Check that you cannot reorder items
3. You should be able to drop items in a folder

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
