### PR TITLE
Fix DuckPlayer overlays

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -281,13 +281,14 @@ extension DuckPlayerTabExtension: NavigationResponder {
         // When the feature is disabled but the webView still gets a Private Player URL,
         // convert it back to a regular YouTube video URL.
         if navigationAction.url.isDuckPlayer {
-            guard let (videoID, timestamp) = navigationAction.url.youtubeVideoParams,
-                  let mainFrame = navigationAction.mainFrameTarget else {
+            guard let (videoID, timestamp) = navigationAction.url.youtubeVideoParams else {
                 return .cancel
             }
 
-            return .redirect(mainFrame) { navigator in
-                navigator.load(URLRequest(url: .youtube(videoID, timestamp: timestamp)))
+            if let mainFrame = navigationAction.mainFrameTarget {
+                return .redirect(mainFrame) { navigator in
+                    navigator.load(URLRequest(url: .youtube(videoID, timestamp: timestamp)))
+                }
             }
         }
         return .next


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204099484721401/1208386895411633/f

**Description**:
Fixes an issue causing Duckplayer videos not to show in new SERP overlays.  
Overlays use an iFrame, so the mainFrame condition was cancelling navigation for these videos when DuckPlayer was disabled

**Steps to test this PR**:
1. Make yourself internal user
2. Disable Duck Player
3. Disable Caches or use the Fire button
4. Go to https://use-devtesting18.duckduckgo.com/?q=metallica+videos and pick a video
5. Click "Watch here"
6. Confirm video plays in the overlay
7. Go to https://www.youtube.com/results?search_query=metallica
8. Pick a video
9. Confirm it plays in Youtube

![09-24 at 10 34 @2x](https://github.com/user-attachments/assets/1710071c-f574-4425-b7f6-4631e36fe07a)
