### PR TITLE
Support dragging strings to new tab button

### DIFF
--- a/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -19,7 +19,7 @@
 import SwiftUI
 import SwiftUIExtensions
 
-struct PinnedTabView: View {
+struct PinnedTabView: View, DropDelegate {
     enum Const {
         static let dimension: CGFloat = 34
         static let cornerRadius: CGFloat = 10
@@ -49,6 +49,7 @@ struct PinnedTabView: View {
             .buttonStyle(TouchDownButtonStyle())
             .cornerRadius(Const.cornerRadius, corners: [.topLeft, .topRight])
             .contextMenu { contextMenu }
+            .onDrop(of: ["public.text"], delegate: self)
 
             BorderView(isSelected: isSelected,
                        cornerRadius: Const.cornerRadius,
@@ -62,7 +63,22 @@ struct PinnedTabView: View {
         } else {
             stack
         }
+    }
 
+    func performDrop(info: DropInfo) -> Bool {
+        if let item = info.itemProviders(for: ["public.utf8-plain-text"]).first {
+            item.loadItem(forTypeIdentifier: "public.utf8-plain-text", options: nil) { (data, _) in
+                if let data = data as? Data, let droppedString = NSString(data: data, encoding: NSUTF8StringEncoding) {
+                    print(droppedString)
+                    let url = URL.makeSearchUrl(from: droppedString as String)!
+
+                    DispatchQueue.main.async {
+                        model.setUrl(url, source: .ui)
+                    }
+                }
+            }
+        }
+        return true
     }
 
     private var isSelected: Bool {

--- a/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -70,7 +70,7 @@ struct PinnedTabView: View, DropDelegate {
             item.loadItem(forTypeIdentifier: "public.utf8-plain-text", options: nil) { (data, _) in
                 if let data = data as? Data, let droppedString = NSString(data: data, encoding: NSUTF8StringEncoding) {
                     print(droppedString)
-                    let url = URL.makeSearchUrl(from: droppedString as String)!
+                    let url = URL.makeURL(from: droppedString as String)!
 
                     DispatchQueue.main.async {
                         model.setUrl(url, source: .ui)

--- a/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
+++ b/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
@@ -33,7 +33,7 @@ final class TabBarCollectionView: NSCollectionView {
         register(nib, forItemWithIdentifier: TabBarViewItem.identifier)
 
         // Register for the dropped object types we can accept.
-        registerForDraggedTypes([.URL, .fileURL, TabBarViewItemPasteboardWriter.utiInternalType])
+        registerForDraggedTypes([.URL, .fileURL, TabBarViewItemPasteboardWriter.utiInternalType, .string])
         // Enable dragging items within and into our CollectionView.
         setDraggingSourceOperationMask([.private], forLocal: true)
     }

--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -991,14 +991,9 @@ extension TabBarViewController: NSCollectionViewDelegate {
             tabCollectionViewModel.insert(Tab(content: .url(url, source: .appOpenUrl), burnerMode: tabCollectionViewModel.burnerMode),
                                           at: .unpinned(newIndex),
                                           selected: true)
-
             return true
-        } else if let string = draggingInfo.draggingPasteboard.string(forType: .string),
-                    let url = URL.makeSearchUrl(from: string),
-                    let index = tabCollectionViewModel.selectionIndex {
-            let tab = Tab(content: .url(url, credential: nil, source: .reload), title: "\(string) at DuckDuckGo", shouldLoadInBackground: true, burnerMode: tabCollectionViewModel.burnerMode)
-            tabCollectionViewModel.replaceTab(at: index, with: tab, forceChange: true)
-            collectionView.reloadData()
+        } else if let string = draggingInfo.draggingPasteboard.string(forType: .string), let url = URL.makeSearchUrl(from: string) {
+            tabCollectionViewModel.insertOrAppendNewTab(.url(url, credential: nil, source: .reload))
             return true
         }
 
@@ -1259,6 +1254,21 @@ extension TabBarViewController: TabBarViewItemDelegate {
               let tab = tabCollectionViewModel.tabCollection.tabs[safe: indexPath.item] else { return nil }
 
         return tab.audioState
+    }
+
+    func tabBarViewItem(_ tabBarViewItem: TabBarViewItem, replaceWithStringSearch: String) {
+        guard let indexPath = collectionView.indexPath(for: tabBarViewItem),
+              let tab = tabCollectionViewModel.tabCollection.tabs[safe: indexPath.item],
+              let tabIndex = tabCollectionViewModel.indexInAllTabs(of: tab) else { return }
+
+        if let url = URL.makeSearchUrl(from: replaceWithStringSearch) {
+            let tab = Tab(content: .url(url, credential: nil, source: .reload),
+                          shouldLoadInBackground: true,
+                          burnerMode: tabCollectionViewModel.burnerMode)
+            tabCollectionViewModel.replaceTab(at: tabIndex, with: tab, forceChange: true)
+            tabCollectionViewModel.select(tab: tab)
+            collectionView.reloadData()
+        }
     }
 
     func otherTabBarViewItemsState(for tabBarViewItem: TabBarViewItem) -> OtherTabBarViewItemsState {

--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -641,7 +641,7 @@ extension TabBarViewController: MouseOverButtonDelegate {
 
     func mouseOverButton(_ sender: MouseOverButton, performDragOperation info: any NSDraggingInfo) -> Bool {
         assert(sender === addTabButton || sender === footerAddButton)
-        if let string = info.draggingPasteboard.string(forType: .string), let url = URL.makeSearchUrl(from: string) {
+        if let string = info.draggingPasteboard.string(forType: .string), let url = URL.makeURL(from: string) {
             tabCollectionViewModel.insertOrAppendNewTab(.url(url, credential: nil, source: .ui))
             return true
         }
@@ -992,7 +992,7 @@ extension TabBarViewController: NSCollectionViewDelegate {
                                           at: .unpinned(newIndex),
                                           selected: true)
             return true
-        } else if let string = draggingInfo.draggingPasteboard.string(forType: .string), let url = URL.makeSearchUrl(from: string) {
+        } else if let string = draggingInfo.draggingPasteboard.string(forType: .string), let url = URL.makeURL(from: string) {
             tabCollectionViewModel.insertOrAppendNewTab(.url(url, credential: nil, source: .reload))
             return true
         }
@@ -1258,16 +1258,10 @@ extension TabBarViewController: TabBarViewItemDelegate {
 
     func tabBarViewItem(_ tabBarViewItem: TabBarViewItem, replaceWithStringSearch: String) {
         guard let indexPath = collectionView.indexPath(for: tabBarViewItem),
-              let tab = tabCollectionViewModel.tabCollection.tabs[safe: indexPath.item],
-              let tabIndex = tabCollectionViewModel.indexInAllTabs(of: tab) else { return }
+              let tab = tabCollectionViewModel.tabCollection.tabs[safe: indexPath.item] else { return }
 
-        if let url = URL.makeSearchUrl(from: replaceWithStringSearch) {
-            let tab = Tab(content: .url(url, credential: nil, source: .reload),
-                          shouldLoadInBackground: true,
-                          burnerMode: tabCollectionViewModel.burnerMode)
-            tabCollectionViewModel.replaceTab(at: tabIndex, with: tab, forceChange: true)
-            tabCollectionViewModel.select(tab: tab)
-            collectionView.reloadData()
+        if let url = URL.makeURL(from: replaceWithStringSearch) {
+            tab.setContent(.url(url, credential: nil, source: .reload))
         }
     }
 

--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -969,6 +969,11 @@ extension TabBarViewController: NSCollectionViewDelegate {
         // allow dropping URLs or files
         guard draggingInfo.draggingPasteboard.url == nil else { return .copy }
 
+        // Check if the pasteboard contains string data
+        if draggingInfo.draggingPasteboard.availableType(from: [.string]) != nil {
+            return .copy
+        }
+
         // dragging a tab
         guard case .private = draggingInfo.draggingSourceOperationMask,
               draggingInfo.draggingPasteboard.types == [TabBarViewItemPasteboardWriter.utiInternalType] else { return .none }
@@ -987,6 +992,13 @@ extension TabBarViewController: NSCollectionViewDelegate {
                                           at: .unpinned(newIndex),
                                           selected: true)
 
+            return true
+        } else if let string = draggingInfo.draggingPasteboard.string(forType: .string),
+                    let url = URL.makeSearchUrl(from: string),
+                    let index = tabCollectionViewModel.selectionIndex {
+            let tab = Tab(content: .url(url, credential: nil, source: .reload), title: "\(string) at DuckDuckGo", shouldLoadInBackground: true, burnerMode: tabCollectionViewModel.burnerMode)
+            tabCollectionViewModel.replaceTab(at: index, with: tab, forceChange: true)
+            collectionView.reloadData()
             return true
         }
 

--- a/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -52,6 +52,7 @@ protocol TabBarViewItemDelegate: AnyObject {
     func tabBarViewItemMuteUnmuteSite(_ tabBarViewItem: TabBarViewItem)
     func tabBarViewItemRemoveFireproofing(_ tabBarViewItem: TabBarViewItem)
     func tabBarViewItemAudioState(_ tabBarViewItem: TabBarViewItem) -> WKWebView.AudioState?
+    func tabBarViewItem(_ tabBarViewItem: TabBarViewItem, replaceWithStringSearch: String)
 
     func otherTabBarViewItemsState(for tabBarViewItem: TabBarViewItem) -> OtherTabBarViewItemsState
 
@@ -393,6 +394,9 @@ final class TabBarViewItem: NSCollectionViewItem {
         } else {
             faviconImageView.contentTintColor = nil
         }
+
+        mouseOverView.registerForDraggedTypes([.string])
+        mouseOverView.delegate = self
     }
 
     private var usedPermissions = Permissions() {
@@ -664,6 +668,20 @@ extension TabBarViewItem: MouseClickViewDelegate {
         delegate?.tabBarViewItemCloseAction(self)
     }
 
+    func mouseOverView(_ sender: MouseOverView, performDragOperation info: any NSDraggingInfo) -> Bool {
+        if let droppedString = info.draggingPasteboard.string(forType: .string) {
+            delegate?.tabBarViewItem(self, replaceWithStringSearch: droppedString)
+            return true
+        }
+        return false
+    }
+
+    func mouseOverView(_ sender: MouseOverView, draggingEntered info: any NSDraggingInfo, isMouseOver: UnsafeMutablePointer<Bool>) -> NSDragOperation {
+        if info.draggingPasteboard.availableType(from: [.string]) != nil {
+            return .copy
+        }
+        return []
+    }
 }
 
 extension TabBarViewItem {

--- a/UnitTests/TabBar/View/MockTabViewItemDelegate.swift
+++ b/UnitTests/TabBar/View/MockTabViewItemDelegate.swift
@@ -125,6 +125,10 @@ class MockTabViewItemDelegate: TabBarViewItemDelegate {
         OtherTabBarViewItemsState(hasItemsToTheLeft: hasItemsToTheLeft, hasItemsToTheRight: hasItemsToTheRight)
     }
 
+    func tabBarViewItem(_ tabBarViewItem: TabBarViewItem, replaceWithStringSearch: String) {
+
+    }
+
     func clear() {
         self.audioState = nil
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208209124965669/f
Tech Design URL:
CC:

**Description**:
This update adds support for dragging strings to the new tab button and the tab bar. 
- When a string is dropped to the new tab button, it opens a new tab with a search on the dropped string.
- When a string is dropped to the current tab (both regular and pinned tabs), the tab gets replaced by a search for the dropped string.
- When a string is dropped in the tab bar. For example, at the right of the + button when there is room, it should open a new search with the dropped string.

This request came from: https://github.com/duckduckgo/macos-browser/issues/3189


https://github.com/user-attachments/assets/d507c762-066a-4022-8813-5b82747b55c0


**Steps to test this PR**:
**Verify new tab is open with a DDG search when a string is dragged to the + button or the tab bar**
1. Drag some text (it could be from a website inside the browser, or any other app) to the new tab button or the tab bar
2. Verify a new tab is open with the dragged text

**Verify current tab is replaced with a DDG search when text is dragged to the tab (either regular or pinned tabs)**
1. Drag some text (it could be from a website inside the browser, or any other app) to a tab (either selected or not)
2. Verify the tab is replaced with a DDG search with the dragged string
3. If the tab was not selected it should now

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
