### PR TITLE
Freemium PIR: Improve Feature Availability Checks By Observing Config & Subscription Changes

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -2720,8 +2720,8 @@
 		C126B35B2C820924005DC2A3 /* FreemiumDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = C126B3592C820924005DC2A3 /* FreemiumDebugMenu.swift */; };
 		C1351DD12C8B31CE0086B058 /* NotificationName+Freemium.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1351DD02C8B31CE0086B058 /* NotificationName+Freemium.swift */; };
 		C1351DD22C8B31CE0086B058 /* NotificationName+Freemium.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1351DD02C8B31CE0086B058 /* NotificationName+Freemium.swift */; };
-		C1351DD42C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1351DD32C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatorTests.swift */; };
-		C1351DD52C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1351DD32C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatorTests.swift */; };
+		C1351DD42C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1351DD32C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatingTests.swift */; };
+		C1351DD52C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1351DD32C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatingTests.swift */; };
 		C1372EF42BBC5BAD003F8793 /* SecureTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1372EF32BBC5BAD003F8793 /* SecureTextField.swift */; };
 		C1372EF52BBC5BAD003F8793 /* SecureTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1372EF32BBC5BAD003F8793 /* SecureTextField.swift */; };
 		C13909EF2B85FD4E001626ED /* AutofillActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13909EE2B85FD4E001626ED /* AutofillActionExecutor.swift */; };
@@ -4535,7 +4535,7 @@
 		C11198332C89AEFA00F0272C /* FreemiumDBPFirstProfileSavedNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumDBPFirstProfileSavedNotifierTests.swift; sourceTree = "<group>"; };
 		C126B3592C820924005DC2A3 /* FreemiumDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumDebugMenu.swift; sourceTree = "<group>"; };
 		C1351DD02C8B31CE0086B058 /* NotificationName+Freemium.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+Freemium.swift"; sourceTree = "<group>"; };
-		C1351DD32C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumDBPPromotionViewCoordinatorTests.swift; sourceTree = "<group>"; };
+		C1351DD32C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumDBPPromotionViewCoordinatingTests.swift; sourceTree = "<group>"; };
 		C1372EF32BBC5BAD003F8793 /* SecureTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureTextField.swift; sourceTree = "<group>"; };
 		C13909EE2B85FD4E001626ED /* AutofillActionExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillActionExecutor.swift; sourceTree = "<group>"; };
 		C13909F32B85FD79001626ED /* AutofillDeleteAllPasswordsExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillDeleteAllPasswordsExecutorTests.swift; sourceTree = "<group>"; };
@@ -8988,7 +8988,7 @@
 				C18194662C7F60E500381092 /* FreemiumDBPPresenterTests.swift */,
 				C1CE846B2C88868D0068913B /* FreemiumDBPScanResultPollingTests.swift */,
 				C11198332C89AEFA00F0272C /* FreemiumDBPFirstProfileSavedNotifierTests.swift */,
-				C1351DD32C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatorTests.swift */,
+				C1351DD32C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatingTests.swift */,
 			);
 			path = DBP;
 			sourceTree = "<group>";
@@ -11468,7 +11468,7 @@
 				3706FE08293F661700E42796 /* WKWebsiteDataStoreExtensionTests.swift in Sources */,
 				3706FE09293F661700E42796 /* VariantManagerTests.swift in Sources */,
 				3706FE0A293F661700E42796 /* UserAgentTests.swift in Sources */,
-				C1351DD52C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatorTests.swift in Sources */,
+				C1351DD52C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatingTests.swift in Sources */,
 				3706FE0B293F661700E42796 /* AVCaptureDeviceMock.swift in Sources */,
 				9FBD84572BB3ACFD00220859 /* AttributionOriginFileProviderTests.swift in Sources */,
 				7B4C5CF62BE51D640007A164 /* VPNUninstallerTests.swift in Sources */,
@@ -13186,7 +13186,7 @@
 				37DB56F22C3B36B80093D4DC /* RemoteMessagingClientTests.swift in Sources */,
 				4B9292C32667103100AD2C21 /* PasteboardBookmarkTests.swift in Sources */,
 				F1AFDBD22C231B7A00710F2C /* SubscriptionAppStoreRestorerTests.swift in Sources */,
-				C1351DD42C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatorTests.swift in Sources */,
+				C1351DD42C8B53500086B058 /* FreemiumDBPPromotionViewCoordinatingTests.swift in Sources */,
 				B610F2E427A8F37A00FCEBE9 /* CBRCompileTimeReporterTests.swift in Sources */,
 				AABAF59C260A7D130085060C /* FaviconManagerMock.swift in Sources */,
 				37D046A42C7DAA8900AEAA50 /* ImageProcessorMock.swift in Sources */,

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -98,6 +98,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     public let subscriptionUIHandler: SubscriptionUIHandling
 
     // MARK: - Freemium DBP
