### PR TITLE
Freemium PIR: Enable Multi-Window Shared UI State

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -99,6 +99,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Freemium DBP
     public let freemiumDBPFeature: FreemiumDBPFeature
+    public let freemiumDBPPromotionViewCoordinator: FreemiumDBPPromotionViewCoordinator
     private var freemiumDBPScanResultPolling: FreemiumDBPScanResultPolling?
 
     // MARK: - VPN
@@ -272,9 +273,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Freemium DBP
         let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
         freemiumDBPFeature = DefaultFreemiumDBPFeature(privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
-                                                                     subscriptionManager: subscriptionManager,
-                                                                     accountManager: subscriptionManager.accountManager,
+                                                       subscriptionManager: subscriptionManager,
+                                                       accountManager: subscriptionManager.accountManager,
                                                        freemiumDBPUserStateManager: freemiumDBPUserStateManager)
+        freemiumDBPPromotionViewCoordinator = FreemiumDBPPromotionViewCoordinator(freemiumDBPUserStateManager: freemiumDBPUserStateManager,
+                                                                                  freemiumDBPFeature: freemiumDBPFeature)
     }
 
     func applicationWillFinishLaunching(_ notification: Notification) {

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -791,9 +791,7 @@ final class BrowserTabViewController: NSViewController {
         return homePageViewController ?? {
             let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
             let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
-
-            let freemiumDBPPromotionViewCoordinator = FreemiumDBPPromotionViewCoordinator(freemiumDBPUserStateManager: freemiumDBPUserStateManager,
-                                                                                             freemiumDBPFeature: freemiumDBPFeature)
+            let freemiumDBPPromotionViewCoordinator = Application.appDelegate.freemiumDBPPromotionViewCoordinator
             let homePageViewController = HomePageViewController(tabCollectionViewModel: tabCollectionViewModel, bookmarkManager: bookmarkManager,
                                                                 freemiumDBPPromotionViewCoordinator: freemiumDBPPromotionViewCoordinator)
             self.homePageViewController = homePageViewController

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -789,8 +789,6 @@ final class BrowserTabViewController: NSViewController {
     var homePageViewController: HomePageViewController?
     private func homePageViewControllerCreatingIfNeeded() -> HomePageViewController {
         return homePageViewController ?? {
-            let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
-            let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
             let freemiumDBPPromotionViewCoordinator = Application.appDelegate.freemiumDBPPromotionViewCoordinator
             let homePageViewController = HomePageViewController(tabCollectionViewModel: tabCollectionViewModel, bookmarkManager: bookmarkManager,
                                                                 freemiumDBPPromotionViewCoordinator: freemiumDBPPromotionViewCoordinator)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206488453854252/1208294167066324/f

**Description**: This PR moves the declaration of FreemiumDBPPromotionViewCoordinator to the App Delegate to enable UI state to be shared by multiple windows (ensuring the new tab page is updated as expected when state changes)

**Testing Prerequisites**
1. Make sure you are an internal user
2. Disable/Signout of Privacy Pro (Settings menu -> PP -> Remove from this device)

**Steps to test this PR**:
1. Launch the browser
2. Ensure you see a Freemium PIR promotion banner on the new tab page
3. Launch a new window
4. Click the ’Scan’ button on the new tab page in one of the windows
5. Ensure the banner is removed from the new tab page in both windows (you might need to focus the other window to force it to update it’s UI)

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
