### PR TITLE
Fix Flaky Phishing Detection Integration Tests

### DIFF
--- a/IntegrationTests/PhishingDetection/PhishingDetectionIntegrationTests.swift
+++ b/IntegrationTests/PhishingDetection/PhishingDetectionIntegrationTests.swift
@@ -61,7 +61,7 @@ class PhishingDetectionIntegrationTests: XCTestCase {
     // MARK: - Tests
 
     @MainActor
-    func testPhishingNotDetected_tabIsNotMarkedPhishing() throws {
+    func testPhishingNotDetected_tabIsNotMarkedPhishing() {
         loadUrl("http://privacy-test-pages.site/")
         let expectation = XCTestExpectation()
         tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
@@ -85,7 +85,7 @@ class PhishingDetectionIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testFeatureDisabledAndPhishingDetection_tabIsNotMarkedPhishing() throws {
+    func testFeatureDisabledAndPhishingDetection_tabIsNotMarkedPhishing() {
         PhishingDetectionPreferences.shared.isEnabled = false
         loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
         let expectation = XCTestExpectation()
@@ -98,7 +98,7 @@ class PhishingDetectionIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testPhishingDetectedThenNotDetected_tabIsNotMarkedPhishing() throws {
+    func testPhishingDetectedThenNotDetected_tabIsNotMarkedPhishing() {
         loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
         let expectation = XCTestExpectation()
         tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
@@ -119,7 +119,7 @@ class PhishingDetectionIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testPhishingDetectedThenDDGLoaded_tabIsNotMarkedPhishing() throws {
+    func testPhishingDetectedThenDDGLoaded_tabIsNotMarkedPhishing() {
         loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
         let expectation = XCTestExpectation()
         tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
@@ -140,7 +140,7 @@ class PhishingDetectionIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testPhishingDetectedViaHTTPRedirectChain_tabIsMarkedPhishing() throws {
+    func testPhishingDetectedViaHTTPRedirectChain_tabIsMarkedPhishing() {
         loadUrl("http://privacy-test-pages.site/security/badware/phishing-redirect/")
         let expectation = XCTestExpectation()
         tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
@@ -152,7 +152,7 @@ class PhishingDetectionIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testPhishingDetectedViaJSRedirectChain_tabIsMarkedPhishing() throws {
+    func testPhishingDetectedViaJSRedirectChain_tabIsMarkedPhishing() {
         loadUrl("http://privacy-test-pages.site/security/badware/phishing-js-redirector.html")
         let expectation = XCTestExpectation()
         tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
@@ -169,18 +169,6 @@ class PhishingDetectionIntegrationTests: XCTestCase {
     private func loadUrl(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         tab.navigateTo(url: url)
-    }
-
-    @MainActor
-    func waitForTabToFinishLoading() async throws {
-        let loadingExpectation = expectation(description: "Tab finished loading")
-        Task {
-            while tabViewModel.tab.isLoading {
-                await Task.yield()
-            }
-            loadingExpectation.fulfill()
-        }
-        await fulfillment(of: [loadingExpectation], timeout: 5)
     }
 }
 

--- a/IntegrationTests/PhishingDetection/PhishingDetectionIntegrationTests.swift
+++ b/IntegrationTests/PhishingDetection/PhishingDetectionIntegrationTests.swift
@@ -1,3 +1,5 @@
+@ -0,0 +1,193 @@
+
 //
 //  PhishingDetectionIntegrationTests.swift
 //
@@ -61,70 +63,108 @@ class PhishingDetectionIntegrationTests: XCTestCase {
     // MARK: - Tests
 
     @MainActor
-    func testPhishingNotDetected_tabIsNotMarkedPhishing() async throws {
+    func testPhishingNotDetected_tabIsNotMarkedPhishing() throws {
         loadUrl("http://privacy-test-pages.site/")
-        let tabErrorCode2 = tabViewModel.tab.error?.errorCode
-        XCTAssertNil(tabErrorCode2)
-    }
-
-    @MainActor
-    func testPhishingDetected_tabIsMarkedPhishing() async throws {
-        loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
-        try await waitForTabToFinishLoading()
-        let tabErrorCode = tabViewModel.tab.error?.errorCode
-        XCTAssertEqual(tabErrorCode, PhishingDetectionError.detected.errorCode)
-    }
-
-    @MainActor
-    func testFeatureDisabledAndPhishingDetection_tabIsNotMarkedPhishing() async throws {
-        PhishingDetectionPreferences.shared.isEnabled = false
-        loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
-        try await waitForTabToFinishLoading()
+        let expectation = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
         let tabErrorCode = tabViewModel.tab.error?.errorCode
         XCTAssertNil(tabErrorCode)
     }
 
     @MainActor
-    func testPhishingDetectedThenNotDetected_tabIsNotMarkedPhishing() async throws {
+    func testPhishingDetected_tabIsMarkedPhishing() {
         loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
-        try await waitForTabToFinishLoading()
+        let expectation = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+        let tabErrorCode = tabViewModel.tab.error?.errorCode
+        XCTAssertEqual(tabErrorCode, PhishingDetectionError.detected.errorCode)
+    }
+
+    @MainActor
+    func testFeatureDisabledAndPhishingDetection_tabIsNotMarkedPhishing() throws {
+        PhishingDetectionPreferences.shared.isEnabled = false
+        loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
+        let expectation = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+        let tabErrorCode = tabViewModel.tab.error?.errorCode
+        XCTAssertNil(tabErrorCode)
+    }
+
+    @MainActor
+    func testPhishingDetectedThenNotDetected_tabIsNotMarkedPhishing() throws {
+        loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
+        let expectation = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
         let tabErrorCode = tabViewModel.tab.error?.errorCode
         XCTAssertEqual(tabErrorCode, PhishingDetectionError.detected.errorCode)
 
         loadUrl("http://broken.third-party.site/")
-        try await waitForTabToFinishLoading()
+        let expectation2 = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation2.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation2], timeout: 5)
         let tabErrorCode2 = tabViewModel.tab.error?.errorCode
         XCTAssertNil(tabErrorCode2)
     }
 
     @MainActor
-    func testPhishingDetectedThenDDGLoaded_tabIsNotMarkedPhishing() async throws {
+    func testPhishingDetectedThenDDGLoaded_tabIsNotMarkedPhishing() throws {
         loadUrl("http://privacy-test-pages.site/security/badware/phishing.html")
-        try await waitForTabToFinishLoading()
+        let expectation = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
         let tabErrorCode = tabViewModel.tab.error?.errorCode
         XCTAssertEqual(tabErrorCode, PhishingDetectionError.detected.errorCode)
 
         loadUrl("http://duckduckgo.com/")
-        try await waitForTabToFinishLoading()
+        let expectation2 = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation2.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation2], timeout: 5)
         let tabErrorCode2 = tabViewModel.tab.error?.errorCode
         XCTAssertNil(tabErrorCode2)
     }
 
     @MainActor
-    func testPhishingDetectedViaHTTPRedirectChain_tabIsMarkedPhishing() async throws {
+    func testPhishingDetectedViaHTTPRedirectChain_tabIsMarkedPhishing() throws {
         loadUrl("http://privacy-test-pages.site/security/badware/phishing-redirect/")
-        try await waitForTabToFinishLoading()
+        let expectation = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
         let tabErrorCode = tabViewModel.tab.error?.errorCode
         XCTAssertEqual(tabErrorCode, PhishingDetectionError.detected.errorCode)
     }
 
     @MainActor
-    func testPhishingDetectedViaJSRedirectChain_tabIsMarkedPhishing() async throws {
+    func testPhishingDetectedViaJSRedirectChain_tabIsMarkedPhishing() throws {
         loadUrl("http://privacy-test-pages.site/security/badware/phishing-js-redirector.html")
-        try await waitForTabToFinishLoading()
+        let expectation = XCTestExpectation()
+        tabViewModel?.tab.webViewDidFinishNavigationPublisher.sink {
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
         let tabErrorCode = tabViewModel.tab.error?.errorCode
         XCTAssertEqual(tabErrorCode, PhishingDetectionError.detected.errorCode)
     }
+
 
     // MARK: - Helper Methods
 

--- a/IntegrationTests/PhishingDetection/PhishingDetectionIntegrationTests.swift
+++ b/IntegrationTests/PhishingDetection/PhishingDetectionIntegrationTests.swift
@@ -1,5 +1,3 @@
-@ -0,0 +1,193 @@
-
 //
 //  PhishingDetectionIntegrationTests.swift
 //
@@ -164,7 +162,6 @@ class PhishingDetectionIntegrationTests: XCTestCase {
         let tabErrorCode = tabViewModel.tab.error?.errorCode
         XCTAssertEqual(tabErrorCode, PhishingDetectionError.detected.errorCode)
     }
-
 
     // MARK: - Helper Methods
 

--- a/IntegrationTests/PrivacyDashboard/PrivacyDashboardIntegrationTests.swift
+++ b/IntegrationTests/PrivacyDashboard/PrivacyDashboardIntegrationTests.swift
@@ -85,26 +85,4 @@ class PrivacyDashboardIntegrationTests: XCTestCase {
         let trackersCount2 = try await trackersCountPromise2.value
         XCTAssertEqual(trackersCount2, 0)
     }
-
-    @MainActor
-    func testWhenPhishingDetected_phishingInfoUpdated() async throws {
-        let tabViewModel = self.tabViewModel
-        let tab = tabViewModel.tab
-
-        let isPhishingPromise = tab.privacyInfoPublisher
-            .compactMap {
-                $0?.$isPhishing
-            }
-            .map { _ in true }
-            .timeout(10)
-            .first()
-            .promise()
-        // Load the test page
-        let url = URL(string: "http://privacy-test-pages.site/security/badware/phishing.html")!
-        _ = await tab.setUrl(url, source: .link)?.result
-
-        let isPhishing = try await isPhishingPromise.value
-        XCTAssertTrue(isPhishing)
-    }
-
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208253815417569/f
Tech Design URL:
CC:

**Description**:
Although the tests passed reliably locally, they are currently flaky in CI, due to the timeouts in waitForPageToLoad. Instead we introduce the same pattern we use for PrivacyDashboard and other ErrorPage tests:
```
let isPhishingPromise = tab.privacyInfoPublisher
    .compactMap { $0?.$isPhishing }
    .map { _ in expectedIsPhishing }
    .timeout(10)
    .first()
    .promise()
let navigationFailedPromise = tab.$error.compactMap { $0 }.timeout(5).first().promise()
```
This allows us to not have to wait for particular navigation events, but instead wait for changes in internal state, which should be significantly more reliable.

**Steps to test this PR**:
1. Run PhishingDetectionIntegrationTests.
2. Ensure they all pass reliably.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
