### PR TITLE
Maintain scroll position, selection and expanded/collapsed when returning from search on bookmarks panel

### DIFF
--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -112,6 +112,7 @@ final class BookmarkListViewController: NSViewController {
         }
         return [BookmarkNode]()
     }
+    private var lastOutlineScrollPosition: NSRect?
 
     private(set) lazy var faviconsFetcherOnboarding: FaviconsFetcherOnboarding? = {
         guard let syncService = NSApp.delegateTyped.syncService, let syncBookmarksAdapter = NSApp.delegateTyped.syncDataProviders?.bookmarksAdapter else {
@@ -738,6 +739,11 @@ extension BookmarkListViewController: NSSearchFieldDelegate {
 
             if searchQuery.isBlank {
                 showTreeView()
+
+                /// Reset to the last scroll position if available
+                if let lastOutlineScrollPosition = self.lastOutlineScrollPosition {
+                    outlineView.scrollToVisible(lastOutlineScrollPosition)
+                }
             } else {
                 showSearch(forSearchQuery: searchQuery)
             }
@@ -747,6 +753,12 @@ extension BookmarkListViewController: NSSearchFieldDelegate {
     }
 
     private func showSearch(forSearchQuery searchQuery: String) {
+        /// Before searching for the first letter we store the current outline scroll position.
+        /// This is needed because we want to maintain the scroll position in case the search is cancelled.
+        if searchQuery.count == 1 {
+            self.lastOutlineScrollPosition = outlineView.visibleRect
+        }
+
         outlineView.highlightedRow = nil
         dataSource.reloadData(forSearchQuery: searchQuery, sortMode: sortBookmarksViewModel.selectedSortMode)
 

--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -499,6 +499,9 @@ final class BookmarkListViewController: NSViewController {
         if !isSearchVisible {
             outlineView.makeMeFirstResponder()
         }
+
+        let selectedNodes = self.selectedNodes
+        expandAndRestore(selectedNodes: selectedNodes)
     }
 
     private func expandFoldersAndScrollUntil(_ folder: BookmarkFolder) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208262956542585/f
Tech Design URL:
CC:

**Description**:
**Given** a user on the bookmarks panel, **when** the user starts a search and comes back to the tree view, **then** the selected, collapsed and expanded folders or bookmarks should be maintained.


https://github.com/user-attachments/assets/5ae781ab-e6c5-4e48-87e1-7eea9b267fda



**Steps to test this PR**:
1. Load a bunch of bookmarks
2. Go to the bookmarks panel, scroll to the last position and open some folders
3. Start a search, type something, and then cancel the search
4. The opened folders should be expanded, and the scroll position should be the same before the search.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
