### PR TITLE
Don't close password manager while editing

### DIFF
--- a/DuckDuckGo/SecureVault/View/PasswordManagementPopover.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementPopover.swift
@@ -71,4 +71,8 @@ extension PasswordManagementPopover: NSPopoverDelegate {
         }
     }
 
+    @MainActor func popoverShouldClose(_ popover: NSPopover) -> Bool {
+        !viewController.isEditing
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1208343732992258/f

**Description**:

Closing the panel while the user is editing is extremely disruptive and can lead to data loss.
Users can copy/paste things from the edit mode back to the page, and it would be very frustrating.

Do not close the management UI when in edit mode, even if the user clicks within the browser.

**Steps to test this PR**:
1. Open the Password Management UI
2. Click Add New -> {Any entry} to start editing
3. Click outside of the window / change tab / switch to a different window (etc)
4. **The  Password Management UI should not close**
5. Stop editing by clicking "Cancel" or by completing the edit flow
3. Click outside of the window / change tab / switch to a different window (etc)
4. **The Password Management UI should close**

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
