### PR TITLE
Accept dropping strings and URLs to the bookmarks bar menu

### DIFF
--- a/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
@@ -49,7 +49,8 @@ final class BookmarkDragDropManager {
         // If the dragged values contain both folders and bookmarks, only validate the move if all objects can be moved.
         case (true, true), (true, nil), (nil, true):
             return .move
-        case (false, _), (_, false): return .none
+        case (false, _), (_, false):
+            return .none
         default:
             if info.draggingPasteboard.availableType(from: [.URL]) != nil {
                 return .copy

--- a/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
@@ -52,6 +52,8 @@ final class BookmarkDragDropManager {
         case (false, _), (_, false):
             return .none
         default:
+            guard destination is BookmarkFolder || destination is PseudoFolder else { return .none }
+
             if info.draggingPasteboard.availableType(from: [.URL]) != nil {
                 return .copy
             }

--- a/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
@@ -49,6 +49,11 @@ final class BookmarkDragDropManager {
         // If the dragged values contain both folders and bookmarks, only validate the move if all objects can be moved.
         case (true, true), (true, nil), (nil, true):
             return .move
+        case (nil, nil):
+            if info.draggingPasteboard.availableType(from: [.URL, .string]) != nil {
+                return .copy
+            }
+            return .none
         default:
             return .none
         }

--- a/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
@@ -49,12 +49,17 @@ final class BookmarkDragDropManager {
         // If the dragged values contain both folders and bookmarks, only validate the move if all objects can be moved.
         case (true, true), (true, nil), (nil, true):
             return .move
-        case (nil, nil):
-            if info.draggingPasteboard.availableType(from: [.URL, .string]) != nil {
+        case (false, _), (_, false): return .none
+        default:
+            if info.draggingPasteboard.availableType(from: [.URL]) != nil {
                 return .copy
             }
-            return .none
-        default:
+
+            if let string = info.draggingPasteboard.string(forType: .string),
+                URL(trimmedAddressBarString: string) != nil {
+                return .copy
+            }
+
             return .none
         }
     }
@@ -181,7 +186,7 @@ final class BookmarkDragDropManager {
                 url = webViewItem.url
                 title = webViewItem.title ?? self.title(forTabWith: webViewItem.url, in: window) ?? titleFromUrlDroppingSchemeIfNeeded(url)
             } else if let draggedString = item.string(forType: .string),
-                      let draggedURL = URL(string: draggedString) {
+                      let draggedURL = URL(trimmedAddressBarString: draggedString) {
                 url = draggedURL
                 title = self.title(forTabWith: draggedURL, in: window) ?? titleFromUrlDroppingSchemeIfNeeded(url)
             } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208262956542588/f
Tech Design URL:
CC:

## Description

**Acceptance criteria**
**AC#1**
Given a user on a website
When the user drags the URL in the address bar to the bookmarks bar menu or any sub-folder of it and the URL is not part of the bookmarks
Then it should add the bookmark to the dropped position

**AC#2**
Given a user on a website
When the user drags the URL in the address bar to the bookmarks bar menu or any sub-folder of it and the URL is part of the bookmarks
Then it should not add the bookmark to the dragged position

**AC#3**
Given a user on the browser
When the user drags a URL from another application to the bookmarks bar or any sub-folder of it
Then it should add the bookmark to the dropped position

**AC#4**
Given a user on the browser
When the user drags a string that is not a URL from another application or the address bar to the bookmarks bar or any sub-folder of it
Then it should not create a bookmark to the dropped position

**Steps to test this PR**:
1. Follow the acceptance criteria

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
