### PR TITLE
Disable sort and search when no bookmarks

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1767,6 +1767,8 @@
 		841BE93C2C6F1CB200E9C2B5 /* MenuItemNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841BE93A2C6F1CB200E9C2B5 /* MenuItemNode.swift */; };
 		841BE93E2C6F236000E9C2B5 /* BookmarkDragDropManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841BE93D2C6F235F00E9C2B5 /* BookmarkDragDropManager.swift */; };
 		841BE93F2C6F236000E9C2B5 /* BookmarkDragDropManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841BE93D2C6F235F00E9C2B5 /* BookmarkDragDropManager.swift */; };
+		8426108D2C9811F30070D5F9 /* KeyEquivalentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8426108C2C9811EC0070D5F9 /* KeyEquivalentView.swift */; };
+		8426108E2C9811F30070D5F9 /* KeyEquivalentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8426108C2C9811EC0070D5F9 /* KeyEquivalentView.swift */; };
 		843965122C6F2FFE004C8899 /* NSDragOperationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843965112C6F2FFE004C8899 /* NSDragOperationExtension.swift */; };
 		843965132C6F2FFE004C8899 /* NSDragOperationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843965112C6F2FFE004C8899 /* NSDragOperationExtension.swift */; };
 		843965152C737022004C8899 /* NSPasteboardExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843965142C737022004C8899 /* NSPasteboardExtension.swift */; };
@@ -3826,6 +3828,7 @@
 		8400DC4D2C6E2770006509D2 /* SteppedScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SteppedScrollView.swift; sourceTree = "<group>"; };
 		841BE93A2C6F1CB200E9C2B5 /* MenuItemNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuItemNode.swift; sourceTree = "<group>"; };
 		841BE93D2C6F235F00E9C2B5 /* BookmarkDragDropManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkDragDropManager.swift; sourceTree = "<group>"; };
+		8426108C2C9811EC0070D5F9 /* KeyEquivalentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyEquivalentView.swift; sourceTree = "<group>"; };
 		843965112C6F2FFE004C8899 /* NSDragOperationExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDragOperationExtension.swift; sourceTree = "<group>"; };
 		843965142C737022004C8899 /* NSPasteboardExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPasteboardExtension.swift; sourceTree = "<group>"; };
 		848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksBarMenuViewController.swift; sourceTree = "<group>"; };
@@ -6769,6 +6772,7 @@
 				B693953E26F04BE70015B914 /* FocusRingView.swift */,
 				B693954326F04BE90015B914 /* GradientView.swift */,
 				B6B140872ABDBCC1004F8E85 /* HoverTrackingArea.swift */,
+				8426108C2C9811EC0070D5F9 /* KeyEquivalentView.swift */,
 				B6B1E88A26D774090062C350 /* LinkButton.swift */,
 				B693954026F04BE80015B914 /* LoadingProgressView.swift */,
 				B693954426F04BE90015B914 /* LongPressButton.swift */,
@@ -11025,6 +11029,7 @@
 				021EA0812BD2A9D500772C9A /* TabsPreferences.swift in Sources */,
 				B6619EFC2B111CC600CD9186 /* InstructionsFormatParser.swift in Sources */,
 				3706FC08293F65D500E42796 /* CoreDataBookmarkImporter.swift in Sources */,
+				8426108E2C9811F30070D5F9 /* KeyEquivalentView.swift in Sources */,
 				3706FC09293F65D500E42796 /* SuggestionViewModel.swift in Sources */,
 				3706FC0A293F65D500E42796 /* BookmarkManagedObject.swift in Sources */,
 				B6ABC5972B4861D4008343B9 /* FocusableTextField.swift in Sources */,
@@ -12173,6 +12178,7 @@
 				AAE246F8270A406200BEEAEE /* FirePopoverCollectionViewHeader.swift in Sources */,
 				AAB7320926DD0CD9002FACF9 /* FireViewController.swift in Sources */,
 				4B92928C26670D1700AD2C21 /* OutlineSeparatorViewCell.swift in Sources */,
+				8426108D2C9811F30070D5F9 /* KeyEquivalentView.swift in Sources */,
 				4BB99D0426FE191E001E4761 /* SafariDataImporter.swift in Sources */,
 				4B9DB0262A983B24000927DB /* WaitlistViewModel.swift in Sources */,
 				987799F929999973005D8EB6 /* LocalBookmarkStore.swift in Sources */,

--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -305,6 +305,12 @@ final class BookmarkListViewController: NSViewController {
         importButton.translatesAutoresizingMaskIntoConstraints = false
         importButton.isHidden = true
 
+        view.addSubview(KeyEquivalentView(keyEquivalents: [
+            [.command, "f"]: { [weak self] in
+                return self?.handleCmdF($0) ?? false
+            }
+        ]))
+
         setupLayout()
     }
 
