### PR TITLE
Fix bookmark sort UI tests failure

### DIFF
--- a/UITests/BookmarkSortTests.swift
+++ b/UITests/BookmarkSortTests.swift
@@ -143,7 +143,7 @@ class BookmarkSortTests: XCTestCase {
         let newApp = XCUIApplication()
         newApp.launch()
 
-        app.openBookmarksPanel()
+        newApp.openBookmarksPanel()
 
         let sortBookmarksPanelButton = newApp.buttons[AccessibilityIdentifiers.sortBookmarksButtonPanel]
         sortBookmarksPanelButton.tap()

--- a/UITests/BookmarkSortTests.swift
+++ b/UITests/BookmarkSortTests.swift
@@ -141,7 +141,9 @@ class BookmarkSortTests: XCTestCase {
 
         app.terminate()
         let newApp = XCUIApplication()
+        newApp.launchEnvironment["UITEST_MODE"] = "1"
         newApp.launch()
+        newApp.enforceSingleWindow()
 
         // Wait for new application to start
         XCTAssertTrue(newApp.waitForExistence(timeout: UITests.Timeouts.elementExistence))

--- a/UITests/BookmarkSortTests.swift
+++ b/UITests/BookmarkSortTests.swift
@@ -143,6 +143,9 @@ class BookmarkSortTests: XCTestCase {
         let newApp = XCUIApplication()
         newApp.launch()
 
+        // Wait for new application to start
+        XCTAssertTrue(newApp.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+
         newApp.openBookmarksPanel()
 
         let sortBookmarksPanelButton = newApp.buttons[AccessibilityIdentifiers.sortBookmarksButtonPanel]

--- a/UITests/Common/XCUIApplicationExtension.swift
+++ b/UITests/Common/XCUIApplicationExtension.swift
@@ -118,7 +118,7 @@ extension XCUIApplication {
     func openBookmarksPanel() {
         let bookmarksPanelShortcutButton = buttons[AccessibilityIdentifiers.bookmarksPanelShortcutButton]
         if !bookmarksPanelShortcutButton.exists {
-            typeKey("K", modifierFlags: [.command, .shift])
+            typeKey("k", modifierFlags: [.command, .shift])
         }
 
         bookmarksPanelShortcutButton.tap()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208220055565873/f
Tech Design URL:
CC:

**Description**:
A bad merge introduced this, we should use the `newApp` instead of the terminated `app` for the test that checks state restoration.

**Steps to test this PR**:
1. Run the `testThatSortIsPersistedThroughBrowserRestarts` UI test
2. Check is passing

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
