### PR TITLE
Left align the bookmarks bar

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -751,7 +751,7 @@
 		3706FC93293F65D500E42796 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AFCE8027DA2CA600471A10 /* PreferencesViewController.swift */; };
 		3706FC94293F65D500E42796 /* FireproofDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B02198125E05FAC00ED7DEA /* FireproofDomains.swift */; };
 		3706FC95293F65D500E42796 /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B677440255DBEEA00025BD8 /* Database.swift */; };
-		3706FC96293F65D500E42796 /* HorizontallyCenteredLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE5336D286915A10019DBFD /* HorizontallyCenteredLayout.swift */; };
+		3706FC96293F65D500E42796 /* LeftAlignedLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE5336D286915A10019DBFD /* LeftAlignedLayout.swift */; };
 		3706FC97293F65D500E42796 /* BookmarksOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B92928526670D1600AD2C21 /* BookmarksOutlineView.swift */; };
 		3706FC98293F65D500E42796 /* CountryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE65482271FCD53008D1D63 /* CountryList.swift */; };
 		3706FC99293F65D500E42796 /* PreferencesSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CD54C427F2FDD100F1F7B9 /* PreferencesSection.swift */; };
@@ -1505,7 +1505,7 @@
 		4BE41A5E28446EAD00760399 /* BookmarksBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE41A5D28446EAD00760399 /* BookmarksBarViewModel.swift */; };
 		4BE5336B286912D40019DBFD /* BookmarksBarCollectionViewItem.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4BE53369286912D40019DBFD /* BookmarksBarCollectionViewItem.xib */; };
 		4BE5336C286912D40019DBFD /* BookmarksBarCollectionViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE5336A286912D40019DBFD /* BookmarksBarCollectionViewItem.swift */; };
-		4BE5336E286915A10019DBFD /* HorizontallyCenteredLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE5336D286915A10019DBFD /* HorizontallyCenteredLayout.swift */; };
+		4BE5336E286915A10019DBFD /* LeftAlignedLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE5336D286915A10019DBFD /* LeftAlignedLayout.swift */; };
 		4BE53374286E39F10019DBFD /* ChromiumKeychainPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE53373286E39F10019DBFD /* ChromiumKeychainPrompt.swift */; };
 		4BE65474271FCD40008D1D63 /* PasswordManagementIdentityItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6546E271FCD40008D1D63 /* PasswordManagementIdentityItemView.swift */; };
 		4BE65476271FCD41008D1D63 /* PasswordManagementCreditCardItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE65470271FCD40008D1D63 /* PasswordManagementCreditCardItemView.swift */; };
@@ -3708,7 +3708,7 @@
 		4BE41A5D28446EAD00760399 /* BookmarksBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksBarViewModel.swift; sourceTree = "<group>"; };
 		4BE53369286912D40019DBFD /* BookmarksBarCollectionViewItem.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BookmarksBarCollectionViewItem.xib; sourceTree = "<group>"; };
 		4BE5336A286912D40019DBFD /* BookmarksBarCollectionViewItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksBarCollectionViewItem.swift; sourceTree = "<group>"; };
-		4BE5336D286915A10019DBFD /* HorizontallyCenteredLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontallyCenteredLayout.swift; sourceTree = "<group>"; };
+		4BE5336D286915A10019DBFD /* LeftAlignedLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeftAlignedLayout.swift; sourceTree = "<group>"; };
 		4BE53373286E39F10019DBFD /* ChromiumKeychainPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromiumKeychainPrompt.swift; sourceTree = "<group>"; };
 		4BE6546E271FCD40008D1D63 /* PasswordManagementIdentityItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordManagementIdentityItemView.swift; sourceTree = "<group>"; };
 		4BE65470271FCD40008D1D63 /* PasswordManagementCreditCardItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordManagementCreditCardItemView.swift; sourceTree = "<group>"; };
@@ -6416,7 +6416,7 @@
 				848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */,
 				4BD18EFF283F0BC500058124 /* BookmarksBarViewController.swift */,
 				4BE41A5D28446EAD00760399 /* BookmarksBarViewModel.swift */,
-				4BE5336D286915A10019DBFD /* HorizontallyCenteredLayout.swift */,
+				4BE5336D286915A10019DBFD /* LeftAlignedLayout.swift */,
 				8400DC4A2C6E26AE006509D2 /* ItemCachingCollectionView.swift */,
 			);
 			path = View;
@@ -11327,7 +11327,7 @@
 				3706FC94293F65D500E42796 /* FireproofDomains.swift in Sources */,
 				3706FC95293F65D500E42796 /* Database.swift in Sources */,
 				3707C71B294B5D0F00682A9F /* AutofillTabExtension.swift in Sources */,
-				3706FC96293F65D500E42796 /* HorizontallyCenteredLayout.swift in Sources */,
+				3706FC96293F65D500E42796 /* LeftAlignedLayout.swift in Sources */,
 				3706FC97293F65D500E42796 /* BookmarksOutlineView.swift in Sources */,
 				3706FC98293F65D500E42796 /* CountryList.swift in Sources */,
 				1DEF3BAE2BD145A9004A2FBA /* AutoClearHandler.swift in Sources */,
@@ -12877,7 +12877,7 @@
 				4B02198A25E05FAC00ED7DEA /* FireproofDomains.swift in Sources */,
 				4B677442255DBEEA00025BD8 /* Database.swift in Sources */,
 				1DDC85032B83903E00670238 /* PreferencesWebTrackingProtectionView.swift in Sources */,
