### PR TITLE
Fix scrolling to new tab when tabs overflow

### DIFF
--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -20,6 +20,11 @@ on:
         description: "Asana release task URL"
         required: false
         type: string
+      skip-mm:
+        description: "Skip Mattermost message"
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       release-type:
@@ -40,6 +45,11 @@ on:
         description: "Branch name"
         required: false
         type: string
+      skip-mm:
+        description: "Skip Mattermost message"
+        required: false
+        default: false
+        type: boolean
     secrets:
       APPLE_API_KEY_BASE64:
         required: true
@@ -310,7 +320,7 @@ jobs:
     name: Send Mattermost message
 
     needs: [export-notarized-app, create-dmg]
-    if: always()
+    if: always() && ${{ inputs.skip-mm == 'false' }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/sync_end_to_end.yml
+++ b/.github/workflows/sync_end_to_end.yml
@@ -13,6 +13,7 @@ jobs:
       release-type: review
       create-dmg: false
       branch: ${{ github.sha }}
+      skip-mm: true
     secrets:
       APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -17,6 +17,7 @@ jobs:
       release-type: review
       create-dmg: false
       branch: ${{ github.sha }}
+      skip-mm: true
     secrets:
       APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
+++ b/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
@@ -61,8 +61,8 @@ final class TabBarCollectionView: NSCollectionView {
     }
 
     func scroll(to indexPath: IndexPath) {
-        let rect = frameForItem(at: indexPath.item)
         animator().performBatchUpdates({
+            let rect = animator().frameForItem(at: indexPath.item)
             animator().scrollToVisible(rect)
         }, completionHandler: nil)
     }

--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -656,24 +656,26 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
         appendToCollectionView(selected: selected)
     }
 
-    func tabCollectionViewModelDidInsert(_ tabCollectionViewModel: TabCollectionViewModel,
-                                         at index: Int,
-                                         selected: Bool) {
+    func tabCollectionViewModelDidInsert(_ tabCollectionViewModel: TabCollectionViewModel, at index: Int, selected: Bool) {
         let indexPathSet = Set(arrayLiteral: IndexPath(item: index))
-        if selected {
-            collectionView.clearSelection(animated: true)
-        }
-        collectionView.animator().insertItems(at: indexPathSet)
-        if selected {
-            collectionView.selectItems(at: indexPathSet, scrollPosition: .centeredHorizontally)
-            collectionView.scrollToSelected()
-        }
 
-        updateTabMode()
-        updateEmptyTabArea()
-        hideTabPreview()
-        if tabMode == .overflow {
-            collectionView.scroll(to: IndexPath(item: index))
+        collectionView.animator().performBatchUpdates {
+            if selected {
+                collectionView.clearSelection(animated: true)
+            }
+            collectionView.animator().insertItems(at: indexPathSet)
+            if selected {
+                collectionView.selectItems(at: indexPathSet, scrollPosition: .centeredHorizontally)
+                collectionView.scrollToSelected()
+            }
+
+            updateTabMode()
+            updateEmptyTabArea()
+            hideTabPreview()
+        } completionHandler: { _ in
+            if self.tabMode == .overflow {
+                self.collectionView.scroll(to: IndexPath(item: index))
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208326825362864/f

**Description**:
Perform all updates of the collection view in a batch and only scroll to the new tab from the completion handler.

**Steps to test this PR**:
1. Open so many new tabs that the tab bar overflow mode is enabled and arrow buttons are present
2. From the Open new tab via context menu or cmd+click
3. Verify that the tab bar is scrolled to show the newly opened (inactive) tab.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
