### PR TITLE
Freemium DBP: Bug - Fix Freemium Match Count Logic (Which Previously Counted Mirror Sites without Extracted Profiles)

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDataManager.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDataManager.swift
@@ -146,14 +146,12 @@ public class DataBrokerProtectionDataManager: DataBrokerProtectionDataManaging {
 
     /// Fetches all broker profile query data from the database and calculates the total number of matches and brokers with matches.
     ///
-    /// A match is defined as either:
-    /// 1. An extracted profile associated with the broker profile query data.
-    /// 2. A mirror site that should be included in the count (determined by the `shouldWeIncludeMirrorSite()` logic).
+    /// A match is defined as: An extracted profile associated with the broker profile query data.
     ///
-    /// Additionally, a broker is counted if it has at least one match (either an extracted profile or a valid mirror site).
+    /// Additionally, a broker is counted if it has at least one match (either an extracted profile).
     ///
     /// - Returns: A tuple containing:
-    ///   - `matchCount`: The total number of matches found (extracted profiles + valid mirror sites).
+    ///   - `matchCount`: The total number of matches found (extracted profiles).
     ///   - `brokerCount`: The number of brokers that have at least one match.
     /// - Throws: An error if fetching broker profile query data from the database fails.
     public func matchesFoundAndBrokersCount() throws -> (matchCount: Int, brokerCount: Int) {
@@ -182,15 +180,19 @@ private extension DataBrokerProtectionDataManager {
         let matchCount = queryData.reduce(0) { count, data in
             guard !data.profileQuery.deprecated else { return count }
 
-            let extractedProfileCount = data.extractedProfiles.count
-            let mirrorSitesCount = data.dataBroker.mirrorSites.filter { $0.shouldWeIncludeMirrorSite() }.count
+            let profilesCount = data.extractedProfiles.count
+            var validMirrorSitesCount = 0
 
-            // Only increment broker count if there are matches (profiles or mirror sites)
-            if extractedProfileCount + mirrorSitesCount > 0 {
+            data.extractedProfiles.forEach { _ in
+                let mirrorSitesMatches = data.dataBroker.mirrorSites.filter { $0.shouldWeIncludeMirrorSite() }
+                validMirrorSitesCount += mirrorSitesMatches.count
+            }
+
+            if profilesCount + validMirrorSitesCount > 0 {
                 brokerCount += 1
             }
 
-            return count + extractedProfileCount + mirrorSitesCount
+            return count + profilesCount + validMirrorSitesCount
         }
 
         return (matchCount, brokerCount)

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionDataManagingTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionDataManagingTests.swift
@@ -96,9 +96,9 @@ final class DataBrokerProtectionDataManagingTests: XCTestCase {
         let result = try sut.matchesFoundAndBrokersCount()
 
         // Then
-        // 1 mirror site should be counted, and 1 broker with matches.
-        XCTAssertEqual(result.matchCount, 1)
-        XCTAssertEqual(result.brokerCount, 1)
+        // No extracted profiles, so count should be zero
+        XCTAssertEqual(result.matchCount, 0)
+        XCTAssertEqual(result.brokerCount, 0)
     }
 
     func testWhenMirrorSitesAreRemoved_thenTheyAreNotCountedAndBrokerCountIsZero() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208338809971749/f

**Description**: I noticed when testing that the results displayed on the new tab page banner were not correct. Then noticed original logic was incorrect, and counted mirror sites before checking if we had any extracted profiles.

**Steps to test this PR**:
1. Check updated unit test logic, and ensure it satisfies intention of change (that brokers are only counted when there are extracted profiles)

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
