### PR TITLE
Fix retain cycle in NetworkProtectionTunnelController

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -175,7 +175,9 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 
     private func subscribeToStatusChanges() {
         notificationCenter.publisher(for: .NEVPNStatusDidChange)
-            .sink(receiveValue: handleStatusChange(_:))
+            .sink { [weak self] status in
+                self?.handleStatusChange(status)
+            }
             .store(in: &cancellables)
     }
 
@@ -205,7 +207,9 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
     private func subscribeToConfigurationChanges() {
         notificationCenter.publisher(for: .NEVPNConfigurationChange)
             .receive(on: DispatchQueue.main)
-            .sink { _ in
+            .sink { [weak self] _ in
+                guard let self else { return }
+
                 Task { @MainActor in
                     guard let manager = await self.manager else {
                         return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1208331423616717/f

## Description

Fixes a retain cycle in `NetworkProtectionTunnelController`.

**Important:** This retain cycle is invisible in macOS because we only instantiate the tunnel controller once, so this isn't really very impactful.

Kudos to @brindy for coming up with this fix - I'm taking his proposed changes and applying them after verifying they work correctly.

## Testing

**Privacy Pro Setup:**
1. If you don't have a VPN account yet, I recommend using the Stripe option from https://app.asana.com/0/1207603085593419/1207149361119036/f to set things up to test the VPN.
 
**Steps:**
1. Start the VPN and stop it a few times.
2. Show and hide the status bar VPN view.
4. Verify that you only see one instance of `NetworkProtectionTunnelController ` at all times using Xcode's "Debug Memory Graph" or Instruments.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
