### PR TITLE
Fix UI tests failing in the CI

### DIFF
--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -810,7 +810,6 @@ extension MainViewController {
     @objc func resetBookmarks(_ sender: Any?) {
         LocalBookmarkManager.shared.resetBookmarks()
         UserDefaults.standard.set(false, forKey: UserDefaultsWrapper<Bool>.Key.homePageContinueSetUpImport.rawValue)
-        UserDefaults.standard.set(false, forKey: UserDefaultsWrapper<Bool>.Key.bookmarksBarPromptShown.rawValue)
         LocalBookmarkManager.shared.sortMode = .manual
     }
 

--- a/UITests/BookmarksAndFavoritesTests.swift
+++ b/UITests/BookmarksAndFavoritesTests.swift
@@ -47,6 +47,7 @@ class BookmarksAndFavoritesTests: XCTestCase {
     private var openBookmarksMenuItem: XCUIElement!
     private var optionsButton: XCUIElement!
     private var removeFavoritesContextMenuItem: XCUIElement!
+    private var resetBookMarksMenuItem: XCUIElement!
     private var settingsAppearanceButton: XCUIElement!
     private var showBookmarksBarPreferenceToggle: XCUIElement!
     private var showBookmarksBarAlways: XCUIElement!
@@ -86,6 +87,7 @@ class BookmarksAndFavoritesTests: XCTestCase {
         openBookmarksMenuItem = app.menuItems["MoreOptionsMenu.openBookmarks"]
         optionsButton = app.buttons["NavigationBarViewController.optionsButton"]
         removeFavoritesContextMenuItem = app.menuItems["HomePage.Views.removeFavorite"]
+        resetBookMarksMenuItem = app.menuItems["MainMenu.resetBookmarks"]
         settingsAppearanceButton = app.buttons["PreferencesSidebar.appearanceButton"]
         showBookmarksBarAlways = app.menuItems["Preferences.AppearanceView.showBookmarksBarAlways"]
         showBookmarksBarPopup = app.popUpButtons["Preferences.AppearanceView.showBookmarksBarPopUp"]
@@ -93,8 +95,9 @@ class BookmarksAndFavoritesTests: XCTestCase {
         showFavoritesPreferenceToggle = app.checkBoxes["Preferences.AppearanceView.showFavoritesToggle"]
 
         app.launch()
-        app.resetBookmarks()
-        app.enforceSingleWindow()
+        resetBookmarks()
+        app.typeKey("w", modifierFlags: [.command, .option, .shift]) // Let's enforce a single window
+        app.typeKey("n", modifierFlags: .command)
     }
 
     func test_bookmarks_canBeAddedTo_withContextClickBookmarkThisPage() {
@@ -638,6 +641,15 @@ class BookmarksAndFavoritesTests: XCTestCase {
 }
 
 private extension BookmarksAndFavoritesTests {
+    /// Reset the bookmarks so we can rely on a single bookmark's existence
+    func resetBookmarks() {
+        app.typeKey("n", modifierFlags: [.command]) // Can't use debug menu without a window
+        XCTAssertTrue(
+            resetBookMarksMenuItem.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+            "Reset bookmarks menu item didn't become available in a reasonable timeframe."
+        )
+        resetBookMarksMenuItem.click()
+    }
 
     /// Make sure that we can reply on the bookmarks bar always appearing
     func toggleShowBookmarksBarAlwaysOn() {

--- a/UITests/BookmarksAndFavoritesTests.swift
+++ b/UITests/BookmarksAndFavoritesTests.swift
@@ -47,7 +47,6 @@ class BookmarksAndFavoritesTests: XCTestCase {
     private var openBookmarksMenuItem: XCUIElement!
     private var optionsButton: XCUIElement!
     private var removeFavoritesContextMenuItem: XCUIElement!
-    private var resetBookMarksMenuItem: XCUIElement!
     private var settingsAppearanceButton: XCUIElement!
     private var showBookmarksBarPreferenceToggle: XCUIElement!
     private var showBookmarksBarAlways: XCUIElement!
@@ -87,7 +86,6 @@ class BookmarksAndFavoritesTests: XCTestCase {
         openBookmarksMenuItem = app.menuItems["MoreOptionsMenu.openBookmarks"]
         optionsButton = app.buttons["NavigationBarViewController.optionsButton"]
         removeFavoritesContextMenuItem = app.menuItems["HomePage.Views.removeFavorite"]
-        resetBookMarksMenuItem = app.menuItems["MainMenu.resetBookmarks"]
         settingsAppearanceButton = app.buttons["PreferencesSidebar.appearanceButton"]
         showBookmarksBarAlways = app.menuItems["Preferences.AppearanceView.showBookmarksBarAlways"]
         showBookmarksBarPopup = app.popUpButtons["Preferences.AppearanceView.showBookmarksBarPopUp"]
@@ -95,9 +93,8 @@ class BookmarksAndFavoritesTests: XCTestCase {
         showFavoritesPreferenceToggle = app.checkBoxes["Preferences.AppearanceView.showFavoritesToggle"]
 
         app.launch()
-        resetBookmarks()
-        app.typeKey("w", modifierFlags: [.command, .option, .shift]) // Let's enforce a single window
-        app.typeKey("n", modifierFlags: .command)
+        app.resetBookmarks()
+        app.enforceSingleWindow()
     }
 
     func test_bookmarks_canBeAddedTo_withContextClickBookmarkThisPage() {
@@ -641,15 +638,6 @@ class BookmarksAndFavoritesTests: XCTestCase {
 }
 
 private extension BookmarksAndFavoritesTests {
-    /// Reset the bookmarks so we can rely on a single bookmark's existence
-    func resetBookmarks() {
-        app.typeKey("n", modifierFlags: [.command]) // Can't use debug menu without a window
-        XCTAssertTrue(
-            resetBookMarksMenuItem.waitForExistence(timeout: UITests.Timeouts.elementExistence),
-            "Reset bookmarks menu item didn't become available in a reasonable timeframe."
-        )
-        resetBookMarksMenuItem.click()
-    }
 
     /// Make sure that we can reply on the bookmarks bar always appearing
     func toggleShowBookmarksBarAlwaysOn() {

--- a/UITests/Common/XCUIApplicationExtension.swift
+++ b/UITests/Common/XCUIApplicationExtension.swift
@@ -33,11 +33,19 @@ extension XCUIApplication {
         static let resetBookmarksMenuItem = "MainMenu.resetBookmarks"
     }
 
-    /// Dismiss popover with the passed button identifier
+    /// Dismiss popover with the passed button identifier if exists. If it does not exist it continues the execution without failing.
     /// - Parameter buttonIdentifier: The button identifier we want to tap from the popover
     func dismissPopover(buttonIdentifier: String) {
         let popover = popovers.firstMatch
+        guard popover.exists else {
+            return
+        }
+
         let button = popover.buttons[buttonIdentifier]
+        guard button.exists else {
+            return
+        }
+
         button.tap()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208242072125397/f
Tech Design URL:
CC:

**Description**:
Removes resetting the show bookmarks bar popover from the debug menu item, and when dismissing a popover we only do it if exists, if not it continues with the test.

**Steps to test this PR**:
You can test the flow locally, but it takes some time, and we also need to make sure it’s passing in the CI. I’ve run the flow in the CI, here is the link: https://github.com/duckduckgo/macos-browser/actions/runs/10816432950/job/30007600733

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
