### PR TITLE
Wait for UserScripts to be loaded for subscription pages

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
@@ -22,6 +22,7 @@ import Common
 import ContentBlocking
 import Foundation
 import Navigation
+import Subscription
 import os.log
 
 struct DetectedTracker {
@@ -100,7 +101,9 @@ extension ContentBlockingTabExtension: NavigationResponder {
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
         if !navigationAction.url.isDuckDuckGo
             // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/email/
-            || navigationAction.url.absoluteString.hasPrefix(URL.duckDuckGoEmailLogin.absoluteString) {
+            || navigationAction.url.absoluteString.hasPrefix(URL.duckDuckGoEmailLogin.absoluteString)
+            // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/subscriptions
+            || navigationAction.url.absoluteString.hasPrefix(SubscriptionURL.baseURL.subscriptionURL(environment: .production).absoluteString) {
             await prepareForContentBlocking()
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207435976391442/1208283514585319/f

**Description**:
Wait for UserScripts to be loaded for subscription pages

**Steps to test this PR**:
1. Activate Settings->General->Reopen all windows from last session
2. Open Privacy Pro purchase page "…" -> "Privacy Pro"
3. Quit
4. rm -rf ~/Library/WebKit/com.duckduckgo.macos.browser.debug/ContentRuleLists
5. Run; validate Privacy Pro purchase page loads successfully and it is not redirected to an empty SERP page
-
1. Search for "Privacy Pro"
2. From SERP results find one for https://duckduckgo.com/pro
3. CMD + click the result multiple times to open the result in other tabs
4. Verify that all tabs have opened Privacy Pro purchase page successfully and none was redirected to an empty SERP page

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
