### PR TITLE
Freemium DBP: Change didOnboard State to didActivate

### DIFF
--- a/DuckDuckGo/DBP/DataBrokerProtectionFeatureGatekeeper.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionFeatureGatekeeper.swift
@@ -88,7 +88,7 @@ struct DefaultDataBrokerProtectionFeatureGatekeeper: DataBrokerProtectionFeature
     func arePrerequisitesSatisfied() async -> Bool {
 
         let isAuthenticated = accountManager.isUserAuthenticated
-        if !isAuthenticated && freemiumDBPUserStateManager.didOnboard { return true }
+        if !isAuthenticated && freemiumDBPUserStateManager.didActivate { return true }
 
         let entitlements = await accountManager.hasEntitlement(forProductName: .dataBrokerProtection,
                                                                cachePolicy: .reloadIgnoringLocalCacheData)

--- a/DuckDuckGo/DBP/DataBrokerProtectionFeatureGatekeeper.swift
+++ b/DuckDuckGo/DBP/DataBrokerProtectionFeatureGatekeeper.swift
@@ -81,7 +81,7 @@ struct DefaultDataBrokerProtectionFeatureGatekeeper: DataBrokerProtectionFeature
     /// Checks DBP prerequisites
     ///
     /// Prerequisites are satisified if either:
-    /// 1. The user is an active freemium user (e.g has onboarded to freemium and is not authenticated)
+    /// 1. The user is an active freemium user (e.g has activated freemium and is not authenticated)
     /// 2. The user has a subscription with valid entitlements
     ///
     /// - Returns: Bool indicating prerequisites are satisfied

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
@@ -155,7 +155,7 @@ private extension DefaultFreemiumDBPFeature {
 
     /// Returns true IFF:
     ///
-    /// 1. The user did onboard to Freemium DBP
+    /// 1. The user did activate Freemium DBP
     /// 2. The feature flag is disabled
     /// 3. The user `isPotentialPrivacyProSubscriber` (see definition)
     var shouldDisableAndDelete: Bool {

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
@@ -159,7 +159,7 @@ private extension DefaultFreemiumDBPFeature {
     /// 2. The feature flag is disabled
     /// 3. The user `isPotentialPrivacyProSubscriber` (see definition)
     var shouldDisableAndDelete: Bool {
-        guard freemiumDBPUserStateManager.didOnboard else { return false }
+        guard freemiumDBPUserStateManager.didActivate else { return false }
 
         return !privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(DBPSubfeature.freemium)
         && isPotentialPrivacyProSubscriber

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPFirstProfileSavedNotifier.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPFirstProfileSavedNotifier.swift
@@ -23,7 +23,7 @@ import Subscription
 import OSLog
 
 /// A concrete implementation of the `DBPProfileSavedNotifier` protocol that handles posting the "Profile Saved" notification
-/// for Freemium users based on their onboarding status, authentication state, and if this is their first saved profile. This class ensures the notification is posted only once.
+/// for Freemium users based on their Freemium activation state, authentication state, and if this is their first saved profile. This class ensures the notification is posted only once.
 final class FreemiumDBPFirstProfileSavedNotifier: DBPProfileSavedNotifier {
 
     private var freemiumDBPUserStateManager: FreemiumDBPUserStateManager
@@ -44,7 +44,7 @@ final class FreemiumDBPFirstProfileSavedNotifier: DBPProfileSavedNotifier {
 
     /// Posts the "Profile Saved" notification if the following conditions are met:
     /// - The user is not authenticated
-    /// - The user has completed the freemium onboarding process.
+    /// - The user has activated Freemium (i.e accessed the feature).
     /// - The "Profile Saved" notification has not already been posted.
     ///
     /// If all conditions are met, the method posts a `pirProfileSaved` notification via the `NotificationCenter` and records that the notification has been posted.

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPFirstProfileSavedNotifier.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPFirstProfileSavedNotifier.swift
@@ -50,7 +50,7 @@ final class FreemiumDBPFirstProfileSavedNotifier: DBPProfileSavedNotifier {
     /// If all conditions are met, the method posts a `pirProfileSaved` notification via the `NotificationCenter` and records that the notification has been posted.
     func postProfileSavedNotificationIfPermitted() {
         guard !accountManager.isUserAuthenticated
-                && freemiumDBPUserStateManager.didOnboard
+                && freemiumDBPUserStateManager.didActivate
                 && !freemiumDBPUserStateManager.didPostFirstProfileSavedNotification else { return }
 
         Logger.freemiumDBP.debug("[Freemium DBP] Posting Profile Saved Notification")

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPPresenter.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPPresenter.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// Conforming types provide functionality to show Freemium DBP
 protocol FreemiumDBPPresenter {
-    func showFreemiumDBP(didOnboard: Bool, windowControllerManager: WindowControllersManagerProtocol?)
+    func showFreemiumDBP(windowControllerManager: WindowControllersManagerProtocol?)
 }
 
 /// Default implementation of `FreemiumDBPPresenter`
@@ -28,26 +28,9 @@ struct DefaultFreemiumDBPPresenter: FreemiumDBPPresenter {
 
     @MainActor
     /// Displays Freemium DBP
-    /// If the `didOnboard` parameter is true, opens DBP directly
-    /// If the `didOnboard` parameter is false, opens Freemium DBP onboarding
-    /// - Parameter didOnboard: Bool indicating if the user has onboarded already
-    func showFreemiumDBP(didOnboard: Bool, windowControllerManager: WindowControllersManagerProtocol? = nil) {
+    func showFreemiumDBP(windowControllerManager: WindowControllersManagerProtocol? = nil) {
 
         let windowControllerManager = windowControllerManager ?? WindowControllersManager.shared
-
-        if didOnboard {
-            windowControllerManager.showTab(with: .dataBrokerProtection)
-        } else  {
-            // TODO: - Onboard (i.e Ts and Cs)
-            showFreemiumDBPOnboarding()
-        }
-    }
-}
-
-private extension DefaultFreemiumDBPPresenter {
-
-    @MainActor
-    func showFreemiumDBPOnboarding() {
-        // TODO: - Show onboarding if we decide to do this
+        windowControllerManager.showTab(with: .dataBrokerProtection)
     }
 }

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPPresenter.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPPresenter.swift
@@ -17,20 +17,28 @@
 //
 
 import Foundation
+import Freemium
 
 /// Conforming types provide functionality to show Freemium DBP
 protocol FreemiumDBPPresenter {
-    func showFreemiumDBP(windowControllerManager: WindowControllersManagerProtocol?)
+    func showFreemiumDBPAndSetActivated(windowControllerManager: WindowControllersManagerProtocol?)
 }
 
 /// Default implementation of `FreemiumDBPPresenter`
-struct DefaultFreemiumDBPPresenter: FreemiumDBPPresenter {
+final class DefaultFreemiumDBPPresenter: FreemiumDBPPresenter {
+
+    private var freemiumDBPStateManager: FreemiumDBPUserStateManager
+
+    init(freemiumDBPStateManager: FreemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)) {
+        self.freemiumDBPStateManager = freemiumDBPStateManager
+    }
 
     @MainActor
     /// Displays Freemium DBP
-    func showFreemiumDBP(windowControllerManager: WindowControllersManagerProtocol? = nil) {
+    func showFreemiumDBPAndSetActivated(windowControllerManager: WindowControllersManagerProtocol? = nil) {
 
         let windowControllerManager = windowControllerManager ?? WindowControllersManager.shared
+        freemiumDBPStateManager.didActivate = true
         windowControllerManager.showTab(with: .dataBrokerProtection)
     }
 }

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinating.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinating.swift
@@ -99,7 +99,6 @@ private extension FreemiumDBPPromotionViewCoordinator {
     /// Action to be executed when the user proceeds with the promotion (e.g opens DBP)
     var proceedAction: () -> Void {
         { [weak self] in
-            self?.markUserAsOnboarded()
             self?.showFreemiumDBP()
             self?.dismissHomePagePromotion()
         }
@@ -112,17 +111,9 @@ private extension FreemiumDBPPromotionViewCoordinator {
         }
     }
 
-    /// Marks the user as onboarded in the Freemium DBP system.
-    func markUserAsOnboarded() {
-        freemiumDBPUserStateManager.didOnboard = true
-    }
-
     /// Shows the Freemium DBP user interface via the presenter.
     func showFreemiumDBP() {
-        freemiumDBPPresenter.showFreemiumDBP(
-            didOnboard: freemiumDBPUserStateManager.didOnboard,
-            windowControllerManager: WindowControllersManager.shared
-        )
+        freemiumDBPPresenter.showFreemiumDBP(windowControllerManager: WindowControllersManager.shared)
     }
 
     /// Dismisses the home page promotion and updates the user state to reflect this.

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinating.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinating.swift
@@ -113,7 +113,7 @@ private extension FreemiumDBPPromotionViewCoordinator {
 
     /// Shows the Freemium DBP user interface via the presenter.
     func showFreemiumDBP() {
-        freemiumDBPPresenter.showFreemiumDBP(windowControllerManager: WindowControllersManager.shared)
+        freemiumDBPPresenter.showFreemiumDBPAndSetActivated(windowControllerManager: WindowControllersManager.shared)
     }
 
     /// Dismisses the home page promotion and updates the user state to reflect this.

--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinating.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinating.swift
@@ -56,7 +56,7 @@ final class FreemiumDBPPromotionViewCoordinator: FreemiumDBPPromotionViewCoordin
         }
     }
 
-    /// The user state manager, which tracks the user's onboarding status and scan results.
+    /// The user state manager, which tracks the user's activation status and scan results.
     private var freemiumDBPUserStateManager: FreemiumDBPUserStateManager
 
     /// Responsible for determining the availability of Freemium DBP.

--- a/DuckDuckGo/Freemium/FreemiumDebugMenu.swift
+++ b/DuckDuckGo/Freemium/FreemiumDebugMenu.swift
@@ -34,8 +34,8 @@ final class FreemiumDebugMenu: NSMenuItem {
     private func makeSubmenu() -> NSMenu {
         let menu = NSMenu(title: "")
 
-        menu.addItem(NSMenuItem(title: "Set Freemium DBP Onboarded State TRUE", action: #selector(setFreemiumDBPActivateStateTrue), target: self))
-        menu.addItem(NSMenuItem(title: "Set Freemium DBP Onboarded State FALSE", action: #selector(setFreemiumDBPActivateStateFalse), target: self))
+        menu.addItem(NSMenuItem(title: "Set Freemium DBP Activated State TRUE", action: #selector(setFreemiumDBPActivateStateTrue), target: self))
+        menu.addItem(NSMenuItem(title: "Set Freemium DBP Activated State FALSE", action: #selector(setFreemiumDBPActivateStateFalse), target: self))
         menu.addItem(NSMenuItem(title: "Set Freemium DBP First Profile Saved Timestamp NIL", action: #selector(setFirstProfileSavedTimestampNil), target: self))
         menu.addItem(NSMenuItem(title: "Set Freemium DBP Did Post First Profile Saved FALSE", action: #selector(setDidPostFirstProfileSavedNotificationFalse), target: self))
         menu.addItem(NSMenuItem(title: "Set Freemium DBP Did Post Results FALSE", action: #selector(setDidPostResultsNotificationFalse), target: self))

--- a/DuckDuckGo/Freemium/FreemiumDebugMenu.swift
+++ b/DuckDuckGo/Freemium/FreemiumDebugMenu.swift
@@ -34,8 +34,8 @@ final class FreemiumDebugMenu: NSMenuItem {
     private func makeSubmenu() -> NSMenu {
         let menu = NSMenu(title: "")
 
-        menu.addItem(NSMenuItem(title: "Set Freemium DBP Onboarded State TRUE", action: #selector(setFreemiumDBPOnboardStateTrue), target: self))
-        menu.addItem(NSMenuItem(title: "Set Freemium DBP Onboarded State FALSE", action: #selector(setFreemiumDBPOnboardStateFalse), target: self))
+        menu.addItem(NSMenuItem(title: "Set Freemium DBP Onboarded State TRUE", action: #selector(setFreemiumDBPActivateStateTrue), target: self))
+        menu.addItem(NSMenuItem(title: "Set Freemium DBP Onboarded State FALSE", action: #selector(setFreemiumDBPActivateStateFalse), target: self))
         menu.addItem(NSMenuItem(title: "Set Freemium DBP First Profile Saved Timestamp NIL", action: #selector(setFirstProfileSavedTimestampNil), target: self))
         menu.addItem(NSMenuItem(title: "Set Freemium DBP Did Post First Profile Saved FALSE", action: #selector(setDidPostFirstProfileSavedNotificationFalse), target: self))
         menu.addItem(NSMenuItem(title: "Set Freemium DBP Did Post Results FALSE", action: #selector(setDidPostResultsNotificationFalse), target: self))
@@ -51,13 +51,13 @@ final class FreemiumDebugMenu: NSMenuItem {
     }
 
     @objc
-    func setFreemiumDBPOnboardStateTrue() {
-        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didOnboard = true
+    func setFreemiumDBPActivateStateTrue() {
+        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didActivate = true
     }
 
     @objc
-    func setFreemiumDBPOnboardStateFalse() {
-        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didOnboard = false
+    func setFreemiumDBPActivateStateFalse() {
+        DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didActivate = false
     }
 
     @objc
@@ -93,7 +93,7 @@ final class FreemiumDebugMenu: NSMenuItem {
     @objc
     func logAllState() {
 
-        Logger.freemiumDBP.debug("FREEMIUM DBP: DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didOnboard \(DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didOnboard)")
+        Logger.freemiumDBP.debug("FREEMIUM DBP: DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didActivate \(DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didActivate)")
         Logger.freemiumDBP.debug("FREEMIUM DBP: DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).firstProfileSavedTimestamp \(DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).firstProfileSavedTimestamp ?? "Nil")")
         Logger.freemiumDBP.debug("FREEMIUM DBP: DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didPostFirstProfileSavedNotification \(DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didPostFirstProfileSavedNotification)")
         Logger.freemiumDBP.debug("FREEMIUM DBP: DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didPostResultsNotification \(DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didPostResultsNotification)")

--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -271,7 +271,7 @@ final class MoreOptionsMenu: NSMenu {
 
     @MainActor
     @objc func openFreemiumDBP(_ sender: NSMenuItem) {
-        freemiumDBPPresenter.showFreemiumDBP(windowControllerManager: WindowControllersManager.shared)
+        freemiumDBPPresenter.showFreemiumDBPAndSetActivated(windowControllerManager: WindowControllersManager.shared)
         notificationCenter.post(name: .freemiumDBPEntryPointActivated, object: nil)
     }
 

--- a/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -60,7 +60,6 @@ final class MoreOptionsMenu: NSMenu {
     private lazy var sharingMenu: NSMenu = SharingMenu(title: UserText.shareMenuItem)
     private var accountManager: AccountManager { subscriptionManager.accountManager }
     private let subscriptionManager: SubscriptionManager
-    private var freemiumDBPUserStateManager: FreemiumDBPUserStateManager
     private let freemiumDBPFeature: FreemiumDBPFeature
     private let freemiumDBPPresenter: FreemiumDBPPresenter
     private let appearancePreferences: AppearancePreferences
@@ -83,7 +82,6 @@ final class MoreOptionsMenu: NSMenu {
          sharingMenu: NSMenu? = nil,
          internalUserDecider: InternalUserDecider,
          subscriptionManager: SubscriptionManager,
-         freemiumDBPUserStateManager: FreemiumDBPUserStateManager,
          freemiumDBPFeature: FreemiumDBPFeature,
          freemiumDBPPresenter: FreemiumDBPPresenter = DefaultFreemiumDBPPresenter(),
          appearancePreferences: AppearancePreferences = .shared,
@@ -96,7 +94,6 @@ final class MoreOptionsMenu: NSMenu {
         self.subscriptionFeatureAvailability = subscriptionFeatureAvailability
         self.internalUserDecider = internalUserDecider
         self.subscriptionManager = subscriptionManager
-        self.freemiumDBPUserStateManager = freemiumDBPUserStateManager
         self.freemiumDBPFeature = freemiumDBPFeature
         self.freemiumDBPPresenter = freemiumDBPPresenter
         self.appearancePreferences = appearancePreferences
@@ -274,13 +271,7 @@ final class MoreOptionsMenu: NSMenu {
 
     @MainActor
     @objc func openFreemiumDBP(_ sender: NSMenuItem) {
-
-        // TODO: Remove this
-        freemiumDBPUserStateManager.didOnboard = true
-        // ------
-
-        freemiumDBPPresenter.showFreemiumDBP(didOnboard: freemiumDBPUserStateManager.didOnboard, windowControllerManager: WindowControllersManager.shared)
-
+        freemiumDBPPresenter.showFreemiumDBP(windowControllerManager: WindowControllersManager.shared)
         notificationCenter.post(name: .freemiumDBPEntryPointActivated, object: nil)
     }
 

--- a/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -286,14 +286,12 @@ final class NavigationBarViewController: NSViewController {
 
     @IBAction func optionsButtonAction(_ sender: NSButton) {
         let internalUserDecider = NSApp.delegateTyped.internalUserDecider
-        let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
         let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
         let menu = MoreOptionsMenu(tabCollectionViewModel: tabCollectionViewModel,
                                    passwordManagerCoordinator: PasswordManagerCoordinator.shared,
                                    vpnFeatureGatekeeper: DefaultVPNFeatureGatekeeper(subscriptionManager: subscriptionManager),
                                    internalUserDecider: internalUserDecider,
                                    subscriptionManager: subscriptionManager,
-                                   freemiumDBPUserStateManager: freemiumDBPUserStateManager,
                                    freemiumDBPFeature: freemiumDBPFeature)
 
         menu.actionDelegate = self

--- a/DuckDuckGo/RemoteMessaging/RemoteMessagingConfigMatcherProvider.swift
+++ b/DuckDuckGo/RemoteMessaging/RemoteMessagingConfigMatcherProvider.swift
@@ -138,7 +138,7 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
         let deprecatedRemoteMessageStorage = DefaultSurveyRemoteMessagingStorage.surveys()
 
         let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
-        let isCurrentFreemiumDBPUser = !subscriptionManager.accountManager.isUserAuthenticated && freemiumDBPUserStateManager.didOnboard
+        let isCurrentFreemiumDBPUser = !subscriptionManager.accountManager.isUserAuthenticated && freemiumDBPUserStateManager.didActivate
 
         return RemoteMessagingConfigMatcher(
             appAttributeMatcher: AppAttributeMatcher(statisticsStore: statisticsStore,

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Utils/DataBrokerProtectionAgentStopper.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Utils/DataBrokerProtectionAgentStopper.swift
@@ -62,9 +62,9 @@ struct DefaultDataBrokerProtectionAgentStopper: DataBrokerProtectionAgentStopper
         do {
             let hasProfile = try dataManager.fetchProfile() != nil
             let isAuthenticated = authenticationManager.isUserAuthenticated
-            let didOnboardToFreemium = freemiumDBPUserStateManager.didOnboard
+            let didActivateFreemium = freemiumDBPUserStateManager.didActivate
 
-            if !hasProfile || (!isAuthenticated && !didOnboardToFreemium) {
+            if !hasProfile || (!isAuthenticated && !didActivateFreemium) {
                 Logger.dataBrokerProtection.debug("Prerequisites are invalid")
                 stopAgent()
                 return
@@ -95,8 +95,8 @@ struct DefaultDataBrokerProtectionAgentStopper: DataBrokerProtectionAgentStopper
 
     private func satisfiesFreemiumPrerequisites() -> Bool {
         let isAuthenticated = authenticationManager.isUserAuthenticated
-        let didOnboardToFreemium = freemiumDBPUserStateManager.didOnboard
-        return !isAuthenticated && didOnboardToFreemium
+        let didActivateFreemium = freemiumDBPUserStateManager.didActivate
+        return !isAuthenticated && didActivateFreemium
     }
 
     private func stopAgent() {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionAgentManagerTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionAgentManagerTests.swift
@@ -89,7 +89,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
 
         mockDataManager.profileToReturn = mockProfile
         mockAuthenticationManager.isUserAuthenticatedValue = true
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let schedulerStartedExpectation = XCTestExpectation(description: "Scheduler started")
         var schedulerStarted = false
@@ -129,7 +129,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
             freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         mockDataManager.profileToReturn = mockProfile
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let schedulerStartedExpectation = XCTestExpectation(description: "Scheduler started")
         var schedulerStarted = false
@@ -175,7 +175,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
             freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         mockDataManager.profileToReturn = nil
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let stopAgentExpectation = XCTestExpectation(description: "Stop agent expectation")
 
@@ -250,7 +250,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
 
         mockDataManager.profileToReturn = mockProfile
         mockAuthenticationManager.isUserAuthenticatedValue = true
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         var startScheduledScansCalled = false
         mockQueueManager.startScheduledAllOperationsIfPermittedCalledCompletion = { _ in
@@ -279,7 +279,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
             freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         mockDataManager.profileToReturn = mockProfile
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         var startScheduledScansCalled = false
         mockQueueManager.startScheduledScanOperationsIfPermittedCalledCompletion = { _ in
@@ -308,7 +308,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
             freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         mockDataManager.profileToReturn = mockProfile
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         var startImmediateScansCalled = false
         mockQueueManager.startImmediateScanOperationsIfPermittedCalledCompletion = { _ in
@@ -337,7 +337,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
             freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         mockDataManager.profileToReturn = mockProfile
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         var startImmediateScansCalled = false
         mockQueueManager.startImmediateScanOperationsIfPermittedCalledCompletion = { _ in
@@ -484,7 +484,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
             freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         mockAuthenticationManager.isUserAuthenticatedValue = true
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         var startScheduledScansCalled = false
         mockQueueManager.startScheduledAllOperationsIfPermittedCalledCompletion = { _ in
@@ -512,7 +512,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
             authenticationManager: mockAuthenticationManager,
             freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         var startScheduledScansCalled = false
         mockQueueManager.startScheduledScanOperationsIfPermittedCalledCompletion = { _ in

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionAgentStopperTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionAgentStopperTests.swift
@@ -47,7 +47,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
                                                               fakeBrokerFlag: DataBrokerDebugFlagFakeBroker())
         mockStopAction = MockDataProtectionStopAction()
         mockFreemiumDBPUserStateManager = MockFreemiumDBPUserStateManager()
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
     }
 
     override func tearDown() {
@@ -63,7 +63,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = false
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = nil
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -80,7 +80,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = false
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = nil
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -97,7 +97,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = nil
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -114,7 +114,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = nil
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -131,7 +131,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = false
         mockAuthenticationManager.hasValidEntitlementValue = false
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -148,7 +148,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = false
         mockAuthenticationManager.hasValidEntitlementValue = false
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -165,7 +165,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = false
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -182,7 +182,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = false
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -199,7 +199,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = false
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -216,7 +216,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = false
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -249,7 +249,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -266,7 +266,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -283,7 +283,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -307,7 +307,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = true
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -331,7 +331,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = true
         mockAuthenticationManager.hasValidEntitlementValue = false
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,
@@ -355,7 +355,7 @@ final class DataBrokerProtectionAgentStopperTests: XCTestCase {
         mockAuthenticationManager.isUserAuthenticatedValue = false
         mockAuthenticationManager.hasValidEntitlementValue = false
         mockDataManager.profileToReturn = fakeProfile
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
 
         let stopper = DefaultDataBrokerProtectionAgentStopper(dataManager: mockDataManager,
                                                               entitlementMonitor: mockEntitlementMonitor,

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -1961,7 +1961,7 @@ struct MockMigrationsProvider: DataBrokerProtectionDatabaseMigrationsProvider {
 
 final class MockFreemiumDBPUserStateManager: FreemiumDBPUserStateManager {
 
-    var didOnboard = false
+    var didActivate = false
     var didPostFirstProfileSavedNotification = false
     var didPostResultsNotification = false
     var didDismissHomePagePromotion = false

--- a/LocalPackages/Freemium/Sources/Freemium/FreemiumDBPUserStateManager.swift
+++ b/LocalPackages/Freemium/Sources/Freemium/FreemiumDBPUserStateManager.swift
@@ -46,8 +46,8 @@ public struct FreemiumDBPMatchResults: Codable, Equatable {
 /// Conforming types are responsible for persisting and retrieving these values.
 public protocol FreemiumDBPUserStateManager {
 
-    /// A boolean value indicating whether the user has completed the onboarding process.
-    var didOnboard: Bool { get set }
+    /// A boolean value indicating whether the user has accessed the Freemium DBP feature
+    var didActivate: Bool { get set }
 
     /// A boolean value indicating whether the "First Profile Saved" notification has been posted.
     var didPostFirstProfileSavedNotification: Bool { get set }
@@ -75,7 +75,7 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
 
     /// Keys for storing the values in `UserDefaults`.
     private enum Keys {
-        static let didOnboard = "macos.browser.freemium.dbp.did.onboard"
+        static let didActivate = "macos.browser.freemium.dbp.did.activate"
         static let didPostFirstProfileSavedNotification = "macos.browser.freemium.dbp.did.post.first.profile.saved.notification"
         static let didPostResultsNotification = "macos.browser.freemium.dbp.did.post.results.notification"
         static let didDismissHomePagePromotion = "macos.browser.freemium.dbp.did.post.dismiss.home.page.promotion"
@@ -87,15 +87,15 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
 
     // MARK: - FreemiumDBPUserStateManager Properties
 
-    /// Tracks whether the user has completed the onboarding process.
+    /// Tracks whether the user has accessed the Freemium DBP feature.
     ///
-    /// - Uses the `UserDefaults` key: `macos.browser.freemium.dbp.did.onboard`.
-    public var didOnboard: Bool {
+    /// - Uses the `UserDefaults` key: `macos.browser.freemium.dbp.did.activate`.
+    public var didActivate: Bool {
         get {
-            userDefaults.bool(forKey: Keys.didOnboard)
+            userDefaults.bool(forKey: Keys.didActivate)
         }
         set {
-            userDefaults.set(newValue, forKey: Keys.didOnboard)
+            userDefaults.set(newValue, forKey: Keys.didActivate)
         }
     }
 
@@ -178,7 +178,7 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     /// Resets all stored user state by clearing or resetting the relevant keys in `UserDefaults`.
     public func resetAllState() {
         // Reset each stored value to its default state
-        userDefaults.removeObject(forKey: Keys.didOnboard)
+        userDefaults.removeObject(forKey: Keys.didActivate)
         userDefaults.removeObject(forKey: Keys.firstProfileSavedTimestamp)
         userDefaults.removeObject(forKey: Keys.didPostFirstProfileSavedNotification)
         userDefaults.removeObject(forKey: Keys.didPostResultsNotification)

--- a/LocalPackages/Freemium/Sources/Freemium/FreemiumDBPUserStateManager.swift
+++ b/LocalPackages/Freemium/Sources/Freemium/FreemiumDBPUserStateManager.swift
@@ -41,7 +41,7 @@ public struct FreemiumDBPMatchResults: Codable, Equatable {
 /// Protocol that manages the user's state in the FreemiumDBP feature.
 ///
 /// The properties in this protocol represent the various states and milestones in the user journey,
-/// such as whether onboarding is complete, notifications have been posted, and important timestamps or data points.
+/// such as whether Freemium is activated (i.e was accessed), notifications have been posted, and important timestamps or data points.
 ///
 /// Conforming types are responsible for persisting and retrieving these values.
 public protocol FreemiumDBPUserStateManager {

--- a/LocalPackages/Freemium/Tests/FreemiumTests/FreemiumDBPUserStateManagerTests.swift
+++ b/LocalPackages/Freemium/Tests/FreemiumTests/FreemiumDBPUserStateManagerTests.swift
@@ -22,7 +22,7 @@ import XCTest
 final class FreemiumDBPUserStateManagerTests: XCTestCase {
 
     private enum Keys {
-        static let didOnboard = "macos.browser.freemium.dbp.did.onboard"
+        static let didActivate = "macos.browser.freemium.dbp.did.activate"
         static let didPostFirstProfileSavedNotification = "macos.browser.freemium.dbp.did.post.first.profile.saved.notification"
         static let didPostResultsNotification = "macos.browser.freemium.dbp.did.post.results.notification"
         static let didDismissHomePagePromotion = "macos.browser.freemium.dbp.did.post.dismiss.home.page.promotion"
@@ -37,27 +37,27 @@ final class FreemiumDBPUserStateManagerTests: XCTestCase {
         testUserDefaults.removePersistentDomain(forName: FreemiumDBPUserStateManagerTests.testSuiteName)
     }
 
-    func testSetsDidOnboard() throws {
+    func testSetsdidActivate() throws {
         // Given
         let sut = DefaultFreemiumDBPUserStateManager(userDefaults: testUserDefaults)
-        XCTAssertFalse(testUserDefaults.bool(forKey: Keys.didOnboard))
+        XCTAssertFalse(testUserDefaults.bool(forKey: Keys.didActivate))
 
         // When
-        sut.didOnboard = true
+        sut.didActivate = true
 
         // Then
-        XCTAssertTrue(testUserDefaults.bool(forKey: Keys.didOnboard))
+        XCTAssertTrue(testUserDefaults.bool(forKey: Keys.didActivate))
     }
 
-    func testGetsDidOnboard() throws {
+    func testGetsdidActivate() throws {
         // Given
         let sut = DefaultFreemiumDBPUserStateManager(userDefaults: testUserDefaults)
-        XCTAssertFalse(sut.didOnboard)
-        testUserDefaults.setValue(true, forKey: Keys.didOnboard)
-        XCTAssertTrue(testUserDefaults.bool(forKey: Keys.didOnboard))
+        XCTAssertFalse(sut.didActivate)
+        testUserDefaults.setValue(true, forKey: Keys.didActivate)
+        XCTAssertTrue(testUserDefaults.bool(forKey: Keys.didActivate))
 
         // When
-        let result = sut.didOnboard
+        let result = sut.didActivate
 
         // Then
         XCTAssertTrue(result)
@@ -206,7 +206,7 @@ final class FreemiumDBPUserStateManagerTests: XCTestCase {
     func testResetAllStateResetsAllProperties() {
         // Given
         let sut = DefaultFreemiumDBPUserStateManager(userDefaults: testUserDefaults)
-        sut.didOnboard = true
+        sut.didActivate = true
         sut.firstProfileSavedTimestamp = "2024-01-01T12:00:00Z"
         sut.didPostFirstProfileSavedNotification = true
         sut.didPostResultsNotification = true
@@ -218,7 +218,7 @@ final class FreemiumDBPUserStateManagerTests: XCTestCase {
         sut.resetAllState()
 
         // Then
-        XCTAssertFalse(sut.didOnboard)
+        XCTAssertFalse(sut.didActivate)
         XCTAssertNil(sut.firstProfileSavedTimestamp)
         XCTAssertFalse(sut.didPostFirstProfileSavedNotification)
         XCTAssertFalse(sut.didPostResultsNotification)

--- a/UnitTests/DBP/Tests/DataBrokerProtectionFeatureGatekeeperTests.swift
+++ b/UnitTests/DBP/Tests/DataBrokerProtectionFeatureGatekeeperTests.swift
@@ -39,7 +39,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
         mockFeatureAvailability = MockFeatureAvailability()
         mockAccountManager = MockAccountManager()
         mockFreemiumDBPUserStateManager = MockFreemiumDBPUserStateManager()
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
     }
 
     func testWhenNoAccessTokenIsFound_butEntitlementIs_andIsNotActiveFreemiumUser_thenFeatureIsDisabled() async {
@@ -63,7 +63,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
         // Given
         mockAccountManager.accessToken = "token"
         mockAccountManager.hasEntitlementResult = .failure(MockError.someError)
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
         sut = DefaultDataBrokerProtectionFeatureGatekeeper(featureDisabler: mockFeatureDisabler,
                                                            userDefaults: userDefaults(),
                                                            subscriptionAvailability: mockFeatureAvailability,
@@ -81,7 +81,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
         // Given
         mockAccountManager.accessToken = "token"
         mockAccountManager.hasEntitlementResult = .failure(MockError.someError)
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
         sut = DefaultDataBrokerProtectionFeatureGatekeeper(featureDisabler: mockFeatureDisabler,
                                                            userDefaults: userDefaults(),
                                                            subscriptionAvailability: mockFeatureAvailability,
@@ -99,7 +99,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
         // Given
         mockAccountManager.accessToken = nil
         mockAccountManager.hasEntitlementResult = .failure(MockError.someError)
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
         sut = DefaultDataBrokerProtectionFeatureGatekeeper(featureDisabler: mockFeatureDisabler,
                                                            userDefaults: userDefaults(),
                                                            subscriptionAvailability: mockFeatureAvailability,
@@ -117,7 +117,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
         // Given
         mockAccountManager.accessToken = "token"
         mockAccountManager.hasEntitlementResult = .success(true)
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
         sut = DefaultDataBrokerProtectionFeatureGatekeeper(featureDisabler: mockFeatureDisabler,
                                                            userDefaults: userDefaults(),
                                                            subscriptionAvailability: mockFeatureAvailability,
@@ -135,7 +135,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
         // Given
         mockAccountManager.accessToken = nil
         mockAccountManager.hasEntitlementResult = .failure(MockError.someError)
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
         sut = DefaultDataBrokerProtectionFeatureGatekeeper(featureDisabler: mockFeatureDisabler,
                                                            userDefaults: userDefaults(),
                                                            subscriptionAvailability: mockFeatureAvailability,

--- a/UnitTests/Freemium/DBP/FreemiumDBPFeatureTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPFeatureTests.swift
@@ -149,7 +149,7 @@ final class FreemiumDBPFeatureTests: XCTestCase {
 
     func testWhenUserDidNotOnboard_thenOffboardingIsNotExecuted() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = false
+        mockFreemiumDBPUserStateManagerManager.didActivate = false
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in false }
         mockSubscriptionManager.canPurchase = true
         mockAccountManager.accessToken = nil
@@ -165,9 +165,9 @@ final class FreemiumDBPFeatureTests: XCTestCase {
         XCTAssertFalse(mockFeatureDisabler.disableAndDeleteWasCalled)
     }
 
-    func testWhenUserDidOnboard_andFeatureIsDisabled_andUserCanPurchase_andUserIsNotSubscribed_thenOffboardingIsExecuted() {
+    func testWhenUserdidActivate_andFeatureIsDisabled_andUserCanPurchase_andUserIsNotSubscribed_thenOffboardingIsExecuted() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = true
+        mockFreemiumDBPUserStateManagerManager.didActivate = true
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in false }
         mockSubscriptionManager.canPurchase = true
         mockAccountManager.accessToken = nil
@@ -187,9 +187,9 @@ final class FreemiumDBPFeatureTests: XCTestCase {
         XCTAssertTrue(mockFeatureDisabler.disableAndDeleteWasCalled)
     }
 
-    func testWhenUserDidOnboard_andFeatureIsDisabled_andUserCanPurchase_andUserIsSubscribed_thenOffboardingIsNotExecuted() {
+    func testWhenUserdidActivate_andFeatureIsDisabled_andUserCanPurchase_andUserIsSubscribed_thenOffboardingIsNotExecuted() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = true
+        mockFreemiumDBPUserStateManagerManager.didActivate = true
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in false }
         mockSubscriptionManager.canPurchase = true
         mockAccountManager.accessToken = "some_token"
@@ -209,9 +209,9 @@ final class FreemiumDBPFeatureTests: XCTestCase {
         XCTAssertFalse(mockFeatureDisabler.disableAndDeleteWasCalled)
     }
 
-    func testWhenUserDidOnboard_andFeatureIsEnabled_andUserCanPurchase_andUserIsNotSubscribed_thenOffboardingIsNotExecuted() {
+    func testWhenUserdidActivate_andFeatureIsEnabled_andUserCanPurchase_andUserIsNotSubscribed_thenOffboardingIsNotExecuted() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = true
+        mockFreemiumDBPUserStateManagerManager.didActivate = true
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in true }
         mockSubscriptionManager.canPurchase = true
         mockAccountManager.accessToken = nil
@@ -224,13 +224,13 @@ final class FreemiumDBPFeatureTests: XCTestCase {
                                         featureDisabler: mockFeatureDisabler)
 
         // Then
-        XCTAssertTrue(mockFreemiumDBPUserStateManagerManager.didOnboard)
+        XCTAssertTrue(mockFreemiumDBPUserStateManagerManager.didActivate)
         XCTAssertFalse(mockFeatureDisabler.disableAndDeleteWasCalled)
     }
 
-    func testWhenUserDidOnboard_andFeatureIsDisabled_andUserCannotPurchase_thenOffboardingIsNotExecuted() {
+    func testWhenUserdidActivate_andFeatureIsDisabled_andUserCannotPurchase_thenOffboardingIsNotExecuted() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = true
+        mockFreemiumDBPUserStateManagerManager.didActivate = true
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in true }
         mockSubscriptionManager.canPurchase = false
         mockAccountManager.accessToken = nil
@@ -243,13 +243,13 @@ final class FreemiumDBPFeatureTests: XCTestCase {
                                         featureDisabler: mockFeatureDisabler)
 
         // Then
-        XCTAssertTrue(mockFreemiumDBPUserStateManagerManager.didOnboard)
+        XCTAssertTrue(mockFreemiumDBPUserStateManagerManager.didActivate)
         XCTAssertFalse(mockFeatureDisabler.disableAndDeleteWasCalled)
     }
 
     func testWhenFeatureFlagValueChangesToEnabled_thenIsAvailablePublisherEmitsCorrectValue() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = false
+        mockFreemiumDBPUserStateManagerManager.didActivate = false
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in false }
         mockSubscriptionManager.canPurchase = true
         mockAccountManager.accessToken = nil
@@ -283,7 +283,7 @@ final class FreemiumDBPFeatureTests: XCTestCase {
 
     func testWhenFeatureFlagValueChangesToDisabled_thenIsAvailablePublisherEmitsCorrectValue() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = true
+        mockFreemiumDBPUserStateManagerManager.didActivate = true
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in true }
         mockSubscriptionManager.canPurchase = true
         mockAccountManager.accessToken = nil
@@ -317,7 +317,7 @@ final class FreemiumDBPFeatureTests: XCTestCase {
 
     func testSubscriptionStatusChangesToSubscribed_thenIsAvailablePublisherEmitsCorrectValue() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = true
+        mockFreemiumDBPUserStateManagerManager.didActivate = true
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in true }
         mockSubscriptionManager.canPurchase = true
         mockAccountManager.accessToken = nil
@@ -351,7 +351,7 @@ final class FreemiumDBPFeatureTests: XCTestCase {
 
     func testSubscriptionStatusChangesToUnsubscribed_thenIsAvailablePublisherEmitsCorrectValue() {
         // Given
-        mockFreemiumDBPUserStateManagerManager.didOnboard = true
+        mockFreemiumDBPUserStateManagerManager.didActivate = true
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in true }
         mockSubscriptionManager.canPurchase = true
         mockAccountManager.accessToken = "some_token"

--- a/UnitTests/Freemium/DBP/FreemiumDBPFeatureTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPFeatureTests.swift
@@ -147,7 +147,7 @@ final class FreemiumDBPFeatureTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-    func testWhenUserDidNotOnboard_thenOffboardingIsNotExecuted() {
+    func testWhenUserDidNotActivate_thenOffboardingIsNotExecuted() {
         // Given
         mockFreemiumDBPUserStateManagerManager.didActivate = false
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in false }

--- a/UnitTests/Freemium/DBP/FreemiumDBPFirstProfileSavedNotifierTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPFirstProfileSavedNotifierTests.swift
@@ -63,7 +63,7 @@ final class FreemiumDBPFirstProfileSavedNotifierTests: XCTestCase {
         XCTAssertFalse(mockNotificationCenter.didCallPostNotification)
     }
 
-    func testWhenUserHasNotCompletedOnboarding_thenNotificationShouldNotBePosted() {
+    func testWhenUserHasNotActivated_thenNotificationShouldNotBePosted() {
         // Given
         mockAccountManager.accessToken = nil
         mockFreemiumDBPUserStateManager.didActivate = false

--- a/UnitTests/Freemium/DBP/FreemiumDBPFirstProfileSavedNotifierTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPFirstProfileSavedNotifierTests.swift
@@ -38,7 +38,7 @@ final class FreemiumDBPFirstProfileSavedNotifierTests: XCTestCase {
     func testWhenAllCriteriaSatisfied_thenNotificationShouldBePosted() {
         // Given
         mockAccountManager.accessToken = nil
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = false
 
         // When
@@ -53,7 +53,7 @@ final class FreemiumDBPFirstProfileSavedNotifierTests: XCTestCase {
     func testWhenUserIsAuthenticated_thenNotificationShouldNotBePosted() {
         // Given
         mockAccountManager.accessToken = "some_token"
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = false
 
         // When
@@ -66,7 +66,7 @@ final class FreemiumDBPFirstProfileSavedNotifierTests: XCTestCase {
     func testWhenUserHasNotCompletedOnboarding_thenNotificationShouldNotBePosted() {
         // Given
         mockAccountManager.accessToken = nil
-        mockFreemiumDBPUserStateManager.didOnboard = false
+        mockFreemiumDBPUserStateManager.didActivate = false
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = false
 
         // When
@@ -79,7 +79,7 @@ final class FreemiumDBPFirstProfileSavedNotifierTests: XCTestCase {
     func testWhenNotificationAlreadyPosted_thenShouldNotPostAgain() {
         // Given
         mockAccountManager.accessToken = nil
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = true
 
         // When
@@ -92,7 +92,7 @@ final class FreemiumDBPFirstProfileSavedNotifierTests: XCTestCase {
     func testWhenNotificationIsPosted_thenStateShouldBeUpdated() {
         // Given
         mockAccountManager.accessToken = nil
-        mockFreemiumDBPUserStateManager.didOnboard = true
+        mockFreemiumDBPUserStateManager.didActivate = true
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = false
 
         // When

--- a/UnitTests/Freemium/DBP/FreemiumDBPPresenterTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPPresenterTests.swift
@@ -26,23 +26,13 @@ final class FreemiumDBPPresenterTests: XCTestCase {
     private var sut = DefaultFreemiumDBPPresenter()
 
     @MainActor
-    func testWhenCallShowFreemiumDBPAndDidOnboardThenShowPIRTabIsCalled() async throws {
+    func testWhenCallShowFreemiumDBPThenShowPIRTabIsCalled() async throws {
         // Given
         mockWindowControllerManager = MockWindowControllerManager()
         // When
-        sut.showFreemiumDBP(didOnboard: true, windowControllerManager: mockWindowControllerManager)
+        sut.showFreemiumDBP(windowControllerManager: mockWindowControllerManager)
         // Then
         XCTAssertEqual(mockWindowControllerManager.showTabContent, Tab.Content.dataBrokerProtection)
-    }
-
-    @MainActor
-    func testWhenCallShowFreemiumDBPAndDidNotOnboardThenShowPIRTabIsNotCalled() async throws {
-        // Given
-        mockWindowControllerManager = MockWindowControllerManager()
-        // When
-        sut.showFreemiumDBP(didOnboard: false, windowControllerManager: mockWindowControllerManager)
-        // Then
-        XCTAssertEqual(mockWindowControllerManager.showTabContent, Tab.Content.none)
     }
 }
 

--- a/UnitTests/Freemium/DBP/FreemiumDBPPresenterTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPPresenterTests.swift
@@ -30,7 +30,7 @@ final class FreemiumDBPPresenterTests: XCTestCase {
         // Given
         mockWindowControllerManager = MockWindowControllerManager()
         mockFreemiumDBPStateManager = MockFreemiumDBPUserStateManager()
-        let sut = DefaultFreemiumDBPPresenter(freemiumDBFPStateManager: mockFreemiumDBPStateManager)
+        let sut = DefaultFreemiumDBPPresenter(freemiumDBPStateManager: mockFreemiumDBPStateManager)
         XCTAssertFalse(mockFreemiumDBPStateManager.didActivate)
         // When
         sut.showFreemiumDBPAndSetActivated(windowControllerManager: mockWindowControllerManager)

--- a/UnitTests/Freemium/DBP/FreemiumDBPPresenterTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPPresenterTests.swift
@@ -23,16 +23,20 @@ import Combine
 final class FreemiumDBPPresenterTests: XCTestCase {
 
     private var mockWindowControllerManager: MockWindowControllerManager!
-    private var sut = DefaultFreemiumDBPPresenter()
+    private var mockFreemiumDBPStateManager: MockFreemiumDBPUserStateManager!
 
     @MainActor
-    func testWhenCallShowFreemiumDBPThenShowPIRTabIsCalled() async throws {
+    func testWhenCallShowFreemiumDBPThenShowPIRTabIsCalledAndActivatedStateIsSet() async throws {
         // Given
         mockWindowControllerManager = MockWindowControllerManager()
+        mockFreemiumDBPStateManager = MockFreemiumDBPUserStateManager()
+        let sut = DefaultFreemiumDBPPresenter(freemiumDBFPStateManager: mockFreemiumDBPStateManager)
+        XCTAssertFalse(mockFreemiumDBPStateManager.didActivate)
         // When
-        sut.showFreemiumDBP(windowControllerManager: mockWindowControllerManager)
+        sut.showFreemiumDBPAndSetActivated(windowControllerManager: mockWindowControllerManager)
         // Then
         XCTAssertEqual(mockWindowControllerManager.showTabContent, Tab.Content.dataBrokerProtection)
+        XCTAssertTrue(mockFreemiumDBPStateManager.didActivate)
     }
 }
 

--- a/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatingTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatingTests.swift
@@ -88,14 +88,14 @@ final class FreemiumDBPPromotionViewCoordinatingTests: XCTestCase {
     @MainActor
     func testProceedAction_marksUserAsOnboarded_andDismissesPromotion() {
         // Given
-        mockUserStateManager.didOnboard = false
+        mockUserStateManager.didActivate = false
 
         // When
         let viewModel = sut.viewModel
         viewModel.proceedAction()
 
         // Then
-        XCTAssertTrue(mockUserStateManager.didOnboard)
+        XCTAssertTrue(mockUserStateManager.didActivate)
         XCTAssertTrue(mockUserStateManager.didDismissHomePagePromotion)
         XCTAssertTrue(mockPresenter.didCallShowFreemium)
     }

--- a/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatingTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatingTests.swift
@@ -86,7 +86,7 @@ final class FreemiumDBPPromotionViewCoordinatingTests: XCTestCase {
     }
 
     @MainActor
-    func testProceedAction_marksUserAsOnboarded_andDismissesPromotion() {
+    func testProceedAction_dismissesPromotion_andCallsShowFreemium() {
         // Given
         mockUserStateManager.didActivate = false
 
@@ -95,7 +95,6 @@ final class FreemiumDBPPromotionViewCoordinatingTests: XCTestCase {
         viewModel.proceedAction()
 
         // Then
-        XCTAssertTrue(mockUserStateManager.didActivate)
         XCTAssertTrue(mockUserStateManager.didDismissHomePagePromotion)
         XCTAssertTrue(mockPresenter.didCallShowFreemium)
     }

--- a/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -41,7 +41,6 @@ final class MoreOptionsMenuTests: XCTestCase {
     private var mockPrivacyConfigurationManager: MockPrivacyConfigurationManaging!
     private var mockFreemiumDBPPresenter = MockFreemiumDBPPresenter()
     private var freemiumDBPFeature: DefaultFreemiumDBPFeature!
-    private var mockFreemiumDBPUserStateManager = MockFreemiumDBPUserStateManager()
     private var mockNotificationCenter: MockNotificationCenter!
 
     var moreOptionsMenu: MoreOptionsMenu!
@@ -97,7 +96,6 @@ final class MoreOptionsMenuTests: XCTestCase {
                                           sharingMenu: NSMenu(),
                                           internalUserDecider: internalUserDecider,
                                           subscriptionManager: subscriptionManager,
-                                          freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager,
                                           freemiumDBPFeature: freemiumDBPFeature,
                                           freemiumDBPPresenter: mockFreemiumDBPPresenter,
                                           notificationCenter: mockNotificationCenter)
@@ -285,12 +283,11 @@ final class MoreOptionsMenuTests: XCTestCase {
     }
 
     @MainActor
-    func testWhenClickingFreemiumDBPOptionAndDidNotOnboardThenFreemiumPresenterIsCalledWithDidNotOnboardStateAndNotificationIsPosted() throws {
+    func testWhenClickingFreemiumDBPOptionThenFreemiumPresenterIsCalledAndNotificationIsPosted() throws {
         // Given
         subscriptionManager.canPurchase = true
         subscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
         mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in true }
-        mockFreemiumDBPUserStateManager.didOnboard = false
         setupMoreOptionsMenu()
 
         let freemiumItemIndex = try XCTUnwrap(moreOptionsMenu.indexOfItem(withTitle: UserText.freemiumDBPOptionsMenuItem))
@@ -300,28 +297,6 @@ final class MoreOptionsMenuTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mockFreemiumDBPPresenter.didCallShowFreemium)
-        XCTAssertTrue(mockFreemiumDBPPresenter.didOnboardState)
-        XCTAssertTrue(mockNotificationCenter.didCallPostNotification)
-        XCTAssertEqual(mockNotificationCenter.lastPostedNotification, .freemiumDBPEntryPointActivated)
-    }
-
-    @MainActor
-    func testWhenClickingFreemiumDBPOptionAndDidOnboardThenFreemiumPresenterIsCalledWithDidOnboardStateAndNotificationIsPosted() throws {
-        // Given
-        subscriptionManager.canPurchase = true
-        subscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
-        mockPrivacyConfigurationManager.mockConfig.isSubfeatureKeyEnabled = { _, _ in true }
-        mockFreemiumDBPUserStateManager.didOnboard = true
-        setupMoreOptionsMenu()
-
-        let freemiumItemIndex = try XCTUnwrap(moreOptionsMenu.indexOfItem(withTitle: UserText.freemiumDBPOptionsMenuItem))
-
-        // When
-        moreOptionsMenu.performActionForItem(at: freemiumItemIndex)
-
-        // Then
-        XCTAssertTrue(mockFreemiumDBPPresenter.didCallShowFreemium)
-        XCTAssertTrue(mockFreemiumDBPPresenter.didOnboardState)
         XCTAssertTrue(mockNotificationCenter.didCallPostNotification)
         XCTAssertEqual(mockNotificationCenter.lastPostedNotification, .freemiumDBPEntryPointActivated)
     }
@@ -425,10 +400,8 @@ final class MockFreemiumDBPFeature: FreemiumDBPFeature {
 
 final class MockFreemiumDBPPresenter: FreemiumDBPPresenter {
     var didCallShowFreemium = false
-    var didOnboardState = false
 
-    func showFreemiumDBP(didOnboard: Bool, windowControllerManager: WindowControllersManagerProtocol? = nil) {
+    func showFreemiumDBP(windowControllerManager: WindowControllersManagerProtocol? = nil) {
         didCallShowFreemium = true
-        didOnboardState = didOnboard
     }
 }

--- a/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -401,7 +401,7 @@ final class MockFreemiumDBPFeature: FreemiumDBPFeature {
 final class MockFreemiumDBPPresenter: FreemiumDBPPresenter {
     var didCallShowFreemium = false
 
-    func showFreemiumDBP(windowControllerManager: WindowControllersManagerProtocol? = nil) {
+    func showFreemiumDBPAndSetActivated(windowControllerManager: WindowControllersManagerProtocol? = nil) {
         didCallShowFreemium = true
     }
 }

--- a/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
+++ b/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
@@ -34,7 +34,7 @@ final class MockFreemiumDBPUserStateManager: FreemiumDBPUserStateManager {
 
     var didCallResetAllState = false
 
-    var didOnboard = false
+    var didActivate = false
     var didPostFirstProfileSavedNotification = false
     var didPostResultsNotification = false
     var didDismissHomePagePromotion = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206488453854252/1208294167066323/f

**Description**: This PR changes a previously defined `didOnboard` state value to `didActivate. This change is because:

1. We previously planned to “onboard” to Freemium in native code (e.g presenting Ts & Cs natively, accepting them, setting state etc.)
2. We changed this to occur on the frontend. Which means we don’t need to track `didOnboard` on the native side and propagate that to the FE.
3. So, we are removing the `didOnboard` state. 
4. However, we still need some way to track that the user is using Freemium
5. So, we introduce a new `didActivate` state, which is set when a user accesses Freemium DBP

**How to Review this PR:**
1. Commit 1 is removing usage of `didOnboard`
2. Commit 2 is all renaming
3. **Commit 3 is where the main changes occur, setting `didActivate` when we show Freemium**
4. Commit 4 is just cleanup of comments, naming etc.

**Testing Prerequisites:**
1. Make sure you are an internal user
2. Disable/Signout of Privacy Pro (Settings menu -> PP -> Remove from this device)

**Steps to test this PR**:
1. Launch browser
2. Access Freemium via the new tab page banner or via the meatball menu item
3. Go to Debug menu -> Freemium -> Log All State
4. Check the Xcode console and confirm the state is set to true, e.g -> `FREEMIUM DBP: DefaultFreemiumDBPUserStateManager(userDefaults: .dbp).didActivate true`

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
