### PR TITLE
Make bookmarks panel grow as screen permits

### DIFF
--- a/DuckDuckGo/Bookmarks/View/BookmarkListPopover.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListPopover.swift
@@ -48,6 +48,10 @@ final class BookmarkListPopover: NSPopover {
         contentViewController = controller
     }
 
+    override func show(relativeTo positioningRect: NSRect, of positioningView: NSView, preferredEdge: NSRectEdge) {
+        viewController.adjustPreferredContentSize(positionedRelativeTo: positioningRect, of: positioningView, at: preferredEdge)
+        super.show(relativeTo: positioningRect, of: positioningView, preferredEdge: preferredEdge)
+    }
 }
 
 extension BookmarkListPopover: BookmarkListViewControllerDelegate {

--- a/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -424,12 +424,12 @@ final class BookmarkListViewController: NSViewController {
 
         let windowRect = positioningView.convert(positioningRect, to: nil)
         let screenPosRect = mainWindow.convertToScreen(windowRect)
-        let insetMargin = 48.0
-        let availableHeightBelow = screenPosRect.minY - screenFrame.minY - insetMargin
-        let availableHeightAbove = screenFrame.maxY - screenPosRect.maxY - insetMargin
+        let bookmarkHeaderHeight = 48.0
+        let availableHeightBelow = screenPosRect.minY - screenFrame.minY - bookmarkHeaderHeight
+        let availableHeightAbove = screenFrame.maxY - screenPosRect.maxY - bookmarkHeaderHeight
         let availableHeight = max(availableHeightAbove, availableHeightBelow)
 
-        let totalHeightForRootBookmarks = CGFloat(outlineView.numberOfRows) * BookmarkOutlineCellView.rowHeight
+        let totalHeightForRootBookmarks = (CGFloat(outlineView.numberOfRows) * BookmarkOutlineCellView.rowHeight) + bookmarkHeaderHeight + 12.0
         var contentSize = Constants.preferredContentSize
 
         if totalHeightForRootBookmarks > availableHeight {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208262956542590/f
Tech Design URL:
CC:

## Description

### Acceptance criteria

**AC#1**
Given a user with a lot of bookmarks
When the user opens the bookmarks panel
Then, the popover will try to take as much available space either to the top or the bottom of the bookmarks popover button

**AC#1**
Given a user with some bookmarks
When the user opens the bookmarks panel
Then, the popover will be at least 420 wide and 500 taller.

### Demo

⚠️ Ignore beach ball of death. The problem is related to having a lot of bookmarks.

https://github.com/user-attachments/assets/708b08ea-f867-4355-8e22-5a5cbadf1cfb


**Steps to test this PR**:
1. You can load 3k bookmarks from the asana ticket
2. Move the window around and test whether the popover takes the space either to the top or bottom


**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
