### PR TITLE
Add missing Asana token to environment for populating tasks since last release

### DIFF
--- a/.github/workflows/publish_dmg_release.yml
+++ b/.github/workflows/publish_dmg_release.yml
@@ -267,6 +267,7 @@ jobs:
         id: get-tasks-since-last-internal-release
         if: contains(github.event.inputs.release-type, '') || github.event.inputs.release-type == 'internal'
         env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
           GH_TOKEN: ${{ github.token }}
         run: |
           tasks="$(./scripts/update_asana_for_release.sh list-tasks-in-last-internal-release)"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208036161861763/1208205621016469/f

**Description**:
The token is required for that step so that update_asana_for_release.sh script can actually access Asana.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
