### PR TITLE
Fix Tab; Window Controller not deallocated on close

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -930,7 +930,6 @@
 		3706FE7D293F661700E42796 /* WKDownloadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B630794126731F5400DCEE41 /* WKDownloadMock.swift */; };
 		3706FE7E293F661700E42796 /* RunLoopExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C0B24526E9CB190031CB7F /* RunLoopExtensionTests.swift */; };
 		3706FE7F293F661700E42796 /* FileDownloadManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B693956226F1C2A40015B914 /* FileDownloadManagerMock.swift */; };
-		3706FE80293F661700E42796 /* DeallocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2C9EE276081AB005B7F0A /* DeallocationTests.swift */; };
 		3706FE81293F661700E42796 /* PermissionModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63ED0D726AE729600A9DAD1 /* PermissionModelTests.swift */; };
 		3706FE82293F661700E42796 /* MockStatisticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B50492726CA2900758A2B /* MockStatisticsStore.swift */; };
 		3706FE83293F661700E42796 /* AutofillPreferencesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CD54BC27F2ECAE00F1F7B9 /* AutofillPreferencesModelTests.swift */; };
@@ -1775,6 +1774,8 @@
 		843D73BC2C786E5400E4F9DC /* BookmarkListPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F1C8DA2C774CA900716446 /* BookmarkListPopover.swift */; };
 		844D7DA42C9443EA00BE61D4 /* NSPrintInfoExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D7DA32C9443E500BE61D4 /* NSPrintInfoExtension.swift */; };
 		844D7DA52C9443EA00BE61D4 /* NSPrintInfoExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D7DA32C9443E500BE61D4 /* NSPrintInfoExtension.swift */; };
+		84537A082C99C203008723BC /* DeallocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2C9EE276081AB005B7F0A /* DeallocationTests.swift */; };
+		84537A092C99C203008723BC /* DeallocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2C9EE276081AB005B7F0A /* DeallocationTests.swift */; };
 		848648A12C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */; };
 		848648A22C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */; };
 		84DC715A2C1C1E9000033B8C /* UserDefaultsWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DC71582C1C1E8A00033B8C /* UserDefaultsWrapperTests.swift */; };
@@ -2561,7 +2562,6 @@
 		B6C0BB6829AEFF8100AE8E3C /* BookmarkExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C0BB6629AEFF8100AE8E3C /* BookmarkExtension.swift */; };
 		B6C0BB6A29AF1C7000AE8E3C /* BrowserTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C0BB6929AF1C7000AE8E3C /* BrowserTabView.swift */; };
 		B6C0BB6B29AF1C7000AE8E3C /* BrowserTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C0BB6929AF1C7000AE8E3C /* BrowserTabView.swift */; };
-		B6C2C9EF276081AB005B7F0A /* DeallocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2C9EE276081AB005B7F0A /* DeallocationTests.swift */; };
 		B6C2C9F62760B659005B7F0A /* TestDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B6C2C9F42760B659005B7F0A /* TestDataModel.xcdatamodeld */; };
 		B6C416A7294A4AE500C4F2E7 /* DuckPlayerTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C416A6294A4AE500C4F2E7 /* DuckPlayerTabExtension.swift */; };
 		B6C843DA2BA1CAB6006FDEC3 /* FilePresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C843D92BA1CAB6006FDEC3 /* FilePresenterTests.swift */; };
@@ -5658,6 +5658,7 @@
 		4B1AD89E25FC27E200261379 /* IntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				84537A072C99C1EF008723BC /* App */,
 				EEE0E1CB2C32F53C0058E148 /* DataImport */,
 				B603972A29BEDF0F00902A34 /* Common */,
 				B31055CC27A1BA39001AC618 /* Autoconsent */,
@@ -6658,6 +6659,14 @@
 				7BDA36EB2B7E037200AD5388 /* VPNProxyExtension.entitlements */,
 			);
 			path = VPNProxyExtension;
