### PR TITLE
Fix "Show VPN in browser toolbar" setting

### DIFF
--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1011,12 +1011,11 @@ extension NavigationBarViewController: NSMenuDelegate {
             }
             .store(in: &cancellables)
 
-        networkProtectionButtonModel.$showButton
-            .removeDuplicates()
+        networkProtectionButtonModel.$showVPNButton
             .receive(on: RunLoop.main)
             .sink { [weak self] show in
                 let isPopUpWindow = self?.view.window?.isPopUpWindow ?? false
-                self?.networkProtectionButton.isHidden =  isPopUpWindow || !show
+                self?.networkProtectionButton.isHidden = isPopUpWindow || !show
             }
             .store(in: &cancellables)
 

--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
@@ -46,7 +46,7 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
     private let pinningManager: PinningManager
 
     @Published
-    private(set) var showButton = false {
+    private(set) var showVPNButton = false {
         didSet {
             shortcutTitle = pinningManager.shortcutTitle(for: .networkProtection)
         }
@@ -138,11 +138,11 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
               !isHavingConnectivityIssues else {
 
             pinNetworkProtectionToNavBarIfNeverPinnedBefore()
-            showButton = true
+            showVPNButton = true
             return
         }
 
-        showButton = false
+        showVPNButton = false
     }
 
     // MARK: - Pinning


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1208255115319777/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue where the "Show VPN in browser toolbar" setting wasn't worked properly when disabled. Specifically, if you disabled this setting then opened the panel from the "..." menu, the VPN button stayed visible.

**Steps to test this PR**:
1. Sign into Privacy Pro
2. Go into the app settings, then in the VPN settings panel disable "Show VPN in browser toolbar"
3. Open the "..." the open the VPN popover from the Privacy Pro option
4. Close the panel and make sure that the VPN button disappears
5. Check that enabling the  "Show VPN in browser toolbar" setting still keeps the button around permanently

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
