### PR TITLE
Ignore accents when doing a bookmark search

### DIFF
--- a/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -426,7 +426,7 @@ final class LocalBookmarkManager: BookmarkManager {
         while !queue.isEmpty {
             let current = queue.removeFirst()
 
-            if current.title.removingAccents().lowercased().contains(query.removingAccents().lowercased()) {
+            if current.title.cleanStringForBookmarkSearch.contains(query.cleanStringForBookmarkSearch) {
                 result.append(current)
             }
 

--- a/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -426,7 +426,7 @@ final class LocalBookmarkManager: BookmarkManager {
         while !queue.isEmpty {
             let current = queue.removeFirst()
 
-            if current.title.cleanStringForBookmarkSearch.contains(query.cleanStringForBookmarkSearch) {
+            if current.title.cleaningStringForBookmarkSearch.contains(query.cleaningStringForBookmarkSearch) {
                 result.append(current)
             }
 
@@ -437,4 +437,36 @@ final class LocalBookmarkManager: BookmarkManager {
 
         return result
     }
+}
+
+private extension String {
+
+    /// A computed property that returns a cleaned version of the string for bookmark search purposes.
+    /// The cleaning process involves removing accents, stripping out non-alphanumeric characters,
+    /// and converting the string to lowercase.
+    ///
+    /// - Returns: A cleaned string suitable for bookmark searches.
+    var cleaningStringForBookmarkSearch: String {
+        self.removeAccents()
+            .replacingOccurrences(of: "[^a-zA-Z0-9]", with: "", options: .regularExpression)
+            .lowercased()
+    }
+
+    /// Removes accents (diacritics) from the string by normalizing it and applying transformations.
+    /// This method uses Unicode normalization to decompose characters and then strips away
+    /// the combining marks (accents).
+    ///
+    /// - Returns: A new string with accents removed. For example, café, will return cafe.
+    private func removeAccents() -> String {
+        // Normalize the string to NFD (Normalization Form Decomposition)
+        let normalizedString = self as NSString
+        let range = NSRange(location: 0, length: normalizedString.length)
+
+        // Apply the transform to remove diacritics
+        let transformedString = normalizedString.applyingTransform(.toLatin, reverse: false) ?? ""
+        let finalString = transformedString.applyingTransform(.stripCombiningMarks, reverse: false) ?? ""
+
+        return finalString
+    }
+
 }

--- a/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -426,7 +426,7 @@ final class LocalBookmarkManager: BookmarkManager {
         while !queue.isEmpty {
             let current = queue.removeFirst()
 
-            if current.title.lowercased().contains(query.lowercased()) {
+            if current.title.removingAccents().lowercased().contains(query.removingAccents().lowercased()) {
                 result.append(current)
             }
 

--- a/DuckDuckGo/Common/Extensions/StringExtension.swift
+++ b/DuckDuckGo/Common/Extensions/StringExtension.swift
@@ -85,7 +85,13 @@ extension String {
         self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    func removingAccents() -> String {
+    var cleanStringForBookmarkSearch: String {
+        self.removeAccents()
+            .replacingOccurrences(of: "[^a-zA-Z0-9]", with: "", options: .regularExpression)
+            .lowercased()
+    }
+
+    private func removeAccents() -> String {
         // Normalize the string to NFD (Normalization Form Decomposition)
         let normalizedString = self as NSString
         let range = NSRange(location: 0, length: normalizedString.length)

--- a/DuckDuckGo/Common/Extensions/StringExtension.swift
+++ b/DuckDuckGo/Common/Extensions/StringExtension.swift
@@ -85,24 +85,6 @@ extension String {
         self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    var cleanStringForBookmarkSearch: String {
-        self.removeAccents()
-            .replacingOccurrences(of: "[^a-zA-Z0-9]", with: "", options: .regularExpression)
-            .lowercased()
-    }
-
-    private func removeAccents() -> String {
-        // Normalize the string to NFD (Normalization Form Decomposition)
-        let normalizedString = self as NSString
-        let range = NSRange(location: 0, length: normalizedString.length)
-
-        // Apply the transform to remove diacritics
-        let transformedString = normalizedString.applyingTransform(.toLatin, reverse: false) ?? ""
-        let finalString = transformedString.applyingTransform(.stripCombiningMarks, reverse: false) ?? ""
-
-        return finalString
-    }
-
     // MARK: - URL
 
     var url: URL? {

--- a/DuckDuckGo/Common/Extensions/StringExtension.swift
+++ b/DuckDuckGo/Common/Extensions/StringExtension.swift
@@ -85,6 +85,18 @@ extension String {
         self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    func removingAccents() -> String {
+        // Normalize the string to NFD (Normalization Form Decomposition)
+        let normalizedString = self as NSString
+        let range = NSRange(location: 0, length: normalizedString.length)
+
+        // Apply the transform to remove diacritics
+        let transformedString = normalizedString.applyingTransform(.toLatin, reverse: false) ?? ""
+        let finalString = transformedString.applyingTransform(.stripCombiningMarks, reverse: false) ?? ""
+
+        return finalString
+    }
+
     // MARK: - URL
 
     var url: URL? {

--- a/UnitTests/Bookmarks/Model/LocalBookmarkManagerTests.swift
+++ b/UnitTests/Bookmarks/Model/LocalBookmarkManagerTests.swift
@@ -348,6 +348,37 @@ final class LocalBookmarkManagerTests: XCTestCase {
         XCTAssertTrue(resultsWithNotCapitalizedQuery.count == 2)
     }
 
+    @MainActor
+    func testSearchIgnoresAccents() {
+        let coffeeBookmark = Bookmark(id: "1", url: "www.coffee.com", title: "Mi café favorito", isFavorite: true)
+        let coffeeTwoBookmark = Bookmark(id: "1", url: "www.coffee.com", title: "Mi cafe favorito", isFavorite: true)
+
+        let bookmarkStore = BookmarkStoreMock(bookmarks: [coffeeBookmark, coffeeTwoBookmark])
+        let sut = LocalBookmarkManager(bookmarkStore: bookmarkStore, faviconManagement: FaviconManagerMock())
+
+        sut.loadBookmarks()
+
+        let resultsWithoutAccent = sut.search(by: "cafe")
+        let resultsWithAccent = sut.search(by: "café")
+
+        XCTAssertTrue(resultsWithoutAccent.count == 2)
+        XCTAssertTrue(resultsWithAccent.count == 2)
+    }
+
+    @MainActor
+    func testWhenASearchIsDoneWithoutAccenttsThenItMatchesBookmarksWithoutAccent() {
+        let coffeeBookmark = Bookmark(id: "1", url: "www.coffee.com", title: "Mi café favorito", isFavorite: true)
+
+        let bookmarkStore = BookmarkStoreMock(bookmarks: [coffeeBookmark])
+        let sut = LocalBookmarkManager(bookmarkStore: bookmarkStore, faviconManagement: FaviconManagerMock())
+
+        sut.loadBookmarks()
+
+        let results = sut.search(by: "cafe")
+
+        XCTAssertTrue(results.count == 1)
+    }
+
     private func topLevelBookmarks() -> [BaseBookmarkEntity] {
         let topBookmark = Bookmark(id: "4", url: "www.favorite.com", title: "Favorite bookmark", isFavorite: true)
         let favoriteFolder = BookmarkFolder(id: "5", title: "Favorite folder", children: [topBookmark])

--- a/UnitTests/Bookmarks/Model/LocalBookmarkManagerTests.swift
+++ b/UnitTests/Bookmarks/Model/LocalBookmarkManagerTests.swift
@@ -379,6 +379,34 @@ final class LocalBookmarkManagerTests: XCTestCase {
         XCTAssertTrue(results.count == 1)
     }
 
+    @MainActor
+    func testWhenBookmarkHasASymbolThenItsIgnoredWhenSearching() {
+        let bookmark = Bookmark(id: "1", url: "www.test.com", title: "Site • Login", isFavorite: true)
+
+        let bookmarkStore = BookmarkStoreMock(bookmarks: [bookmark])
+        let sut = LocalBookmarkManager(bookmarkStore: bookmarkStore, faviconManagement: FaviconManagerMock())
+
+        sut.loadBookmarks()
+
+        let results = sut.search(by: "site login")
+
+        XCTAssertTrue(results.count == 1)
+    }
+
+    @MainActor
+    func testSearchQueryHasASymbolThenItsIgnoredWhenSearching() {
+        let bookmark = Bookmark(id: "1", url: "www.test.com", title: "Site Login", isFavorite: true)
+
+        let bookmarkStore = BookmarkStoreMock(bookmarks: [bookmark])
+        let sut = LocalBookmarkManager(bookmarkStore: bookmarkStore, faviconManagement: FaviconManagerMock())
+
+        sut.loadBookmarks()
+
+        let results = sut.search(by: "site • login")
+
+        XCTAssertTrue(results.count == 1)
+    }
+
     private func topLevelBookmarks() -> [BaseBookmarkEntity] {
         let topBookmark = Bookmark(id: "4", url: "www.favorite.com", title: "Favorite bookmark", isFavorite: true)
         let favoriteFolder = BookmarkFolder(id: "5", title: "Favorite folder", children: [topBookmark])


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203972458584429/1208262956542583/f
Tech Design URL: 
CC:

## Description
**Acceptance criteria**
**AC#1**
Given a user with a bookmark with an accent, for example `café` , when searching for `cafe` we should return the bookmark with the accent.

**AC#2**
Given a user with a bookmark without an accent, for example `cafe` , when searching for `café` we should return the bookmark without the accent, ignoring the accent on the search query.

**AC#3**
Given a user with a bookmark with symbols, for example, Site • Login , when searching for site login then we should return the bookmark with the symbol

**AC#4**
Given a user with a bookmark without symbols, for example, Site Login , when searching for site • login then we should return the bookmark without the symbol ignoring the symbol in the search query.


## Steps to test this PR

**Accents**
1. Add a bookmark, and in the bookmark name, add it with an accent. For example, `café`
2. Go to the bookmarks manager or the bookmark panel and start a search
3. Search for `cafe` (without the accent)
4. It should return the result
5. Do the same thing but viceversa. Create a bookmark without an accent, for example, `cafe`, and search for `café`, the accent should be ignored and the result should be returned in the search.


**Symbols**
1. Add a bookmark, and in the bookmark name, add it with a symbol. For example, `Site • Login`
2. Go to the bookmarks manager or the bookmark panel and start a search
3. Search for `site login` (without the symbol)
4. It should return the result
5. Do the same thing but viceversa. 

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