+    public let freemiumDBPFeature: FreemiumDBPFeature
     private var freemiumDBPScanResultPolling: FreemiumDBPScanResultPolling?
 
     // MARK: - VPN
@@ -267,6 +268,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Update DBP environment and match the Subscription environment
         DataBrokerProtectionSettings().alignTo(subscriptionEnvironment: subscriptionManager.currentEnvironment)
+
+        // Freemium DBP
+        let freemiumPIRUserStateManager = DefaultFreemiumPIRUserStateManager(userDefaults: .dbp)
+        freemiumPIRFeature = DefaultFreemiumPIRFeature(privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
+                                                                     subscriptionManager: subscriptionManager,
+                                                                     accountManager: subscriptionManager.accountManager,
+                                                       freemiumPIRUserStateManager: freemiumPIRUserStateManager)
     }
 
     func applicationWillFinishLaunching(_ notification: Notification) {
@@ -291,6 +299,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         networkProtectionSubscriptionEventHandler = NetworkProtectionSubscriptionEventHandler(subscriptionManager: subscriptionManager,
                                                                                               tunnelController: tunnelController,
                                                                                               vpnUninstaller: vpnUninstaller)
+
+        // Freemium DBP
+        freemiumPIRFeature.subscribeToDependencyUpdates()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -270,11 +270,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DataBrokerProtectionSettings().alignTo(subscriptionEnvironment: subscriptionManager.currentEnvironment)
 
         // Freemium DBP
-        let freemiumPIRUserStateManager = DefaultFreemiumPIRUserStateManager(userDefaults: .dbp)
-        freemiumPIRFeature = DefaultFreemiumPIRFeature(privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
+        let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
+        freemiumDBPFeature = DefaultFreemiumDBPFeature(privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
                                                                      subscriptionManager: subscriptionManager,
                                                                      accountManager: subscriptionManager.accountManager,
-                                                       freemiumPIRUserStateManager: freemiumPIRUserStateManager)
+                                                       freemiumDBPUserStateManager: freemiumDBPUserStateManager)
     }
 
     func applicationWillFinishLaunching(_ notification: Notification) {
@@ -301,7 +301,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                                                               vpnUninstaller: vpnUninstaller)
 
         // Freemium DBP