-				4BE5336E286915A10019DBFD /* HorizontallyCenteredLayout.swift in Sources */,
+				4BE5336E286915A10019DBFD /* LeftAlignedLayout.swift in Sources */,
 				B6BCC5232AFCDABB002C5499 /* DataImportSourceViewModel.swift in Sources */,
 				4B92928B26670D1700AD2C21 /* BookmarksOutlineView.swift in Sources */,
 				4BF01C00272AE74C00884A61 /* CountryList.swift in Sources */,

--- a/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -98,7 +98,7 @@ final class BookmarksBarViewController: NSViewController {
 
         bookmarksBarCollectionView.delegate = viewModel
         bookmarksBarCollectionView.dataSource = viewModel
-        bookmarksBarCollectionView.collectionViewLayout = createCenteredCollectionViewLayout()
+        bookmarksBarCollectionView.collectionViewLayout = createLeftAlignedCollectionViewLayout()
 
         view.postsFrameChangedNotifications = true
         bookmarksBarCollectionView.setAccessibilityIdentifier("BookmarksBarViewController.bookmarksBarCollectionView")
@@ -228,14 +228,14 @@ final class BookmarksBarViewController: NSViewController {
 
     // MARK: - Layout
 
-    private func createCenteredLayout(centered: Bool) -> NSCollectionLayoutSection {
-        let group = NSCollectionLayoutGroup.horizontallyCentered(cellSizes: viewModel.cellSizes, interItemSpacing: BookmarksBarViewModel.Constants.buttonSpacing, centered: centered)
+    private func createLeftAlignedLayout() -> NSCollectionLayoutSection {
+        let group = NSCollectionLayoutGroup.leftAligned(cellSizes: viewModel.cellSizes, interItemSpacing: BookmarksBarViewModel.Constants.buttonSpacing)
         return NSCollectionLayoutSection(group: group)
     }
 
-    func createCenteredCollectionViewLayout() -> NSCollectionViewLayout {
-        return BookmarksBarCenteredLayout { [unowned self] _, _ in
-            return createCenteredLayout(centered: viewModel.clippedItems.isEmpty)
+    private func createLeftAlignedCollectionViewLayout() -> NSCollectionViewLayout {
+        return BookmarksBarLeftAlignedLayout { [unowned self] _, _ in
+            return createLeftAlignedLayout()
         }
     }
 

--- a/DuckDuckGo/BookmarksBar/View/BookmarksBarViewModel.swift
+++ b/DuckDuckGo/BookmarksBar/View/BookmarksBarViewModel.swift
@@ -36,7 +36,7 @@ final class BookmarksBarViewModel: NSObject {
     // MARK: Enums
 
     enum Constants {
-        static let buttonSpacing: CGFloat = 6
+        static let buttonSpacing: CGFloat = 2
         static let buttonHeight: CGFloat = 28
         static let maximumButtonWidth: CGFloat = 128
         static let labelFont = NSFont.systemFont(ofSize: 12)

--- a/DuckDuckGo/BookmarksBar/View/LeftAlignedLayout.swift
+++ b/DuckDuckGo/BookmarksBar/View/LeftAlignedLayout.swift
@@ -1,5 +1,5 @@
 //
-//  HorizontallyCenteredLayout.swift
+//  LeftAlignedLayout.swift
 //
 //  Copyright © 2022 DuckDuckGo. All rights reserved.
 //
@@ -23,26 +23,15 @@ extension NSCollectionView {
 
 extension NSCollectionLayoutGroup {
 
-    static func horizontallyCentered(cellSizes: [CGSize], interItemSpacing: CGFloat, centered: Bool = true) -> NSCollectionLayoutGroup {
+    static func leftAligned(cellSizes: [CGSize], interItemSpacing: CGFloat) -> NSCollectionLayoutGroup {
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(28))
 
         return custom(layoutSize: groupSize) { environment in
             let verticalPosition: CGFloat = environment.container.contentInsets.top
-            let totalWidth = cellSizes.map(\.width).reduce(0) { $0 == 0 ? $1 : $0 + interItemSpacing + $1 }
             let maxItemHeight = cellSizes.map(\.height).max() ?? 0
 
             var items: [NSCollectionLayoutGroupCustomItem] = []
-            var horizontalPosition: CGFloat
-
-            // Derive initial horizontal position:
-
-            if centered {
-                horizontalPosition = (environment.container.effectiveContentSize.width - totalWidth) / 2 + environment.container.contentInsets.leading
-            } else {
-                horizontalPosition = interItemSpacing
-            }
-
-            // Calculate frames for layout group items:
+            var horizontalPosition: CGFloat = interItemSpacing
 
             let rowItems: [NSCollectionLayoutGroupCustomItem] = cellSizes.map { size in
                 let origin = CGPoint(x: ceil(horizontalPosition), y: verticalPosition + (maxItemHeight - size.height) / 2)
@@ -59,9 +48,9 @@ extension NSCollectionLayoutGroup {
     }
 }
 
-final class BookmarksBarCenteredLayout: NSCollectionViewCompositionalLayout {
+final class BookmarksBarLeftAlignedLayout: NSCollectionViewCompositionalLayout {
 
-    private static let interItemGapWidth: CGFloat = 16
+    private static let interItemGapWidth: CGFloat = 2
 
     private var lastKnownInterItemGapIndicatorLayoutAttributes: NSCollectionViewLayoutAttributes?
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208262956542591/f
Tech Design URL:
CC:

**Description**:
Left-aligns the bookmarks bar.

Before this change, bookmarks were centered until they occupied the whole bookmarks bar. Once the whole bar was occupied by bookmarks, the bookmarks bar became centered, and the overflow indicator was shown.

Now, bookmarks are aligned to the left. This aligns with other browsers and with Windows.

This also changed the spacing between bookmarks in the bar from six to two (something required here: https://app.asana.com/0/0/1208262956542589/f)

**Steps to test this PR**:
1. Add bookmarks
2. Check bookmarks are positioned to the left of the bookmarks bar when added.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