@@ -441,6 +447,7 @@ final class BookmarkListViewController: NSViewController {
         self.outlineView.isHidden = isEmpty
 
         if isEmpty {
+            self.hideSearchBar()
             self.showEmptyStateView(for: .noBookmarks)
         }
     }
@@ -486,7 +493,9 @@ final class BookmarkListViewController: NSViewController {
     private func hideSearchBar() {
         isSearchVisible = false
         outlineView.highlightedRow = nil
-        outlineView.makeMeFirstResponder()
+        if outlineView.isShown {
+            outlineView.makeMeFirstResponder()
+        }
         searchBar.stringValue = ""
         searchBar.removeFromSuperview()
         boxDividerTopConstraint.isActive = true
@@ -521,6 +530,9 @@ final class BookmarkListViewController: NSViewController {
     private func showEmptyStateView(for mode: BookmarksEmptyStateContent) {
         emptyState.isHidden = false
         outlineView.isHidden = true
+        if !isSearchVisible {
+            view.makeMeFirstResponder()
+        }
         emptyStateTitle.stringValue = mode.title
         emptyStateMessage.stringValue = mode.description
         emptyStateImageView.image = mode.image
@@ -529,19 +541,23 @@ final class BookmarkListViewController: NSViewController {
 
     // MARK: Actions
 
+    private func handleCmdF(_ event: NSEvent) -> Bool {
+        // start search on cmd+f when bookmarks are available
+        guard bookmarkManager.list?.totalBookmarks != 0 else {
+            __NSBeep()
+            return true
+        }
+
+        if isSearchVisible {
+            searchBar.makeMeFirstResponder()
+        } else {
+            showSearchBar()
+        }
+        return true
+    }
+
     override func keyDown(with event: NSEvent) {
         switch Int(event.keyCode) {
-        case kVK_ANSI_F where event.deviceIndependentFlags == .command:
-            guard bookmarkManager.list?.totalBookmarks != 0 else {
-                return
-            }
-
-            if isSearchVisible {
-                searchBar.makeMeFirstResponder()
-            } else {
-                showSearchBar()
-            }
-
         case kVK_Return, kVK_ANSI_KeypadEnter, kVK_Space:
             if outlineView.highlightedRow != nil {
                 // submit action when there‘s a highlighted row
@@ -556,9 +572,10 @@ final class BookmarkListViewController: NSViewController {
             delegate?.closeBookmarksPopover(self)
 
         default:
-            // start search when letters are typed
-            if let characters = event.characters,
-               !characters.isEmpty {
+            // start search when letters are typed when bookmarks are available
+            if event.deviceIndependentFlags.isEmpty,
+               let characters = event.characters, !characters.isEmpty,
+               bookmarkManager.list?.totalBookmarks != 0 {
 
                 showSearchBar()
                 searchBar.currentEditor()?.keyDown(with: event)

--- a/DuckDuckGo/Bookmarks/View/BookmarkManagementSplitViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkManagementSplitViewController.swift
@@ -61,15 +61,6 @@ final class BookmarkManagementSplitViewController: NSSplitViewController {
         detailViewController.delegate = self
     }
 
-    override func keyDown(with event: NSEvent) {
-        let commandKeyDown = event.modifierFlags.contains(.command)
-        if commandKeyDown && event.keyCode == 3 { // CMD + F
-            detailViewController.searchBar.makeMeFirstResponder()
-        } else {
-            super.keyDown(with: event)
-        }
-    }
-
 }
 
 extension BookmarkManagementSplitViewController: BookmarkManagementSidebarViewControllerDelegate {

--- a/DuckDuckGo/Common/Extensions/NSMenuItemExtension.swift
+++ b/DuckDuckGo/Common/Extensions/NSMenuItemExtension.swift
@@ -26,7 +26,7 @@ extension NSMenuItem {
         return item
     }
 
-    convenience init(title string: String, action selector: Selector? = nil, target: AnyObject? = nil, keyEquivalent: [KeyEquivalentElement] = [], representedObject: Any? = nil, state: NSControl.StateValue = .off, items: [NSMenuItem]? = nil) {
+    convenience init(title string: String, action selector: Selector? = nil, target: AnyObject? = nil, keyEquivalent: NSEvent.KeyEquivalent = [], representedObject: Any? = nil, state: NSControl.StateValue = .off, items: [NSMenuItem]? = nil) {
         self.init(title: string, action: selector, keyEquivalent: keyEquivalent.charCode)
         if !keyEquivalent.modifierMask.isEmpty {
             self.keyEquivalentModifierMask = keyEquivalent.modifierMask
@@ -40,7 +40,7 @@ extension NSMenuItem {
         }
     }
 
-    convenience init(title string: String, action selector: Selector? = nil, target: AnyObject? = nil, keyEquivalent: [KeyEquivalentElement] = [], representedObject: Any? = nil, state: NSControl.StateValue = .off, @MenuBuilder items: () -> [NSMenuItem]) {
+    convenience init(title string: String, action selector: Selector? = nil, target: AnyObject? = nil, keyEquivalent: NSEvent.KeyEquivalent = [], representedObject: Any? = nil, state: NSControl.StateValue = .off, @MenuBuilder items: () -> [NSMenuItem]) {
         self.init(title: string, action: selector, target: target, keyEquivalent: keyEquivalent, representedObject: representedObject, state: state, items: items())
     }
 
@@ -126,61 +126,6 @@ extension NSMenuItem {
     func withModifierMask(_ mask: NSEvent.ModifierFlags) -> NSMenuItem {
         self.keyEquivalentModifierMask = mask
         return self
-    }
-
-}
-
-enum KeyEquivalentElement: ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-
-    case charCode(String)
-    case command
-    case shift
-    case option
-    case control
-
-    static let backspace = KeyEquivalentElement.charCode("\u{8}")
-    static let tab = KeyEquivalentElement.charCode("\t")
-    static let left = KeyEquivalentElement.charCode("\u{2190}")
-    static let right = KeyEquivalentElement.charCode("\u{2192}")
-
-    init(stringLiteral value: String) {
-        self = .charCode(value)
-    }
-}
-
-extension [KeyEquivalentElement]: ExpressibleByStringLiteral, ExpressibleByUnicodeScalarLiteral, ExpressibleByExtendedGraphemeClusterLiteral {
-    public typealias StringLiteralType = String
-
-    public init(stringLiteral value: String) {
-        self = [.charCode(value)]
-    }
-
-    var charCode: String {
-        for item in self {
-            if case .charCode(let value) = item {
-                return value
-            }
-        }
-        return ""
-    }
-
-    var modifierMask: NSEvent.ModifierFlags {
-        var result: NSEvent.ModifierFlags = []
-        for item in self {
-            switch item {
-            case .charCode: continue
-            case .command:
-                result.insert(.command)
-            case .shift:
-                result.insert(.shift)
-            case .option:
-                result.insert(.option)
-            case .control:
-                result.insert(.control)
-            }
-        }
-        return result
     }
 
 }

--- a/DuckDuckGo/Common/View/AppKit/KeyEquivalentView.swift
+++ b/DuckDuckGo/Common/View/AppKit/KeyEquivalentView.swift
@@ -1,0 +1,37 @@
+//
+//  KeyEquivalentView.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/// Used to catch `performKeyEquivalent:` events in View Controllers
+final class KeyEquivalentView: NSView {
+    private let keyEquivalents: [NSEvent.KeyEquivalent: (NSEvent) -> Bool]
+
+    init(keyEquivalents: [NSEvent.KeyEquivalent: (NSEvent) -> Bool]) {
+        self.keyEquivalents = keyEquivalents
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("\(type(of: self)): Bad initializer")
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard let keyEquivalent = event.keyEquivalent,
+              let handler = keyEquivalents[keyEquivalent] else { return false }
+        return handler(event)
+    }
+}

--- a/DuckDuckGo/MainWindow/MainWindow.swift
+++ b/DuckDuckGo/MainWindow/MainWindow.swift
@@ -48,6 +48,11 @@ final class MainWindow: NSWindow {
     // To avoid beep sounds, this keyDown method catches events that go through the
     // responder chain when no other responders process it
     override func keyDown(with event: NSEvent) {
+        if event.keyEquivalent == [.command, "f"] {
+            // beep on Cmd+F when Find In Page is unavailable
+            super.keyDown(with: event)
+            return
+        }
         super.performKeyEquivalent(with: event)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208262956542586/f
Tech Design URL:
CC:

## Description
It disables the sort and search buttons in the bookmarks manager and panel, when the user has no bookmarks.

### Acceptance criteria
**AC#1**
Given a user with no bookmarks, when the user opens the bookmarks panel then the sort and search button are disabled

**AC#2**
Given a user with no bookmarks, when the user opens the bookmarks manager then the sort and search button are disabled

**AC#3**
Given a user with no bookmarks, when the user adds a bookmark then the sort and search features are enabled

### Demo
https://github.com/user-attachments/assets/8d27720f-b637-4088-95a5-3ade649c3782


**Steps to test this PR**:
Verify the listed acceptance criteria are correct.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
