### PR TITLE
Remove DuckPlayer onboarding animation

### DIFF
--- a/DuckDuckGo/YoutubePlayer/Onboarding/DuckPlayerOnboardingModal/DuckPlayerOnboardingModalView.swift
+++ b/DuckDuckGo/YoutubePlayer/Onboarding/DuckPlayerOnboardingModal/DuckPlayerOnboardingModalView.swift
@@ -64,9 +64,7 @@ struct DuckPlayerOnboardingModalView: View {
 
         case .onboardingOptions:
             DuckPlayerOnboardingChoiceView(turnOnButtonPressed: {
-                withAnimation {
-                    viewModel.currentView = .confirmation
-                }
+                viewModel.currentView = .confirmation
                 viewModel.handleTurnOnCTA()
             }, notNowPressed: viewModel.handleNotNowCTA)
         }

--- a/DuckDuckGo/YoutubePlayer/Onboarding/DuckPlayerOnboardingModal/DuckPlayerOnboardingModalView.swift
+++ b/DuckDuckGo/YoutubePlayer/Onboarding/DuckPlayerOnboardingModal/DuckPlayerOnboardingModalView.swift
@@ -177,6 +177,7 @@ private struct DaxSpeechBubble<Content: View>: View {
             HStack(alignment: .top, spacing: 12) {
                 Image("DuckPlayerOnboardingModalDax")
                     .padding(.leading, -10)
+                    .padding(.top, 8)
 
                 ZStack {
                     SpeechBubble()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1208215097981301/f

**Description**:
Remove DuckPlayer onboarding animation
Center dax logo with dialog

**Steps to test this PR**:
1. Trigger the onboarding, make sure there's no animation when moving from modal A to modal B

