### PR TITLE
Triggering the update check right after the start to fetch release notes

### DIFF
--- a/DuckDuckGo/Updates/UpdateController.swift
+++ b/DuckDuckGo/Updates/UpdateController.swift
@@ -190,6 +190,9 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
         updater.updater.automaticallyChecksForUpdates = false
         updater.updater.automaticallyDownloadsUpdates = false
         updater.updater.updateCheckInterval = 0
+#else
+        // Load the appcast to retrieve information about the latest update (required for displaying Release Notes)
+        checkForUpdateInBackground()
 #endif
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208205370452095/f

**Description**:
Triggering the update check right after the start to fetch release notes and resolve the empty container in the Release Notes page

**Steps to test this PR**:
1. Run the app
2. Open Release notes page
3. Make sure it shows release notes of the latest build

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
