### PR TITLE
Add Phishing Detection Preferences

### DIFF
--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -412,6 +412,10 @@ struct UserText {
 
     static let downloadsOpenPopupOnCompletion = NSLocalizedString("downloads.open.on.completion", value: "Automatically open the Downloads panel when downloads complete", comment: "Checkbox to open a Download Manager popover when downloads are completed")
 
+    static let phishingDetectionHeader = NSLocalizedString("phishing-detection.enabled.header", value: "Malicious Site Protection", comment: "Header for phishing site protection section in the settings page")
+    static let phishingDetectionIsEnabled = NSLocalizedString("phishing-detection.enabled.checkbox", value: "Allow DuckDuckGo to warn you before loading a webpage that has been flagged as malicious or fraudulent.", comment: "Checkbox that enables or disables the phishing detection feature in the browser")
+    static let phishingDetectionEnabledWarning = NSLocalizedString("phishing-detection.enabled.warning", value: "Disabling this feature can put your personal information at risk. Only do so if you fully understand the risk involved.", comment: "A description box to warn users away from disabling phishing protection")
+
     // MARK: Password Manager
     static let passwordManagementAllItems = NSLocalizedString("passsword.management.all-items", value: "All Items", comment: "Used as title for the Autofill All Items option")
     static let passwordManagementLogins = NSLocalizedString("passsword.management.logins", value: "Passwords", comment: "Used as title for the Autofill Logins option")

--- a/DuckDuckGo/FeatureFlagging/Model/FeatureFlag.swift
+++ b/DuckDuckGo/FeatureFlagging/Model/FeatureFlag.swift
@@ -22,7 +22,8 @@ import BrowserServicesKit
 public enum FeatureFlag: String {
     case debugMenu
     case sslCertificatesBypass
-    case phishingDetection
+    case phishingDetectionErrorPage
+    case phishingDetectionPreferences
 
     /// Add experimental atb parameter to SERP queries for internal users to display Privacy Reminder
     /// https://app.asana.com/0/1199230911884351/1205979030848528/f
@@ -53,8 +54,10 @@ extension FeatureFlag: FeatureFlagSourceProviding {
             return .remoteReleasable(.subfeature(AutofillSubfeature.unknownUsernameCategorization))
         case .freemiumPIR:
             return .remoteDevelopment(.subfeature(DBPSubfeature.freemium))
-        case .phishingDetection:
+        case .phishingDetectionErrorPage:
             return .remoteReleasable(.subfeature(PhishingDetectionSubfeature.allowErrorPage))
+        case .phishingDetectionPreferences:
+            return .remoteReleasable(.subfeature(PhishingDetectionSubfeature.allowPreferencesToggle))
         }
     }
 }

--- a/DuckDuckGo/Localizable.xcstrings
+++ b/DuckDuckGo/Localizable.xcstrings
@@ -41246,10 +41246,58 @@
       "comment" : "Checkbox that enables or disables the phishing detection feature in the browser",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaube DuckDuckGo, dich zu warnen, bevor eine Webseite geladen wird, die als bösartig oder betrügerisch gekennzeichnet wurde."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow DuckDuckGo to warn you before loading a webpage that has been flagged as malicious or fraudulent."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que DuckDuckGo te avise antes de cargar una página web que se haya marcado como maliciosa o fraudulenta."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorisez DuckDuckGo à vous avertir avant de charger une page Web signalée comme malveillante ou frauduleuse."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consenti a DuckDuckGo di avvisarti prima di caricare una pagina web contrassegnata come dannosa o fraudolenta."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laat DuckDuckGo je waarschuwen voordat je een webpagina laadt die als kwaadaardig of frauduleus is gemarkeerd."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zezwól DuckDuckGo na ostrzeganie przed załadowaniem strony internetowej, która została oznaczona jako złośliwa lub jako oszustwo."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permitir que o DuckDuckGo te avise antes de carregar uma página que foi sinalizada como maliciosa ou fraudulenta."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разрешить DuckDuckGo предупреждать вас о потенциально вредоносных или мошеннических сайтах перед загрузкой страницы."
           }
         }
       }
@@ -41258,10 +41306,58 @@
       "comment" : "Header for phishing site protection section in the settings page",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schutz vor bösartigen Websites"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Malicious Site Protection"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protección contra sitios maliciosos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protection contre les sites malveillants"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protezione dai siti dannosi"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bescherming tegen schadelijke sites"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ochrona przed złośliwymi witrynami"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proteção contra sites maliciosos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Защита от вредоносных сайтов"
           }
         }
       }
