### PR TITLE
Make 'Customize' button shrink for when app window is narrow

### DIFF
--- a/DuckDuckGo/HomePage/View/HomePageView.swift
+++ b/DuckDuckGo/HomePage/View/HomePageView.swift
@@ -82,9 +82,16 @@ extension HomePage.Views {
                     .animation(.easeInOut, value: settingsVisibilityModel.isSettingsVisible)
 
                     if !settingsVisibilityModel.isSettingsVisible {
-                        SettingsButtonView(isSettingsVisible: $settingsVisibilityModel.isSettingsVisible)
-                            .padding([.bottom, .trailing], 14)
-                            .fixedColorScheme(for: settingsModel.customBackground)
+                        VStack {
+                            Spacer()
+                            HStack {
+                                Spacer(minLength: Self.targetWidth + (geometry.size.width - Self.targetWidth)/2)
+                                SettingsButtonView(isSettingsVisible: $settingsVisibilityModel.isSettingsVisible)
+                                    .padding([.bottom, .trailing], 14)
+                            }
+                        }
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .fixedColorScheme(for: settingsModel.customBackground)
                     }
                 }
                 .background(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208350082163816/f

**Description**:
Fix Customize button layout so that it properly recognizes when there's not enough
space to display the title label.

**Steps to test this PR**:
1. Launch the app
2. Shrink the app window horizontally
3. Verify that 'Customize' button on NTP gets shrunk and hides the title.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
