### PR TITLE
Fix crash when printing from a pinned tab

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1773,6 +1773,8 @@
 		843965162C737022004C8899 /* NSPasteboardExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843965142C737022004C8899 /* NSPasteboardExtension.swift */; };
 		843D73BB2C786E5400E4F9DC /* BookmarkListPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F1C8DA2C774CA900716446 /* BookmarkListPopover.swift */; };
 		843D73BC2C786E5400E4F9DC /* BookmarkListPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F1C8DA2C774CA900716446 /* BookmarkListPopover.swift */; };
+		844D7DA42C9443EA00BE61D4 /* NSPrintInfoExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D7DA32C9443E500BE61D4 /* NSPrintInfoExtension.swift */; };
+		844D7DA52C9443EA00BE61D4 /* NSPrintInfoExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D7DA32C9443E500BE61D4 /* NSPrintInfoExtension.swift */; };
 		848648A12C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */; };
 		848648A22C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */; };
 		84DC715A2C1C1E9000033B8C /* UserDefaultsWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DC71582C1C1E8A00033B8C /* UserDefaultsWrapperTests.swift */; };
@@ -3828,6 +3830,7 @@
 		841BE93D2C6F235F00E9C2B5 /* BookmarkDragDropManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkDragDropManager.swift; sourceTree = "<group>"; };
 		843965112C6F2FFE004C8899 /* NSDragOperationExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDragOperationExtension.swift; sourceTree = "<group>"; };
 		843965142C737022004C8899 /* NSPasteboardExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPasteboardExtension.swift; sourceTree = "<group>"; };
+		844D7DA32C9443E500BE61D4 /* NSPrintInfoExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPrintInfoExtension.swift; sourceTree = "<group>"; };
 		848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksBarMenuViewController.swift; sourceTree = "<group>"; };
 		84DC71582C1C1E8A00033B8C /* UserDefaultsWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapperTests.swift; sourceTree = "<group>"; };
 		84DDB9092C92B667008C997B /* WKVisitedLinkStoreWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKVisitedLinkStoreWrapper.swift; sourceTree = "<group>"; };
@@ -8154,6 +8157,7 @@
 		AADC60E92493B305008F8EF7 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				844D7DA32C9443E500BE61D4 /* NSPrintInfoExtension.swift */,
 				AA7EB6E427E7D6DC00036718 /* AnimationView.swift */,
 				4BA71ED92B4B81E80002EBCE /* AppVersionExtension.swift */,
 				AA61C0D12727F59B00E6B681 /* ArrayExtension.swift */,
@@ -10738,6 +10742,7 @@
 				3706FB65293F65D500E42796 /* PrivacyDashboardWebView.swift in Sources */,
 				372BC2A22A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift in Sources */,
 				3706FB66293F65D500E42796 /* AppearancePreferences.swift in Sources */,
+				844D7DA52C9443EA00BE61D4 /* NSPrintInfoExtension.swift in Sources */,
 				3706FB67293F65D500E42796 /* DownloadListCoordinator.swift in Sources */,
 				3706FB68293F65D500E42796 /* NSNotificationName+Debug.swift in Sources */,
 				3706FB69293F65D500E42796 /* NavigationBarBadgeAnimationView.swift in Sources */,
@@ -12762,6 +12767,7 @@
 				85378D9E274E664C007C5CBF /* PopoverMessageViewController.swift in Sources */,
 				3767318E2C7F32E900EB097B /* SolidColorBackground.swift in Sources */,
 				AA6FFB4624DC3B5A0028F4D0 /* WebView.swift in Sources */,
+				844D7DA42C9443EA00BE61D4 /* NSPrintInfoExtension.swift in Sources */,
 				1DDD3EC02B84F5D5004CBF2B /* PreferencesCookiePopupProtectionView.swift in Sources */,
 				B693955026F04BEB0015B914 /* ShadowView.swift in Sources */,
 				AA3D531D27A2F58F00074EC1 /* FeedbackSender.swift in Sources */,

--- a/DuckDuckGo/Common/Extensions/NSPrintInfoExtension.swift
+++ b/DuckDuckGo/Common/Extensions/NSPrintInfoExtension.swift
@@ -1,0 +1,31 @@
+//
+//  NSPrintInfoExtension.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+extension NSPrintInfo {
+
+    private static let isStartedKey = "isStartedKey"
+    var isStarted: Bool {
+        get {
+            self.dictionary()[Self.isStartedKey] as? Bool ?? false
+        }
+        set {
+            self.dictionary()[Self.isStartedKey] = newValue
+        }
+    }
+
+}

--- a/DuckDuckGo/Tab/Model/Tab+Dialogs.swift
+++ b/DuckDuckGo/Tab/Model/Tab+Dialogs.swift
@@ -108,7 +108,7 @@ extension Tab {
         }
 
         static func == (lhs: Tab.UserDialog, rhs: Tab.UserDialog) -> Bool {
-            lhs.sender == rhs.sender && rhs.dialog == rhs.dialog
+            lhs.sender == rhs.sender && lhs.dialog == rhs.dialog
         }
 
     }

--- a/DuckDuckGo/Tab/View/ModalSheetCancellable.swift
+++ b/DuckDuckGo/Tab/View/ModalSheetCancellable.swift
@@ -36,9 +36,11 @@ final class ModalSheetCancellable: Cancellable {
         self.returnCode = returnCode
         self.condition = condition
         self.cancellationHandler = cancellationHandler
+        // cancel the request when dialog owning window is closed
+        NotificationCenter.default.addObserver(self, selector: #selector(cancel), name: NSWindow.willCloseNotification, object: ownerWindow)
     }
 
-    func cancel() {
+    @objc func cancel() {
         guard let ownerWindow, let modalSheet,
               ownerWindow.sheets.contains(modalSheet),
               condition() == true

--- a/scripts/find_private_symbols.sh
+++ b/scripts/find_private_symbols.sh
@@ -60,7 +60,8 @@ find_private_objc_selectors() {
 	# 4. Print only selectors starting with and underscore.
 	otool -v -s __DATA __objc_selrefs "${app_binary}" \
 		| sed -n -e 's/^.*__TEXT:__objc_methname://' \
-			-e '/^__swift_objectForKeyedSubscript/d' \
+            -e '/^__swift_objectForKeyedSubscript/d' \
+			-e '/^__swift_setObject:forKeyedSubscript:/d' \
 			-e '/^_/P' \
 		| sort | uniq
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208315841728331/f

**Description**:
- Fix crash when printing from a pinned tab

**Steps to test this PR**:
1. Open a pinned tab
2. Open the pinned tab in a new window (so the same tab is open in 2 windows)
3. Print -> validate there‘s no crash and the dialog is only displayed in active window

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
