### PR TITLE
Trigger add-task-to-project when PR marked ready for review

### DIFF
--- a/.github/workflows/pr_task_url.yml
+++ b/.github/workflows/pr_task_url.yml
@@ -2,7 +2,7 @@ name: Asana PR Task URL
 
 on: 
   pull_request:
-    types: [opened, edited, closed, synchronize, review_requested]
+    types: [opened, edited, closed, synchronize, review_requested, ready_for_review]
 
 jobs:
 
@@ -13,6 +13,8 @@ jobs:
     name: Add Task to App Board Project
 
     runs-on: ubuntu-latest
+
+    if: ${{ !github.event.pull_request.draft }}
 
     outputs:
       task_id: ${{ steps.get-task-id.outputs.task_id }}

--- a/.github/workflows/pr_task_url.yml
+++ b/.github/workflows/pr_task_url.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Add Task to the App Board Project
       id: add-task-to-project
-      if: ${{ github.event.action == 'opened' && steps.check-board-membership.outputs.task_in_project == '0' }}
+      if: ${{ (github.event.action == 'opened' || github.event.action == 'ready_for_review') && steps.check-board-membership.outputs.task_in_project == '0' }}
       env:
         ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
         ASANA_PROJECT_ID: ${{ vars.MACOS_APP_BOARD_ASANA_PROJECT_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208036161861763/1207931637636063/f

## Description

Trigger add-task-to-project when PR marked ready for review

## Testing

You can reproduce these steps by creating a copy of this branch and opening a PR to see the CI behavior.

1. This is what was shown in the CI checks when I opened this as a draft without links.

<img width="811" alt="Screenshot 2024-09-13 at 3 42 20 PM" src="https://github.com/user-attachments/assets/703ad6e0-0d07-4d31-8441-9f721bdda0b3">

2. This is what I saw after adding a link, when I changed the status to "Ready for Review"

<img width="827" alt="Screenshot 2024-09-13 at 3 45 21 PM" src="https://github.com/user-attachments/assets/2c9ad211-a4cc-4709-9b15-d754da1e0194">

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
