### PR TITLE
Re-enabling app retention ATB

### DIFF
--- a/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -46,12 +46,6 @@ final class StatisticsLoader {
     }
 
     func refreshRetentionAtb(isSearch: Bool, completion: @escaping Completion = {}) {
-        // Search ATB is the only call being used currently. This guard statement can be removed to re-enable app retention ATB.
-        guard isSearch else {
-            completion()
-            return
-        }
-
         load {
             dispatchPrecondition(condition: .onQueue(.main))
 

--- a/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
+++ b/UnitTests/Statistics/ATB/StatisticsLoaderTests.swift
@@ -295,15 +295,15 @@ class StatisticsLoaderTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testWhenRefreshRetentionAtbIsPerformedForNonSearchAndNoInstallStatisticsExistThenAtbNotRequested() {
+    func testWhenRefreshRetentionAtbIsPerformedForNonSearchAndNoInstallStatisticsExistThenAtbRequested() {
         loadSuccessfulUpdateAtbStub()
 
-        let expect = expectation(description: "App retention ATB not requested")
+        let expect = expectation(description: "App retention ATB requested")
         testee.refreshRetentionAtb(isSearch: false) {
-            XCTAssertNil(self.mockStatisticsStore.atb)
-            XCTAssertNil(self.mockStatisticsStore.appRetentionAtb)
+            XCTAssertEqual(self.mockStatisticsStore.atb, "v20-1")
+            XCTAssertEqual(self.mockStatisticsStore.appRetentionAtb, "v77-5")
             XCTAssertNil(self.mockStatisticsStore.searchRetentionAtb)
-            XCTAssertFalse(self.mockStatisticsStore.isAppRetentionFiredToday)
+            XCTAssertTrue(self.mockStatisticsStore.isAppRetentionFiredToday)
             expect.fulfill()
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1148564399326804/1208261063200358/f

**Description**:
Re-enabling the app retention ATB in order to monitor daily usage.

**Steps to test this PR**:
1. Run the app and type `atb` into the Console filter
2. Navigate to any website (except SERP)
3. Verify the Console contains the following message: `App retention ATB request succeeded`
4. Restart the app and navigate to any website
5. Verify the atb is NOT refreshed again

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
