### PR TITLE
Freemium DBP: Close Any Open Freemium DBP Tabs After Subscription Purchase Success

### DIFF
--- a/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUserScript.swift
+++ b/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUserScript.swift
@@ -28,6 +28,7 @@ import PixelKit
 
 public extension Notification.Name {
     static let subscriptionPageCloseAndOpenPreferences = Notification.Name("com.duckduckgo.subscriptionPage.CloseAndOpenPreferences")
+    static let subscriptionUpgradeFromFreemium = Notification.Name("com.duckduckgo.subscriptionPage.UpgradeFromFreemium")
 }
 
 /// The user script that will be the broker for all subscription features

--- a/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -966,6 +966,90 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         XCTAssertTrue(tokenResponse.isEmpty)
         XCTAssertPrivacyPixelsFired([])
     }
+
+    func testSubscriptionUpgradeNotificationSentWhenSubscriptionSelectedSuccessFromFreemium() async throws {
+        // Given
+        ensureUserUnauthenticatedState()
+        XCTAssertEqual(subscriptionEnvironment.purchasePlatform, .appStore)
+        XCTAssertFalse(accountManager.isUserAuthenticated)
+
+        storePurchaseManager.hasActiveSubscriptionResult = false
+        storePurchaseManager.mostRecentTransactionResult = nil
+
+        authService.createAccountResult = .success(CreateAccountResponse(authToken: Constants.authToken,
+                                                                         externalID: Constants.externalID,
+                                                                         status: "created"))
+        authService.getAccessTokenResult = .success(AccessTokenResponse(accessToken: Constants.accessToken))
+        authService.validateTokenResult = .success(Constants.validateTokenResponse)
+        storePurchaseManager.purchaseSubscriptionResult = .success(Constants.mostRecentTransactionJWS)
+        subscriptionService.confirmPurchaseResult = .success(ConfirmPurchaseResponse(email: Constants.email,
+                                                                                     entitlements: Constants.entitlements,
+                                                                                     subscription: SubscriptionMockFactory.subscription))
+
+        let mockfreemiumDBPUserStateManager = MockFreemiumDBPUserStateManager()
+        mockfreemiumDBPUserStateManager.didActivate = true
+
+        let mockNotificationCenter = MockNotificationCenter()
+
+        feature = SubscriptionPagesUseSubscriptionFeature(subscriptionManager: subscriptionManager,
+                                                          stripePurchaseFlow: stripePurchaseFlow,
+                                                          uiHandler: uiHandler,
+                                                          subscriptionFeatureAvailability: subscriptionFeatureAvailability,
+                                                          freemiumDBPUserStateManager: mockfreemiumDBPUserStateManager,
+                                                          notificationCenter: mockNotificationCenter)
+        feature.with(broker: broker)
+
+        // When
+        let subscriptionSelectedParams = ["id": "some-subscription-id"]
+        let result = try await feature.subscriptionSelected(params: subscriptionSelectedParams, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        XCTAssertTrue(mockNotificationCenter.didCallPostNotification)
+        XCTAssertEqual(mockNotificationCenter.lastPostedNotification, .subscriptionUpgradeFromFreemium)
+    }
+
+    func testSubscriptionUpgradeNotificationNotSentWhenSubscriptionSelectedSuccessNotFromFreemium() async throws {
+        // Given
+        ensureUserUnauthenticatedState()
+        XCTAssertEqual(subscriptionEnvironment.purchasePlatform, .appStore)
+        XCTAssertFalse(accountManager.isUserAuthenticated)
+
+        storePurchaseManager.hasActiveSubscriptionResult = false
+        storePurchaseManager.mostRecentTransactionResult = nil
+
+        authService.createAccountResult = .success(CreateAccountResponse(authToken: Constants.authToken,
+                                                                         externalID: Constants.externalID,
+                                                                         status: "created"))
+        authService.getAccessTokenResult = .success(AccessTokenResponse(accessToken: Constants.accessToken))
+        authService.validateTokenResult = .success(Constants.validateTokenResponse)
+        storePurchaseManager.purchaseSubscriptionResult = .success(Constants.mostRecentTransactionJWS)
+        subscriptionService.confirmPurchaseResult = .success(ConfirmPurchaseResponse(email: Constants.email,
+                                                                                     entitlements: Constants.entitlements,
+                                                                                     subscription: SubscriptionMockFactory.subscription))
+
+        let mockfreemiumDBPUserStateManager = MockFreemiumDBPUserStateManager()
+        mockfreemiumDBPUserStateManager.didActivate = false
+
+        let mockNotificationCenter = MockNotificationCenter()
+
+        feature = SubscriptionPagesUseSubscriptionFeature(subscriptionManager: subscriptionManager,
+                                                          stripePurchaseFlow: stripePurchaseFlow,
+                                                          uiHandler: uiHandler,
+                                                          subscriptionFeatureAvailability: subscriptionFeatureAvailability,
+                                                          freemiumDBPUserStateManager: mockfreemiumDBPUserStateManager,
+                                                          notificationCenter: mockNotificationCenter)
+        feature.with(broker: broker)
+
+        // When
+        let subscriptionSelectedParams = ["id": "some-subscription-id"]
+        let result = try await feature.subscriptionSelected(params: subscriptionSelectedParams, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        XCTAssertFalse(mockNotificationCenter.didCallPostNotification)
+        XCTAssertNil(mockNotificationCenter.lastPostedNotification)
+    }
 }
 
 @available(macOS 12.0, *)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206488453854252/1208399397658124/f

**Description**: This PR implements the sending of a new notification when a user purchases a PP Subscription after activating Freemium DBP. This notification is used to close any open DBP tabs. We close these tabs because after a purchase the DBP dashboard should be refreshed, and we will accomplish this by ensuring the tab is re-opened 

**Testing Prerequisites:**
1. Make sure you are an internal user
2. Disable/Signout of Privacy Pro (Settings menu -> PP -> Remove from this device)
3. Select Debug menu -> Freemium -> Set Experiment Cohort to Treatment
4. Set Subscription environment to staging

**Steps to test this PR**:
1. Launch browser (again)
2. Access Freemium DBP via the New Tab Page banner or the meatball menu item
3. Enter profile info and start a scan
4. Open the Privacy Pro Subscription page via the meatball menu, while keeping the DBP tab also open
5. Purchase a Subscription (using Stripe instructions [here](https://app.asana.com/0/1202500774821704/1207149361119036/f))
6. On purchase success, the DBP tab should close automatically


**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