@@ -41270,10 +41366,58 @@
       "comment" : "A description box to warn users away from disabling phishing protection",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Deaktivieren dieser Funktion kann deine persönlichen Daten gefährden. Wenn du dir über die damit verbundenen Risiken im Klaren bist, kannst du trotzdem fortfahren."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disabling this feature can put your personal information at risk. Only do so if you fully understand the risk involved."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar esta función puede poner en riesgo tu información personal. Hazlo solo si entiendes completamente el riesgo que implica."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La désactivation de cette fonctionnalité peut mettre vos informations personnelles en danger. Faites-le uniquement si vous comprenez parfaitement les risques encourus."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disabilitando questa funzione, potresti mettere a rischio i tuoi dati personali. Fallo solo se comprendi appieno il rischio che comporta."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Als je deze functie uitschakelt, kunnen je persoonlijke gegevens in gevaar komen. Doe dit alleen als je het risico volledig begrijpt."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyłączenie tej funkcji może narazić Twoje dane osobowe na ryzyko. Rób to tylko wtedy, gdy rozumiesz związane z tym zagrożenie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desativar esta funcionalidade pode pôr em risco as tuas informações pessoais. Não desatives a menos que compreendas os riscos."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "При отключении этой функции ваши личные данные могут оказаться под угрозой. Эту функцию следует деактивировать только в том случае, если вы осознаете связанные с этим риски."
           }
         }
       }

--- a/DuckDuckGo/Localizable.xcstrings
+++ b/DuckDuckGo/Localizable.xcstrings
@@ -41242,6 +41242,42 @@
         }
       }
     },
+    "phishing-detection.enabled.checkbox" : {
+      "comment" : "Checkbox that enables or disables the phishing detection feature in the browser",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Allow DuckDuckGo to warn you before loading a webpage that has been flagged as malicious or fraudulent."
+          }
+        }
+      }
+    },
+    "phishing-detection.enabled.header" : {
+      "comment" : "Header for phishing site protection section in the settings page",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Malicious Site Protection"
+          }
+        }
+      }
+    },
+    "phishing-detection.enabled.warning" : {
+      "comment" : "A description box to warn users away from disabling phishing protection",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disabling this feature can put your personal information at risk. Only do so if you fully understand the risk involved."
+          }
+        }
+      }
+    },
     "phishing.error.page.tab.title" : {
       "comment" : "Title shown in an error page tab that warn users of security risks on a website that has been flagged as malicious.",
       "extractionState" : "extracted_with_value",

--- a/DuckDuckGo/PhishingDetection/PhishingDetection.swift
+++ b/DuckDuckGo/PhishingDetection/PhishingDetection.swift
@@ -135,7 +135,7 @@ public class PhishingDetection: PhishingSiteDetecting {
     }
 
     private func startUpdateTasksIfEnabled() {
-        if featureFlagger.isFeatureOn(.phishingDetection),
+        if featureFlagger.isFeatureOn(.phishingDetectionErrorPage),
            self.detectionPreferences.isEnabled {
             startUpdateTasks()
         }

--- a/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
@@ -31,9 +31,11 @@ extension Preferences {
         @ObservedObject var searchModel: SearchPreferences
         @ObservedObject var tabsModel: TabsPreferences
         @ObservedObject var dataClearingModel: DataClearingPreferences
+        @ObservedObject var phishingDetectionModel: PhishingDetectionPreferences
         @State private var showingCustomHomePageSheet = false
         @State private var isAddedToDock = false
         var dockCustomizer: DockCustomizer
+        let featureFlagger = NSApp.delegateTyped.featureFlagger
 
         var body: some View {
             PreferencePane(UserText.general) {
@@ -188,6 +190,20 @@ extension Preferences {
 
                         ToggleMenuItem(UserText.downloadsAlwaysAsk,
                                        isOn: $downloadsModel.alwaysRequestDownloadLocation)
+                    }
+                }
+
+                // SECTION 7: Phishing Detection
+                if featureFlagger.isFeatureOn(.phishingDetectionPreferences) {
+                    PreferencePaneSection(UserText.phishingDetectionHeader) {
+                        PreferencePaneSubSection {
+                            ToggleMenuItem(UserText.phishingDetectionIsEnabled,
+                                           isOn: $phishingDetectionModel.isEnabled)
+                        }.padding(.bottom, 5)
+                        Text(UserText.phishingDetectionEnabledWarning)
+                            .font(.footnote)
+                            .foregroundColor(.red)
+                            .padding(.top, 5)
                     }
                 }
             }

--- a/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -94,6 +94,7 @@ enum Preferences {
                                 searchModel: SearchPreferences.shared,
                                 tabsModel: TabsPreferences.shared,
                                 dataClearingModel: DataClearingPreferences.shared,
+                                phishingDetectionModel: PhishingDetectionPreferences.shared,
                                 dockCustomizer: DockCustomizer())
                 case .sync:
                     SyncView()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1208149630394246/f
Tech Design URL: https://app.asana.com/0/481882893211075/1207220724600204/f
CC:

**Description**:
Implement GeneralPreferencesView for Phishing Detection Error Page. Also add feature flag for enabling/disabling the preferences view.

**Steps to test this PR**:
1. Go to Settings>General
2. Check there is a Malicious Site Protection section
3. Turn it off
4. Visit privacy-test-pages.site/security/badware/phishing.html
5. Check error page is not shown
6. Turn it back on
7. Retest, ensure the error page is shown

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
