### PR TITLE
Use macos-14 for DMG creation and create DMG with APFS filesystem

### DIFF
--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -258,7 +258,7 @@ jobs:
     if: ${{ github.event.inputs.create-dmg == true || inputs.create-dmg == true }}
 
     # use macos-12 for creating DMGs as macos-13 beta runners can't run AppleScript: https://app.asana.com/0/0/1204523592790998/f
-    runs-on: macos-12
+    runs-on: macos-14
 
     env:
       app-version: ${{ needs.export-notarized-app.outputs.app-version }}
@@ -306,7 +306,9 @@ jobs:
         dmg="duckduckgo-${{ env.app-version }}.dmg"
         curl -fLSs $(gh api https://api.github.com/repos/${{ github.repository }}/contents/scripts/assets/dmg-background.png?ref=${{ github.ref }} --jq .download_url) \
             --output dmg-background.png
+        # Using APFS filesystem as per https://github.com/actions/runner-images/issues/7522#issuecomment-2299918092
         create-dmg --volname "${{ env.app-name }}" \
+            --filesystem APFS \
             --icon "${{ env.app-name }}.app" 140 160 \
             --background "dmg-background.png" \
             --window-size 600 400 \

--- a/.github/workflows/create_variant.yml
+++ b/.github/workflows/create_variant.yml
@@ -99,7 +99,7 @@ jobs:
       ATB_VARIANT_NAME: ${{ inputs.atb-variant || github.event.inputs.atb-variant }}
       ORIGIN_VARIANT_NAME: ${{ inputs.origin-variant || github.event.inputs.origin-variant }}
 
-    runs-on: macos-12
+    runs-on: macos-14
     timeout-minutes: 15
 
     steps:
@@ -214,7 +214,9 @@ jobs:
         retries=3
 
         while [[ $retries -gt 0 ]]; do
+          # Using APFS filesystem as per https://github.com/actions/runner-images/issues/7522#issuecomment-2299918092
           if create-dmg --volname "DuckDuckGo" \
+            --filesystem APFS \
             --icon "DuckDuckGo.app" 140 160 \
             --background "scripts/assets/dmg-background.png" \
             --window-size 600 400 \

--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -296,7 +296,9 @@ create_dmg() {
 	rm -rf "${dmg_dir}" "${dmg_output_path}"
 	mkdir -p "${dmg_dir}"
 	cp -R "${app_path}" "${dmg_dir}"
+	# Using APFS filesystem as per https://github.com/actions/runner-images/issues/7522#issuecomment-2299918092
 	${filter_output} create-dmg --volname "${app_name}" \
+		--filesystem APFS \
 		--icon "${app_name}.app" 140 160 \
 		--background "${dmg_background}" \
 		--window-size 600 400 \


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1205305773210819/f

**Description**:
Update to macos-14 to remove our dependency on the legacy macos-12 runner, while also speeding up
DMG creation by using APFS filesystem for DMG images.

**Steps to test this PR**:
Verify that [this workflow](https://github.com/duckduckgo/macos-browser/actions/runs/10772646407) has gone all green on the first run 🚀 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
