### PR TITLE
Fix bookmarks sort UI tests

### DIFF
--- a/UITests/BookmarkSearchTests.swift
+++ b/UITests/BookmarkSearchTests.swift
@@ -94,10 +94,10 @@ class BookmarkSearchTests: XCTestCase {
         testDragAndDropToReorder(in: .manager)
     }
 
-    func testSearchActionIsHiddenOnBookmarksPanelWhenUserHasNoBookmarks() {
+    func testSearchActionIsDisabledOnBookmarksPanelWhenUserHasNoBookmarks() {
         app.openBookmarksPanel()
         let bookmarksPanelPopover = app.popovers.firstMatch
-        XCTAssertFalse(bookmarksPanelPopover.buttons[AccessibilityIdentifiers.searchBookmarksButton].exists)
+        XCTAssertFalse(bookmarksPanelPopover.buttons[AccessibilityIdentifiers.searchBookmarksButton].isEnabled)
     }
 
     // MARK: - Utilities

--- a/UITests/BookmarkSortTests.swift
+++ b/UITests/BookmarkSortTests.swift
@@ -41,7 +41,24 @@ class BookmarkSortTests: XCTestCase {
         app.enforceSingleWindow()
     }
 
+    func testWhenNoBookmarksThenSortIsDisabledOnThePanel() {
+        app.openBookmarksPanel()
+
+        let bookmarksPanelPopover = app.popovers.firstMatch
+        let sortBookmarksButton = bookmarksPanelPopover.buttons[AccessibilityIdentifiers.sortBookmarksButtonPanel]
+        XCTAssertFalse(sortBookmarksButton.isEnabled)
+    }
+
+    func testWhenNoBookmarksThenSortIsDisabledOnTheManager() {
+        app.openBookmarksManager()
+
+        let sortBookmarksButton = app.buttons[AccessibilityIdentifiers.sortBookmarksButtonManager]
+        XCTAssertFalse(sortBookmarksButton.isEnabled)
+    }
+
     func testWhenChangingSortingInThePanelIsReflectedInTheManager() {
+        addBookmark(pageTitle: "Bookmark #1")
+        app.dismissPopover(buttonIdentifier: "Hide")
         app.openBookmarksPanel()
         selectSortByName(mode: .panel)
         app.openBookmarksManager()
@@ -54,6 +71,8 @@ class BookmarkSortTests: XCTestCase {
     }
 
     func testWhenChangingSortingInTheManagerIsReflectedInThePanel() {
+        addBookmark(pageTitle: "Bookmark #1")
+        app.dismissPopover(buttonIdentifier: "Hide")
         app.openBookmarksManager()
         selectSortByName(mode: .manager)
         app.openBookmarksPanel()
@@ -136,6 +155,7 @@ class BookmarkSortTests: XCTestCase {
     }
 
     func testThatSortIsPersistedThroughBrowserRestarts() {
+        addBookmark(pageTitle: "Bookmark #1")
         app.openBookmarksPanel()
         selectSortByName(mode: .panel)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208328455174895/f
Tech Design URL:
CC:

**Description**:
This fixes the bookmark sort UI tests. I introduced some changes where I broke the tests (https://github.com/duckduckgo/macos-browser/pull/3253); luckily, the tests I helped create found the issue!

The main problem is that now we disable sort and search when we do not have bookmarks. UI tests didn’t account for that, so we tried accessing the sort button without bookmarks, which is now impossible.

I fixed the issue and added UI tests to cover the disable states of the sort button when there are no bookmarks.

**Steps to test this PR**:
Successful workflow: https://github.com/duckduckgo/macos-browser/actions/runs/10913325849

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
