### PR TITLE
Fix regex pattern for parsing Privacy Pro release notes

### DIFF
--- a/DuckDuckGo/Updates/ReleaseNotesParser.swift
+++ b/DuckDuckGo/Updates/ReleaseNotesParser.swift
@@ -28,7 +28,7 @@ final class ReleaseNotesParser {
 
         // Patterns for the two sections with more flexible spacing
         let standardPattern = "<h3[^>]*>What's new</h3>\\s*<ul>(.*?)</ul>"
-        let privacyProPattern = "<h2[^>]*>For Privacy Pro subscribers</h2>\\s*<ul>(.*?)</ul>"
+        let privacyProPattern = "<h3[^>]*>For Privacy Pro subscribers</h3>\\s*<ul>(.*?)</ul>"
 
         do {
             let standardRegex = try NSRegularExpression(pattern: standardPattern, options: .dotMatchesLineSeparators)

--- a/UnitTests/Updates/ReleaseNotesParserTests.swift
+++ b/UnitTests/Updates/ReleaseNotesParserTests.swift
@@ -49,7 +49,7 @@ class ReleaseNotesParserTests: XCTestCase {
 
         func testParseReleaseNotes_withOnlyPrivacyProNotes() {
             let description = """
-            <h2>For Privacy Pro subscribers</h2>
+            <h3>For Privacy Pro subscribers</h3>
             <ul>
                 <li>Exclusive feature X</li>
                 <li>Exclusive improvement Y</li>
@@ -68,7 +68,7 @@ class ReleaseNotesParserTests: XCTestCase {
                 <li>New feature A</li>
                 <li>Improvement B</li>
             </ul>
-            <h2>For Privacy Pro subscribers</h2>
+            <h3>For Privacy Pro subscribers</h3>
             <ul>
                 <li>Exclusive feature X</li>
                 <li>Exclusive improvement Y</li>
@@ -87,7 +87,7 @@ class ReleaseNotesParserTests: XCTestCase {
                 <li>New feature A</li>
                 <li>Improvement B
             </ul>
-            <h2>For Privacy Pro subscribers</h2>
+            <h3>For Privacy Pro subscribers</h3>
             <ul>
                 <li>Exclusive feature X</li>
                 <li>Exclusive improvement Y</li>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208358673191631/f

**Description**:
Use H3 tag instead of H2

**Steps to test this PR**:
1. Run the app in Xcode
2. Go to Settings -> About and check for updates
3. Open a new tab and navigate to duck://release-notes
4. Verify that "For Privacy Pro subscribers" section is present in the release notes.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
