### PR TITLE
Wait for UserScripts to be loaded for email protection

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
@@ -98,7 +98,9 @@ final class ContentBlockingTabExtension: NSObject {
 extension ContentBlockingTabExtension: NavigationResponder {
 
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
-        if !navigationAction.url.isDuckDuckGo {
+        if !navigationAction.url.isDuckDuckGo
+            // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/email/
+            || navigationAction.url.absoluteString.hasPrefix(URL.duckDuckGoEmailLogin.absoluteString) {
             await prepareForContentBlocking()
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207340338530322/1206840081441003/f

**Description**:
- Fixes Email Protection not supported when loaded before `ContentScopeUserScript`

**Steps to test this PR**:
1. Activate Settings->General->Reopen all windows from last session
2. Open …->Email Protection
3. Quit
4. `rm -rf ~/Library/WebKit/com.duckduckgo.macos.browser.debug/ContentRuleLists`
5. Run; validate Email Protection loads and there‘s no "Unavailable in this browser" message

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