+			sourceTree = "<group>";
+		};
+		84537A072C99C1EF008723BC /* App */ = {
+			isa = PBXGroup;
+			children = (
+				B6C2C9EE276081AB005B7F0A /* DeallocationTests.swift */,
+			);
+			path = App;
 			sourceTree = "<group>";
 		};
 		853014D425E6709500FB8205 /* Support */ = {
@@ -8689,7 +8698,6 @@
 			children = (
 				B6A5A2A725BAA35500AA7ADA /* WindowManagerStateRestorationTests.swift */,
 				B6A5A29F25B96E8300AA7ADA /* AppStateChangePublisherTests.swift */,
-				B6C2C9EE276081AB005B7F0A /* DeallocationTests.swift */,
 				1D7693FE2BE3A1AA0016A22B /* DockCustomizerMock.swift */,
 				1DA860712BE3AE950027B813 /* DockPositionProviderTests.swift */,
 			);
@@ -11645,7 +11653,6 @@
 				3706FE7E293F661700E42796 /* RunLoopExtensionTests.swift in Sources */,
 				5681ED412BDB955100F59729 /* SyncCredentialsAdapterTests.swift in Sources */,
 				3706FE7F293F661700E42796 /* FileDownloadManagerMock.swift in Sources */,
-				3706FE80293F661700E42796 /* DeallocationTests.swift in Sources */,
 				3706FE81293F661700E42796 /* PermissionModelTests.swift in Sources */,
 				5681ED442BDBA5F900F59729 /* SyncBookmarksAdapterTests.swift in Sources */,
 				B60C6F8529B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */,
@@ -11671,6 +11678,7 @@
 			files = (
 				B603971329B9D67E00902A34 /* PublishersExtensions.swift in Sources */,
 				3706FE9F293F662100E42796 /* EncryptionKeyStoreMock.swift in Sources */,
+				84537A092C99C203008723BC /* DeallocationTests.swift in Sources */,
 				3706FEA0293F662100E42796 /* EncryptionMocks.swift in Sources */,
 				B62A233D29C322BC00D22475 /* NavigationProtectionIntegrationTests.swift in Sources */,
 				3706FEA1293F662100E42796 /* TestNavigationDelegate.swift in Sources */,
@@ -11716,6 +11724,7 @@
 			files = (
 				B603971129B9D67E00902A34 /* PublishersExtensions.swift in Sources */,
 				B662D3DF275616FF0035D4D6 /* EncryptionKeyStoreMock.swift in Sources */,
+				84537A082C99C203008723BC /* DeallocationTests.swift in Sources */,
 				B62A233C29C322BC00D22475 /* NavigationProtectionIntegrationTests.swift in Sources */,
 				B6EC37DE29B5D05A001ACE79 /* DownloadsIntegrationTests.swift in Sources */,
 				4B1AD8E225FC390B00261379 /* EncryptionMocks.swift in Sources */,
@@ -13196,7 +13205,6 @@
 				317295D22AF058D3002C3206 /* MockWaitlistTermsAndConditionsActionHandler.swift in Sources */,
 				B6C843DA2BA1CAB6006FDEC3 /* FilePresenterTests.swift in Sources */,
 				B693956326F1C2A40015B914 /* FileDownloadManagerMock.swift in Sources */,
-				B6C2C9EF276081AB005B7F0A /* DeallocationTests.swift in Sources */,
 				B63ED0D826AE729600A9DAD1 /* PermissionModelTests.swift in Sources */,
 				B69B504B2726CA2900758A2B /* MockStatisticsStore.swift in Sources */,
 				C17CA7AD2B9B52E6008EC3C1 /* NavigationBarPopoversTests.swift in Sources */,

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -579,7 +579,7 @@ final class AddressBarButtonsViewController: NSViewController {
 
     private func subscribeToSelectedTabViewModel() {
         selectedTabViewModelCancellable = tabCollectionViewModel.$selectedTabViewModel.sink { [weak self] tabViewModel in
-            guard let self, let tabViewModel else { return }
+            guard let self else { return }
 
             stopAnimations()
             closePrivacyDashboard()

--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/ActiveDomainPublisher.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/ActiveDomainPublisher.swift
@@ -30,17 +30,13 @@ final class ActiveDomainPublisher {
     private var activeTabViewModelCancellable: AnyCancellable?
     private var activeTabContentCancellable: AnyCancellable?
 
-    @MainActor
-    @Published
-    private var activeWindowController: MainWindowController? {
+    @MainActor private weak var activeWindowController: MainWindowController? {
         didSet {
             subscribeToActiveTabViewModel()
         }
     }
 
-    @MainActor
-    @Published
-    private var activeTab: Tab? {
+    @MainActor private weak var activeTab: Tab? {
         didSet {
             subscribeToActiveTabContentChanges()
         }

--- a/IntegrationTests/App/DeallocationTests.swift
+++ b/IntegrationTests/App/DeallocationTests.swift
@@ -1,0 +1,145 @@
+//
+//  DeallocationTests.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Combine
+@testable import DuckDuckGo_Privacy_Browser
+
+final class DeallocationTests: XCTestCase {
+    var cancellables = Set<AnyCancellable>()
+    var animationDuration: TimeInterval = 0
+
+    @MainActor
+    override func setUp() {
+        assert(WindowControllersManager.shared.mainWindowControllers.isEmpty)
+        animationDuration = NSAnimationContext.current.duration
+        NSAnimationContext.current.duration = 0
+    }
+
+    @MainActor
+    override func tearDown() {
+        WindowsManager.closeWindows()
+        for controller in WindowControllersManager.shared.mainWindowControllers {
+            WindowControllersManager.shared.unregister(controller)
+        }
+        NSAnimationContext.current.duration = animationDuration
+    }
+
+    class DeallocationTracker {
+        let e: XCTestExpectation
+        init(e: XCTestExpectation) {
+            self.e = e
+        }
+        deinit {
+            e.fulfill()
+        }
+    }
+
+    static let deallocationTrackerKey = UnsafeRawPointer(bitPattern: "DeallocationTrackerKey".hashValue)!
+    func expectDeallocation(of object: NSObject) {
+        let tracker = DeallocationTracker(e: expectation(description: "\(object) should deallocate"))
+        objc_setAssociatedObject(object, Self.deallocationTrackerKey, tracker, .OBJC_ASSOCIATION_RETAIN)
+    }
+
+    // MARK: -
+
+    @MainActor
+    func testWindowsDeallocation() {
+        autoreleasepool {
+
+            // `showWindow: false` would still open a window, but not activate it, which seems to upset CI
+            WindowsManager.openNewWindow()
+            WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: false)
+            WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: true)
+
+            for i in 0..<WindowControllersManager.shared.mainWindowControllers.count {
+                WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel
+                    .appendNewTab()
+
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i])
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].window!)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController)
+
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabBarViewController)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.navigationBarViewController)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.browserTabViewController)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.findInPageViewController)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.fireViewController)
+
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel)
+                for tab in WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs {
+                    expectDeallocation(of: tab)
+                    expectDeallocation(of: tab.webView)
+                }
+            }
+
+            for wc in WindowControllersManager.shared.mainWindowControllers {
+                wc.window!.close()
+            }
+
+            repeat {
+                RunLoop.main.run(until: Date() + 0.1)
+            } while WindowControllersManager.shared.mainWindowControllers.contains(where: { $0.window?.isVisible == true })
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    @MainActor
+    func testWhenLastTabClosed_windowIsDeallocated() {
+        autoreleasepool {
+
+            // `showWindow: false` would still open a window, but not activate it, which seems to upset CI
+            WindowsManager.openNewWindow()
+            WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: false)
+            WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: true)
+
+            for i in 0..<WindowControllersManager.shared.mainWindowControllers.count {
+                WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel
+                    .appendNewTab()
+
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i])
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].window!)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController)
+
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabBarViewController)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.navigationBarViewController)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.browserTabViewController)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.findInPageViewController)
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.fireViewController)
+
+                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel)
+                for tab in WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs {
+                    expectDeallocation(of: tab)
+                    expectDeallocation(of: tab.webView)
+                }
+            }
+
+            for i in (0..<WindowControllersManager.shared.mainWindowControllers.count).reversed() {
+                for _ in 0..<WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs.count {
+                    WindowControllersManager.shared.mainWindowControllers[i].mainViewController.closeTab(self)
+                }
+            }
+
+            repeat {
+                RunLoop.main.run(until: Date() + 0.1)
+            } while WindowControllersManager.shared.mainWindowControllers.contains(where: { $0.window?.isVisible == true })
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199178362774117/1208259344334049/f

**Description**:
- Fix MainWindowController leaking
- Fix Tab not deallocated on close

**Steps to test this PR**:
1. Open a video in a single tab; start playback, close the tab - validate video is stopped
2. Validate MainWindowController and all related View Controllers and models are deallocated on window close

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