-        freemiumPIRFeature.subscribeToDependencyUpdates()
+        freemiumDBPFeature.subscribeToDependencyUpdates()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
@@ -61,7 +61,7 @@ final class DefaultFreemiumDBPFeature: FreemiumDBPFeature {
     ///
     /// Subscribers receive updates when changes occur in the privacy configuration or user subscription status.
     var isAvailablePublisher: AnyPublisher<Bool, Never> {
-        passthroughPublisher.eraseToAnyPublisher()
+        isAvailableSubject.eraseToAnyPublisher()
     }
 
     // MARK: - Private Properties
@@ -72,7 +72,7 @@ final class DefaultFreemiumDBPFeature: FreemiumDBPFeature {
     private let notificationCenter: NotificationCenter
     private lazy var featureDisabler: DataBrokerProtectionFeatureDisabling = DataBrokerProtectionFeatureDisabler()
 
-    private let passthroughPublisher = PassthroughSubject<Bool, Never>()
+    private let isAvailableSubject = PassthroughSubject<Bool, Never>()
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Initialization
@@ -122,7 +122,7 @@ final class DefaultFreemiumDBPFeature: FreemiumDBPFeature {
                 let featureAvailable = self.isAvailable
                 Logger.freemiumDBP.debug("[Freemium DBP] Privacy Config Updated. Feature Availability = \(featureAvailable)")
 
-                self.passthroughPublisher.send(featureAvailable)
+                self.isAvailableSubject.send(featureAvailable)
 
                 self.offBoardIfNecessary()
             }
@@ -136,7 +136,7 @@ final class DefaultFreemiumDBPFeature: FreemiumDBPFeature {
                 let featureAvailable = self.isAvailable
                 Logger.freemiumDBP.debug("[Freemium DBP] Subscription Updated. Feature Availability = \(featureAvailable)")
 
-                self.passthroughPublisher.send(featureAvailable)
+                self.isAvailableSubject.send(featureAvailable)
             }
             .store(in: &cancellables)
     }

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
@@ -20,46 +20,125 @@ import Foundation
 import BrowserServicesKit
 import Subscription
 import Freemium
+import Combine
+import OSLog
 
-/// Conforming types encapsulate logic relating to the Freemium DBP Feature (e.g Feature Availability etc.)
+/// A protocol that defines the behavior for the Freemium DBP feature.
+/// This protocol provides the ability to check the availability of the feature and subscribe to updates
+/// from various dependencies, such as privacy configurations and user subscriptions.
 protocol FreemiumDBPFeature {
+
+    /// A boolean value indicating whether the Freemium DBP feature is currently available.
     var isAvailable: Bool { get }
+
+    /// A publisher that emits updates when the availability of the Freemium DBP feature changes.
+    /// The publisher emits a `Bool` value indicating whether the feature is available.
+    var isAvailablePublisher: AnyPublisher<Bool, Never> { get }
+
+    /// Subscribes to updates from dependencies, including privacy configurations and notifications
+    /// such as subscription changes, and triggers updates for feature availability accordingly.
+    func subscribeToDependencyUpdates()
 }
 
-/// Default implementation of `FreemiumDBPFeature`
+/// The default implementation of the `FreemiumDBPFeature` protocol.
+/// This class manages the Freemium Personal Information Removal (DBP) feature, including
+/// determining its availability based on privacy configurations and user subscription status.
+/// It listens for updates from multiple dependencies, including privacy configurations
+/// and subscription changes, and notifies subscribers accordingly.
 final class DefaultFreemiumDBPFeature: FreemiumDBPFeature {
 
-    private let featureFlagger: FeatureFlagger
+    /// A boolean value indicating whether the Freemium DBP feature is currently available.
+    ///
+    /// The feature is considered available if:
+    /// 1. It is enabled in the privacy configuration (`DBPSubfeature.freemium`), and
+    /// 2. The user is a potential privacy pro subscriber.
+    var isAvailable: Bool {
+        privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(DBPSubfeature.freemium)
+        && isPotentialPrivacyProSubscriber
+    }
+
+    /// A publisher that emits updates when the availability of the Freemium DBP feature changes.
+    ///
+    /// Subscribers receive updates when changes occur in the privacy configuration or user subscription status.
+    var isAvailablePublisher: AnyPublisher<Bool, Never> {
+        passthroughPublisher.eraseToAnyPublisher()
+    }
+
+    // MARK: - Private Properties
+    private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let subscriptionManager: SubscriptionManager
     private let accountManager: AccountManager
     private var freemiumDBPUserStateManager: FreemiumDBPUserStateManager
-    private let featureDisabler: DataBrokerProtectionFeatureDisabling
+    private let notificationCenter: NotificationCenter
+    private lazy var featureDisabler: DataBrokerProtectionFeatureDisabling = DataBrokerProtectionFeatureDisabler()
 
-    var isAvailable: Bool {
-        /* Freemium DBP availability criteria:
-            1. Feature Flag enabled
-            2. Privacy Pro Available
-            3. Not a current Privacy Pro subscriber
-            4. (Temp) In experiment cohort
-         */
-        featureFlagger.isFeatureOn(.freemiumDBP) // #1
-        && isPotentialPrivacyProSubscriber // #2 & #3
-        // TODO: - Also check experiment cohort here
-    }
+    private let passthroughPublisher = PassthroughSubject<Bool, Never>()
+    private var cancellables = Set<AnyCancellable>()
 
-    init(featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
+    // MARK: - Initialization
+
+    /// Initializes a new instance of the `DefaultFreemiumDBPFeature`.
+    ///
+    /// - Parameters:
+    ///   - privacyConfigurationManager: Manages privacy configurations for the app.
+    ///   - subscriptionManager: Manages subscriptions for the user.
+    ///   - accountManager: Manages user account details.
+    ///   - freemiumDBPUserStateManager: Manages the user state for Freemium DBP.
+    ///   - notificationCenter: Observes notifications, defaulting to `.default`.
+    ///   - featureDisabler: Optional feature disabler. If not provided, the default `DataBrokerProtectionFeatureDisabler` is used.
+    init(privacyConfigurationManager: PrivacyConfigurationManaging,
          subscriptionManager: SubscriptionManager,
          accountManager: AccountManager,
          freemiumDBPUserStateManager: FreemiumDBPUserStateManager,
-         featureDisabler: DataBrokerProtectionFeatureDisabling = DataBrokerProtectionFeatureDisabler()) {
+         notificationCenter: NotificationCenter = .default,
+         featureDisabler: DataBrokerProtectionFeatureDisabling? = nil) {
 
-        self.featureFlagger = featureFlagger
+        self.privacyConfigurationManager = privacyConfigurationManager
         self.subscriptionManager = subscriptionManager
         self.accountManager = accountManager
         self.freemiumDBPUserStateManager = freemiumDBPUserStateManager
-        self.featureDisabler = featureDisabler
+        self.notificationCenter = notificationCenter
 
-        offBoardIfNecessary()
+        // Use the provided feature disabler if available, otherwise initialize lazily.
+        if let featureDisabler = featureDisabler {
+            self.featureDisabler = featureDisabler
+        }
+    }
+
+    // MARK: - Public Methods
+
+    /// Subscribes to updates from dependencies such as privacy configuration changes and
+    /// subscription-related notifications.
+    ///
+    /// - When the privacy configuration is updated, it checks whether the Freemium DBP feature
+    ///   is still available based on the user's subscription status and the current privacy settings.
+    /// - When the user's subscription changes, it also triggers a re-evaluation of the feature's availability.
+    func subscribeToDependencyUpdates() {
+        // Subscribe to privacy configuration updates
+        privacyConfigurationManager.updatesPublisher
+            .sink { [weak self] in
+                guard let self = self else { return }
+
+                let featureAvailable = self.isAvailable
+                Logger.freemiumDBP.debug("[Freemium DBP] Privacy Config Updated. Feature Availability = \(featureAvailable)")
+
+                self.passthroughPublisher.send(featureAvailable)
+
+                self.offBoardIfNecessary()
+            }
+            .store(in: &cancellables)
+
+        // Subscribe to notifications about subscription changes
+        notificationCenter.publisher(for: .subscriptionDidChange)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+
+                let featureAvailable = self.isAvailable
+                Logger.freemiumDBP.debug("[Freemium DBP] Subscription Updated. Feature Availability = \(featureAvailable)")
+
+                self.passthroughPublisher.send(featureAvailable)
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -82,7 +161,7 @@ private extension DefaultFreemiumDBPFeature {
     var shouldDisableAndDelete: Bool {
         guard freemiumDBPUserStateManager.didOnboard else { return false }
 
-        return !featureFlagger.isFeatureOn(.freemiumDBP)
+        return !privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(DBPSubfeature.freemium)
         && isPotentialPrivacyProSubscriber
     }
 
@@ -93,7 +172,8 @@ private extension DefaultFreemiumDBPFeature {
     /// - Disabling and deleting DBP data
     func offBoardIfNecessary() {
         if shouldDisableAndDelete {
-            freemiumDBPUserStateManager.didOnboard = false
+            Logger.freemiumDBP.debug("[Freemium DBP] Feature Disabled: Offboarding")
+            freemiumDBPUserStateManager.resetAllState()
             featureDisabler.disableAndDelete()
         }
     }

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinating.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinating.swift
@@ -159,9 +159,9 @@ private extension FreemiumDBPPromotionViewCoordinator {
         }
     }
 
-    /// Subscribes to feature availability updates from the `freemiumPIRFeature`'s availability publisher.
+    /// Subscribes to feature availability updates from the `freemiumDBPFeature`'s availability publisher.
     ///
-    /// This method listens to the `isAvailablePublisher` of the `freemiumPIRFeature`, which publishes
+    /// This method listens to the `isAvailablePublisher` of the `freemiumDBPFeature`, which publishes
     /// changes to the feature's availability. It performs the following actions when an update is received:
     func subscribeToFeatureAvailabilityUpdates() {
         freemiumDBPFeature.isAvailablePublisher

--- a/DuckDuckGo/Freemium/FreemiumDebugMenu.swift
+++ b/DuckDuckGo/Freemium/FreemiumDebugMenu.swift
@@ -107,11 +107,6 @@ final class FreemiumDebugMenu: NSMenuItem {
 
     @objc
     func resetAllState() {
-        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didOnboard = false
-        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).firstProfileSavedTimestamp = nil
-        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didPostFirstProfileSavedNotification = false
-        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didPostResultsNotification = false
-        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).firstScanResults = nil
-        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didDismissHomePagePromotion = false
+        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).resetAllState()
     }
 }

--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -287,7 +287,7 @@ final class NavigationBarViewController: NSViewController {
     @IBAction func optionsButtonAction(_ sender: NSButton) {
         let internalUserDecider = NSApp.delegateTyped.internalUserDecider
         let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
-        let freemiumDBPFeature = DefaultFreemiumDBPFeature(subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager, freemiumDBPUserStateManager: freemiumDBPUserStateManager)
+        let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
         let menu = MoreOptionsMenu(tabCollectionViewModel: tabCollectionViewModel,
                                    passwordManagerCoordinator: PasswordManagerCoordinator.shared,
                                    vpnFeatureGatekeeper: DefaultVPNFeatureGatekeeper(subscriptionManager: subscriptionManager),

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -789,9 +789,8 @@ final class BrowserTabViewController: NSViewController {
     var homePageViewController: HomePageViewController?
     private func homePageViewControllerCreatingIfNeeded() -> HomePageViewController {
         return homePageViewController ?? {
-            let subscriptionManager = Application.appDelegate.subscriptionManager
-            let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
-            let freemiumDBPFeature = DefaultFreemiumDBPFeature(subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager, freemiumDBPUserStateManager: freemiumDBPUserStateManager)
+            let freemiumDBPUserStateManager = DefaultFreemiumPIRUserStateManager(userDefaults: .dbp)
+            let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
 
             let freemiumDBPPromotionViewCoordinator = FreemiumDBPPromotionViewCoordinator(freemiumDBPUserStateManager: freemiumDBPUserStateManager,
                                                                                              freemiumDBPFeature: freemiumDBPFeature)
@@ -807,10 +806,9 @@ final class BrowserTabViewController: NSViewController {
     var dataBrokerProtectionHomeViewController: DBPHomeViewController?
     private func dataBrokerProtectionHomeViewControllerCreatingIfNeeded() -> DBPHomeViewController {
         return dataBrokerProtectionHomeViewController ?? {
-            let subscriptionManager = Application.appDelegate.subscriptionManager
             let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
-            let freemiumDBPFeature = DefaultFreemiumDBPFeature(subscriptionManager: subscriptionManager, accountManager: subscriptionManager.accountManager, freemiumDBPUserStateManager: freemiumDBPUserStateManager)
-            let dataBrokerProtectionHomeViewController = DBPHomeViewController(dataBrokerProtectionManager: DataBrokerProtectionManager.shared, freemiumDBPFeature: freemiumDBPFeature)
+            let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
+            let dataBrokerProtectionHomeViewController = DBPHomeViewController(dataBrokerProtectionManager: DataBrokerProtectionManager.shared, freemiumPIRFeature: freemiumDBPFeature)
             self.dataBrokerProtectionHomeViewController = dataBrokerProtectionHomeViewController
             return dataBrokerProtectionHomeViewController
         }()

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -789,7 +789,7 @@ final class BrowserTabViewController: NSViewController {
     var homePageViewController: HomePageViewController?
     private func homePageViewControllerCreatingIfNeeded() -> HomePageViewController {
         return homePageViewController ?? {
-            let freemiumDBPUserStateManager = DefaultFreemiumPIRUserStateManager(userDefaults: .dbp)
+            let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
             let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
 
             let freemiumDBPPromotionViewCoordinator = FreemiumDBPPromotionViewCoordinator(freemiumDBPUserStateManager: freemiumDBPUserStateManager,
@@ -808,7 +808,7 @@ final class BrowserTabViewController: NSViewController {
         return dataBrokerProtectionHomeViewController ?? {
             let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
             let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
-            let dataBrokerProtectionHomeViewController = DBPHomeViewController(dataBrokerProtectionManager: DataBrokerProtectionManager.shared, freemiumPIRFeature: freemiumDBPFeature)
+            let dataBrokerProtectionHomeViewController = DBPHomeViewController(dataBrokerProtectionManager: DataBrokerProtectionManager.shared, freemiumDBPFeature: freemiumDBPFeature)
             self.dataBrokerProtectionHomeViewController = dataBrokerProtectionHomeViewController
             return dataBrokerProtectionHomeViewController
         }()

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -1960,12 +1960,15 @@ struct MockMigrationsProvider: DataBrokerProtectionDatabaseMigrationsProvider {
 }
 
 final class MockFreemiumDBPUserStateManager: FreemiumDBPUserStateManager {
+
     var didOnboard = false
     var didPostFirstProfileSavedNotification = false
     var didPostResultsNotification = false
     var didDismissHomePagePromotion = false
     var firstProfileSavedTimestamp: String?
     var firstScanResults: FreemiumDBPMatchResults?
+
+    func resetAllState() {}
 }
 
 final class MockDBPProfileSavedNotifier: DBPProfileSavedNotifier {

--- a/LocalPackages/Freemium/Sources/Freemium/FreemiumDBPUserStateManager.swift
+++ b/LocalPackages/Freemium/Sources/Freemium/FreemiumDBPUserStateManager.swift
@@ -63,6 +63,9 @@ public protocol FreemiumDBPUserStateManager {
 
     /// The results of the user's first scan, stored as a `FreemiumDBPMatchResults` object.
     var firstScanResults: FreemiumDBPMatchResults? { get set }
+
+    /// Resets all stored user state
+    func resetAllState()
 }
 
 /// Default implementation of `FreemiumDBPUserStateManager` that uses `UserDefaults` for underlying storage.
@@ -170,5 +173,16 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     /// - Note: Ensure the same `UserDefaults` instance is passed throughout the app to maintain consistency in state management.
     public init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
+    }
+
+    /// Resets all stored user state by clearing or resetting the relevant keys in `UserDefaults`.
+    public func resetAllState() {
+        // Reset each stored value to its default state
+        userDefaults.removeObject(forKey: Keys.didOnboard)
+        userDefaults.removeObject(forKey: Keys.firstProfileSavedTimestamp)
+        userDefaults.removeObject(forKey: Keys.didPostFirstProfileSavedNotification)
+        userDefaults.removeObject(forKey: Keys.didPostResultsNotification)
+        userDefaults.removeObject(forKey: Keys.firstScanResults)
+        userDefaults.removeObject(forKey: Keys.didDismissHomePagePromotion)
     }
 }

--- a/LocalPackages/Freemium/Tests/FreemiumTests/FreemiumDBPUserStateManagerTests.swift
+++ b/LocalPackages/Freemium/Tests/FreemiumTests/FreemiumDBPUserStateManagerTests.swift
@@ -205,7 +205,7 @@ final class FreemiumDBPUserStateManagerTests: XCTestCase {
 
     func testResetAllStateResetsAllProperties() {
         // Given
-        let sut = DefaultFreemiumPIRUserStateManager(userDefaults: testUserDefaults)
+        let sut = DefaultFreemiumDBPUserStateManager(userDefaults: testUserDefaults)
         sut.didOnboard = true
         sut.firstProfileSavedTimestamp = "2024-01-01T12:00:00Z"
         sut.didPostFirstProfileSavedNotification = true

--- a/LocalPackages/Freemium/Tests/FreemiumTests/FreemiumDBPUserStateManagerTests.swift
+++ b/LocalPackages/Freemium/Tests/FreemiumTests/FreemiumDBPUserStateManagerTests.swift
@@ -202,4 +202,27 @@ final class FreemiumDBPUserStateManagerTests: XCTestCase {
         XCTAssertEqual(result?.matchesCount, scanResults.matchesCount)
         XCTAssertEqual(result?.brokerCount, scanResults.brokerCount)
     }
+
+    func testResetAllStateResetsAllProperties() {
+        // Given
+        let sut = DefaultFreemiumPIRUserStateManager(userDefaults: testUserDefaults)
+        sut.didOnboard = true
+        sut.firstProfileSavedTimestamp = "2024-01-01T12:00:00Z"
+        sut.didPostFirstProfileSavedNotification = true
+        sut.didPostResultsNotification = true
+        sut.didDismissHomePagePromotion = true
+        let scanResults = FreemiumDBPMatchResults(matchesCount: 10, brokerCount: 5)
+        sut.firstScanResults = scanResults
+
+        // When
+        sut.resetAllState()
+
+        // Then
+        XCTAssertFalse(sut.didOnboard)
+        XCTAssertNil(sut.firstProfileSavedTimestamp)
+        XCTAssertFalse(sut.didPostFirstProfileSavedNotification)
+        XCTAssertFalse(sut.didPostResultsNotification)
+        XCTAssertNil(sut.firstScanResults)
+        XCTAssertFalse(sut.didDismissHomePagePromotion)
+    }
 }

--- a/UnitTests/Freemium/DBP/FreemiumDBPPresenterTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPPresenterTests.swift
@@ -48,7 +48,6 @@ final class FreemiumDBPPresenterTests: XCTestCase {
 
 private final class MockWindowControllerManager: WindowControllersManagerProtocol {
 
-
     var lastKeyMainWindowController: DuckDuckGo_Privacy_Browser.MainWindowController?
 
     var showTabContent: Tab.Content = .none
@@ -67,11 +66,11 @@ private final class MockWindowControllerManager: WindowControllersManagerProtoco
         showTabContent = content
     }
 
-    func show(url: URL?, source: Tab.TabContent.URLSource, newTab: Bool) {}
+    func show(url: URL?, source: DuckDuckGo_Privacy_Browser.Tab.TabContent.URLSource, newTab: Bool) {}
 
     func showBookmarksTab() {}
 
-    func openNewWindow(with tabCollectionViewModel: TabCollectionViewModel?, burnerMode: BurnerMode, droppingPoint: NSPoint?, contentSize: NSSize?, showWindow: Bool, popUp: Bool, lazyLoadTabs: Bool, isMiniaturized: Bool) -> MainWindow? {
+    func openNewWindow(with tabCollectionViewModel: DuckDuckGo_Privacy_Browser.TabCollectionViewModel?, burnerMode: DuckDuckGo_Privacy_Browser.BurnerMode, droppingPoint: NSPoint?, contentSize: NSSize?, showWindow: Bool, popUp: Bool, lazyLoadTabs: Bool, isMiniaturized: Bool) -> DuckDuckGo_Privacy_Browser.MainWindow? {
         nil
     }
 }

--- a/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatingTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatingTests.swift
@@ -1,0 +1,271 @@
+//
+//  FreemiumDBPPromotionViewCoordinatingTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Freemium
+@testable import DuckDuckGo_Privacy_Browser
+import Combine
+
+final class FreemiumDBPPromotionViewCoordinatingTests: XCTestCase {
+
+    private var sut: FreemiumDBPPromotionViewCoordinator!
+    private var mockUserStateManager: MockFreemiumDBPUserStateManager!
+    private var mockFeature: MockFreemiumDBPFeature!
+    private var mockPresenter: MockFreemiumDBPPresenter!
+    private let notificationCenter: NotificationCenter = .default
+    private var cancellables: Set<AnyCancellable> = []
+
+    @MainActor
+    override func setUpWithError() throws {
+        mockUserStateManager = MockFreemiumDBPUserStateManager()
+        mockFeature = MockFreemiumDBPFeature()
+        mockPresenter = MockFreemiumDBPPresenter()
+
+        sut = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: mockPresenter,
+            notificationCenter: notificationCenter
+        )
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        mockUserStateManager = nil
+        mockFeature = nil
+        mockPresenter = nil
+    }
+
+    @MainActor
+    func testInitialPromotionVisibility_whenFeatureIsAvailable_andNotDismissed() {
+        // Given
+        mockUserStateManager.didDismissHomePagePromotion = false
+        mockFeature.featureAvailable = true
+
+        // When
+        sut = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: mockPresenter
+        )
+
+        // Then
+        XCTAssertTrue(sut.isHomePagePromotionVisible)
+    }
+
+    @MainActor
+    func testInitialPromotionVisibility_whenPromotionDismissed() {
+        // Given
+        mockUserStateManager.didDismissHomePagePromotion = true
+        mockFeature.featureAvailable = true
+
+        // When
+        sut = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: mockPresenter
+        )
+
+        // Then
+        XCTAssertFalse(sut.isHomePagePromotionVisible)
+    }
+
+    @MainActor
+    func testProceedAction_marksUserAsOnboarded_andDismissesPromotion() {
+        // Given
+        mockUserStateManager.didOnboard = false
+
+        // When
+        let viewModel = sut.viewModel
+        viewModel.proceedAction()
+
+        // Then
+        XCTAssertTrue(mockUserStateManager.didOnboard)
+        XCTAssertTrue(mockUserStateManager.didDismissHomePagePromotion)
+        XCTAssertTrue(mockPresenter.didCallShowFreemium)
+    }
+
+    @MainActor
+    func testCloseAction_dismissesPromotion() {
+        // When
+        let viewModel = sut.viewModel
+        viewModel.closeAction()
+
+        // Then
+        XCTAssertTrue(mockUserStateManager.didDismissHomePagePromotion)
+    }
+
+    @MainActor
+    func testViewModel_whenResultsExist_withMatches() {
+        // Given
+        mockUserStateManager.firstScanResults = FreemiumDBPMatchResults(matchesCount: 5, brokerCount: 2)
+
+        // When
+        let viewModel = sut.viewModel
+
+        // Then
+        XCTAssertEqual(viewModel.title, UserText.homePagePromotionFreemiumDBPPostScanEngagementResultsTitle)
+        XCTAssertEqual(viewModel.subtitle, UserText.homePagePromotionFreemiumDBPPostScanEngagementResultPluralSubtitle(resultCount: 5, brokerCount: 2))
+    }
+
+    @MainActor
+    func testViewModel_whenNoResultsExist() {
+        // Given
+        mockUserStateManager.firstScanResults = nil
+
+        // When
+        let viewModel = sut.viewModel
+
+        // Then
+        XCTAssertEqual(viewModel.subtitle, UserText.homePagePromotionFreemiumDBPSubtitle)
+    }
+
+    func testNotificationObservation_updatesPromotionVisibility() {
+        // When
+        notificationCenter.post(name: .freemiumDBPResultPollingComplete, object: nil)
+
+        // Then
+        XCTAssertFalse(mockUserStateManager.didDismissHomePagePromotion)
+
+        // When
+        notificationCenter.post(name: .freemiumDBPEntryPointActivated, object: nil)
+
+        // Then
+        XCTAssertFalse(mockUserStateManager.didDismissHomePagePromotion)
+    }
+
+    @MainActor
+    func testHomePageBecomesVisible_whenFeatureBecomesAvailable_andDidDismissFalse() {
+        // Given
+        mockUserStateManager.didDismissHomePagePromotion = false
+        mockFeature.featureAvailable = false
+        let expectation = XCTestExpectation(description: "isHomePagePromotionVisible becomes true")
+        sut = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: mockPresenter
+        )
+        XCTAssertFalse(sut.isHomePagePromotionVisible)
+
+        // When
+        mockFeature.isAvailableSubject.send(true)
+
+        sut.$isHomePagePromotionVisible
+            .sink { isVisible in
+                if isVisible {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 2.0)
+
+        // Then
+        XCTAssertTrue(sut.isHomePagePromotionVisible)
+    }
+
+    @MainActor
+    func testHomePageBecomesInVisible_whenFeatureBecomesUnAvailable_andDidDismissFalse() {
+        // Given
+        mockUserStateManager.didDismissHomePagePromotion = false
+        mockFeature.featureAvailable = true
+        let expectation = XCTestExpectation(description: "isHomePagePromotionVisible becomes true")
+        sut = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: mockPresenter
+        )
+        XCTAssertTrue(sut.isHomePagePromotionVisible)
+
+        // When
+        mockFeature.isAvailableSubject.send(false)
+
+        sut.$isHomePagePromotionVisible
+            .sink { isVisible in
+                if !isVisible {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 2.0)
+
+        // Then
+        XCTAssertFalse(sut.isHomePagePromotionVisible)
+    }
+
+    @MainActor
+    func testHomePageDoesNotBecomeVisible_whenFeatureBecomesAvailable_andDidDismissTrue() {
+        // Given
+        mockUserStateManager.didDismissHomePagePromotion = true
+        mockFeature.featureAvailable = false
+        let expectation = XCTestExpectation(description: "isHomePagePromotionVisible becomes true")
+        sut = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: mockPresenter
+        )
+        XCTAssertFalse(sut.isHomePagePromotionVisible)
+
+        // When
+        mockFeature.isAvailableSubject.send(true)
+
+        sut.$isHomePagePromotionVisible
+            .sink { isVisible in
+                if !isVisible {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 2.0)
+
+        // Then
+        XCTAssertFalse(sut.isHomePagePromotionVisible)
+    }
+
+    @MainActor
+    func testHomePageDoesNotBecomeVisible_whenFeatureBecomesUnAvailable_andDidDismissTrue() {
+        // Given
+        mockUserStateManager.didDismissHomePagePromotion = true
+        mockFeature.featureAvailable = true
+        let expectation = XCTestExpectation(description: "isHomePagePromotionVisible becomes true")
+        sut = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: mockPresenter
+        )
+        XCTAssertFalse(sut.isHomePagePromotionVisible)
+
+        // When
+        mockFeature.isAvailableSubject.send(false)
+
+        sut.$isHomePagePromotionVisible
+            .sink { isVisible in
+                if !isVisible {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 2.0)
+
+        // Then
+        XCTAssertFalse(sut.isHomePagePromotionVisible)
+    }
+}

--- a/UnitTests/Onboarding/Mocks/MockContentBlocking.swift
+++ b/UnitTests/Onboarding/Mocks/MockContentBlocking.swift
@@ -42,9 +42,17 @@ class MockEmbeddedDataProvider: EmbeddedDataProvider {
 class MockPrivacyConfigurationManaging: PrivacyConfigurationManaging {
     var currentConfig: Data = Data()
 
-    var updatesPublisher: AnyPublisher<Void, Never> = Empty<Void, Never>(completeImmediately: false).eraseToAnyPublisher()
+    let updatesSubject = PassthroughSubject<Void, Never>()
+
+    var updatesPublisher: AnyPublisher<Void, Never> {
+        updatesSubject.eraseToAnyPublisher()
+    }
 
     var privacyConfig: PrivacyConfiguration = MockPrivacyConfiguration()
+
+    var mockConfig: MockPrivacyConfiguration {
+        privacyConfig as! MockPrivacyConfiguration
+    }
 
     var internalUserDecider: InternalUserDecider = InternalUserDeciderMock()
 

--- a/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
+++ b/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
@@ -31,12 +31,19 @@ struct MockRemoteMessagingStoreProvider: RemoteMessagingStoreProviding {
 }
 
 final class MockFreemiumDBPUserStateManager: FreemiumDBPUserStateManager {
+
+    var didCallResetAllState = false
+
     var didOnboard = false
     var didPostFirstProfileSavedNotification = false
     var didPostResultsNotification = false
     var didDismissHomePagePromotion = false
     var firstProfileSavedTimestamp: String?
     var firstScanResults: FreemiumDBPMatchResults?
+
+    func resetAllState() {
+        didCallResetAllState = true
+    }
 }
 
 final class RemoteMessagingClientTests: XCTestCase {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208258950415952/f

**Description**: This PR improves upon existing behavior by doing the following:

1. Updates `FreemiumPIRFeature` to observe changes to Privacy Config and Subscription status
2. Moves the declaration of `FreemiumPIRFeature` to the `AppDelegate`, to be accessed my multiple, distinct types
3. Observes Feature Availability changes in the new tab view Promotion Coordinator (future work will likely mean other types will also observe Feature Availability changes)

**Testing Prerequisites**
1. Make sure you are an internal user
2. Disable/Signout of Privacy Pro (Settings menu -> PP -> Remove from this device)
3. Remove an Freemium DBP data (i.e profile data) - Launch the browser and remove it via the DBP Dashboard `Edit My Info` button and `Turn Personal Information Removal off and delete my information` at the bottom
4. Reset all freemium state via Debug Menu -> `Freemium` -> `RESET ALL STATE`
5. Set the `Freemium` feature to disabled in [this JSON Blob](https://www.jsonblob.com/1282779040355049472)
6. Set a custom config in the browser via the debug menu to `https://www.jsonblob.com/api/1282779040355049472`
7. Relaunch the browser

**Steps to test this PR**:
**TEST 1 - ENABLING THE FEATURE FLAG CAUSES A NEW TAB TO DISPLAY THE PROMOTION BANNER**
1. Launch the browser
2. Ensure the Freemium Promotion banner is NOT visible on the new tab page
3. Set the `Freemium` feature to `internal` in the JSON Blob
4. Reload the config via the debug menu
5. Open a new tab
6. Ensure you see the Promotion banner

**TEST 1 - SUBSCRIBING TO PRIVACY PRO REMOVES THE PROMOTION BANNER**
1. With the promotion banner still visible, subscribe to PP (or enter your email and confirm it etc.)
2. Navigate back to the new tab page
3. Ensure the Freemium Promotion banner is gone (it may take a second, the internal notification from Subscription code is a bit slow)

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
