### PR TITLE
CSV parser: add support for backslash-escaped quotes

### DIFF
--- a/DuckDuckGo/DataImport/Logins/CSV/CSVParser.swift
+++ b/DuckDuckGo/DataImport/Logins/CSV/CSVParser.swift
@@ -20,19 +20,17 @@ import Foundation
 
 struct CSVParser {
 
-    enum ParserError: Error {
-        case unexpectedCharacterAfterQuote(Character)
-    }
-
     func parse(string: String) throws -> [[String]] {
         var parser = Parser()
 
         for character in string {
             try Task.checkCancellation()
-            try parser.accept(character)
+            // errors are only handled at the Parser level in `.branching` state
+            try? parser.accept(character)
         }
 
-        parser.flushField()
+        // errors are only handled at the Parser level in `.branching` state
+        try? parser.flushField(final: true)
 
         return parser.result
     }
@@ -41,78 +39,219 @@ struct CSVParser {
         case start
         case field
         case enquotedField
+        case branching([Parser])
+
+        /// returns: `true` if case is `.branching`
+        mutating func performIfBranching(_ action: (inout Parser) throws -> Void) -> Bool {
+            guard case .branching(var parsers) = self else { return false }
+
+            for idx in parsers.indices.reversed() {
+                do {
+                    try action(&parsers[idx])
+                } catch {
+                    parsers.remove(at: idx)
+                }
+            }
+            self = .branching(parsers)
+            return true
+        }
     }
 
     private struct Parser {
         var delimiter: Character?
 
+        enum QuoteEscapingType {
+            case unknown
+            case doubleQuote
+            case backslash
+        }
+        var quoteEscapingType = QuoteEscapingType.unknown
+
         var result: [[String]] = [[]]
 
         var state = State.start
-        var hasPrecedingQuote = false
+        enum PrecedingCharKind {
+            case none
+            case quote
+            case backslash
+        }
+        var precedingCharKind = PrecedingCharKind.none
 
         var currentField = ""
 
-        @inline(__always) mutating func flushField() {
-            result[result.endIndex - 1].append(currentField)
-            currentField = ""
-            state = .start
-            hasPrecedingQuote = false
+        enum ParserError: Error {
+            case unexpectedCharacterAfterQuote(Character)
+            case nonEnquotedFieldPayloadStart(Character)
+            case unexpectedDoubleQuoteInBackslashEscapedQuoteMode
+            case unexpectedEOF
         }
 
-        @inline(__always) mutating  func nextLine() {
-            flushField()
+        init() {}
+
+        private func copy(applying action: (inout Self) -> Void) -> Self {
+            var copy = self
+            action(&copy)
+            return copy
+        }
+
+        @inline(__always) mutating func flushField(final: Bool = false) throws {
+            if state.performIfBranching({ try $0.flushField(final: final) }) {
+                guard case .branching(let parsers) = state else { fatalError("Unexpected state") }
+                if parsers.count == 1 {
+                    self = parsers[0]
+                } else if final,
+                          let bestResult = parsers.max(by: { $0.result.reduce(0, { $0 + $1.count }) < $1.result.reduce(0, { $0 + $1.count }) }) {
+                    // not expected corner case: branching parser state at the EOF
+                    // find parser resulting with most fields
+                    self = bestResult
+                }
+                return
+            }
+            result[result.endIndex - 1].append(currentField)
+
+            let lastState = state
+            let lastPrecedingCharKind = precedingCharKind
+
+            currentField = ""
+            state = .start
+            precedingCharKind = .none
+
+            if final, case .enquotedField = lastState, lastPrecedingCharKind != .quote {
+                throw ParserError.unexpectedEOF
+            }
+        }
+
+        @inline(__always) mutating func nextLine() throws {
+            try flushField()
             result.append([])
             state = .start
-            hasPrecedingQuote = false
+            precedingCharKind = .none
         }
 
         mutating func accept(_ character: Character) throws {
-            switch (state, character.kind(delimiter: delimiter), precedingQuote: hasPrecedingQuote) {
-            case (_, .unsupported, _):
+            if state.performIfBranching({ try $0.accept(character) }) {
+                if case .branching(let parsers) = state, parsers.count == 1 {
+                    self = parsers[0]
+                }
+                return
+            }
+
+            let kind = character.kind(delimiter: delimiter)
+            switch (state, kind, preceding: precedingCharKind, quoteEscaping: quoteEscapingType) {
+            case (_, .unsupported, _, _):
                 return // skip control characters
 
             // expecting field start
-            case (.start, .quote, _):
+            case (.start, .quote, _, _):
+                // enquoted field starting
                 state = .enquotedField
-            case (.start, .delimiter, _):
-                flushField()
+            case (.start, .delimiter, _, _):
+                // empty field
+                try flushField()
                 delimiter = character
-            case (.start, .whitespace, _):
+            case (.start, .whitespace, _, _):
                 return // trim leading whitespaces
-            case (.start, .newline, _):
-                nextLine()
-            case (.start, .payload, _):
+            case (.start, .newline, _, _):
+                try nextLine()
+            case (.start, .payload, _, quoteEscaping: .backslash):
+                // all non-empty fields should be enquoted in backslash-escaped-quote mode
+                state = .field
+                currentField.append(character)
+                throw ParserError.nonEnquotedFieldPayloadStart(character)
+            case (.start, .payload, _, _), (.start, .backslash, _, _):
                 state = .field
                 currentField.append(character)
 
-            // quote in field body is escaped with 2 quotes
-            case (_, .quote, precedingQuote: false):
-                hasPrecedingQuote = true
-            case (_, .quote, precedingQuote: true):
-                currentField.append(character)
-                hasPrecedingQuote = false
+            // handle backslash
+            case (.enquotedField, .backslash, preceding: .none, quoteEscaping: .unknown),
+                 (.enquotedField, .backslash, preceding: .none, quoteEscaping: .backslash):
+                precedingCharKind = .backslash
+
+            case (.enquotedField, .quote, preceding: .backslash, quoteEscaping: .unknown):
+                // `\"` received in an unknown `quoteEscaping` state.
+                // It may be either just a backslash-escaped quote or a `\` followed by a field end - `"\n` or `",`.
+                // To figure the right way we do branching:
+                // branch that finishes without errors will be the chosen one.
+                state = .branching([
+                    // one parser will continue parsing in backslash-escaped-quote mode
+                    copy {
+                        $0.quoteEscapingType = .backslash
+                    },
+                    // - another one will continue parsing in double-quote-escaped mode
+                    copy{
+                        $0.quoteEscapingType = .doubleQuote
+                        // take the backslash as a payload
+                        $0.currentField.append("\\")
+                        $0.precedingCharKind = .none
+                    }
+                ])
+                try self.accept(character) // feed the quote character to the parsers
+
+            case (.enquotedField, .quote, preceding: .backslash, quoteEscaping: .backslash):
+                // `\"` received in backslash-escaped-quote mode
+                // it either means an escaped quote or a backslash followed by a field ending quote.
+                // To figure the right way we do branching:
+                // branch that finishes without errors will be the chosen one.
+                state = .branching([
+                    // - one parser will finish the field and continue parsing
+                    copy {
+                        // take the backslash as a payload at the end of the field
+                        $0.currentField.append("\\")
+                        // delimeter received next will finish the field
+                        $0.precedingCharKind = .quote
+                    },
+                    // - another one will unescape the quote and continue parsing the field
+                    copy {
+                        // append the quote and resume building the field
+                        $0.currentField.append(character /* quote */)
+                        $0.precedingCharKind = .none
+                    }
+                ])
+
+            case (_, _, preceding: .backslash, _):
+                // any non-quote character following a backslash: it was just a backslash
+                precedingCharKind = .none
+                currentField.append("\\")
+                try self.accept(character) // feed the character again
+
+            // quote in field body is escaped with 2 quotes (or with a backslash)
+            case (_, .quote, preceding: .none, _):
+                precedingCharKind = .quote
+            case (_, .quote, preceding: .quote, quoteEscaping: .unknown),
+                 (_, .quote, preceding: .quote, quoteEscaping: .doubleQuote):
+                currentField.append(character /* quote */)
+                precedingCharKind = .none
+                quoteEscapingType = .doubleQuote
+
+            // double quotes not allowed in backslash-escaped-quote mode
+            case (.enquotedField, .quote, preceding: .quote, quoteEscaping: .backslash):
+                precedingCharKind = .quote
+                currentField.append(character /* quote */)
+                throw ParserError.unexpectedDoubleQuoteInBackslashEscapedQuoteMode
 
             // enquoted field end
-            case (.enquotedField, .delimiter, precedingQuote: true):
-                flushField()
+            case (.enquotedField, .delimiter, .quote, _):
+                try flushField()
                 delimiter = character
-            case (.enquotedField, .newline, precedingQuote: true):
-                nextLine()
-            case (.enquotedField, .whitespace, precedingQuote: true):
+            case (.enquotedField, .newline, preceding: .quote, _):
+                try nextLine()
+            case (.enquotedField, .whitespace, preceding: .quote, _):
                 return // trim whitespaces between fields
 
             // unbalanced quote
-            case (_, _, precedingQuote: true):
+            case (_, _, preceding: .quote, _):
                 // only expecting a second quote after a quote in field body
+                currentField.append("\"")
+                currentField.append(character)
+                precedingCharKind = .none
                 throw ParserError.unexpectedCharacterAfterQuote(character)
 
             // non-enquoted field end
-            case (.field, .delimiter, _):
-                flushField()
+            case (.field, .delimiter, _, _):
+                try flushField()
                 delimiter = character
-            case (.field, .newline, _):
-                nextLine()
+            case (.field, .newline, _, _):
+                try nextLine()
 
             default:
                 currentField.append(character)
@@ -125,6 +264,7 @@ struct CSVParser {
 private extension Character {
 
     enum Kind {
+    case backslash
     case quote
     case delimiter
     case newline
@@ -134,7 +274,9 @@ private extension Character {
     }
 
     func kind(delimiter: Character?) -> Kind {
-        if self == "\"" {
+        if self == "\\" {
+            .backslash
+        } else if self == "\"" {
             .quote
         } else if self.unicodeScalars.contains(where: { CharacterSet.unsupportedCharacters.contains($0) }) {
             .unsupported

--- a/UnitTests/DataImport/CSVParserTests.swift
+++ b/UnitTests/DataImport/CSVParserTests.swift
@@ -63,22 +63,56 @@ final class CSVParserTests: XCTestCase {
         XCTAssertEqual(parsed, [["url", "username", "password"]])
     }
 
-    func testWhenParsingMalformedCSV_ParserThrows() {
+    func testWhenParsingMalformedCsvWithExtraQuote_ParserAddsItToOutput() throws {
         let string = """
-        "url","user"name","password"
-        """
-
-        XCTAssertThrowsError(try CSVParser().parse(string: string))
-    }
-
-    func testWhenParsingRowsWithAnEscapedQuoteThenQuoteIsUnescaped() throws {
-        let string = """
-        "url","username","password\\""with""quotes"
+        "url","user"name","password",""
         """
 
         let parsed = try CSVParser().parse(string: string)
 
-        XCTAssertEqual(parsed, [["url", "username", "password\\\"with\"quotes"]])
+        XCTAssertEqual(parsed, [["url", #"user"name"#, "password", ""]])
+    }
+
+    func testWhenParsingRowsWithDoubleQuoteEscapedQuoteThenQuoteIsUnescaped() throws {
+        let string = #"""
+        "url","username","password\""with""quotes\""and/slash""\"
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [["url", "username", #"password\"with"quotes\"and/slash"\"#]])
+    }
+
+    func testWhenParsingRowsWithBackslashEscapedQuoteThenQuoteIsUnescaped() throws {
+        let string = #"""
+        "\\","\"password\"with","quotes\","\",\",
+        """#
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [[#"\\"#, #""password"with"#, #"quotes\"#, #"",\"#, ""]])
+    }
+
+    func testWhenParsingRowsWithBackslashEscapedQuoteThenQuoteIsUnescaped2() throws {
+        let string = #"""
+                "\"",  "\"\"","\\","\"password\"with","quotes\","\",\",
+        """#
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed.map({ $0.map { $0.replacingOccurrences(of: "\\", with: "|").replacingOccurrences(of: "\"", with: "”") } }), [["\"", "\"\"", #"\\"#, #""password"with"#, #"quotes\"#, #"",\"#, ""].map { $0.replacingOccurrences(of: "\\", with: "|").replacingOccurrences(of: "\"", with: "”") }])
+    }
+
+    func testWhenParsingRowsWithUnescapedTitleAndEscapedQuoteAndEmojiThenQuoteIsUnescaped() throws {
+        let string = #"""
+        Title,Url,Username,Password,OTPAuth,Notes
+        "A",,"",,,"It’s \\"you! 🖐 Select Edit to fill in more details, like your address and contact information.\",
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [
+            ["Title", "Url", "Username", "Password", "OTPAuth", "Notes"],
+            ["A", "", "", "", "", #"It’s \"you! 🖐 Select Edit to fill in more details, like your address and contact information.\"#, ""]
+        ])
     }
 
     func testWhenParsingQuotedRowsContainingCommasThenTheyAreTreatedAsOneColumnEntry() throws {
@@ -89,6 +123,84 @@ final class CSVParserTests: XCTestCase {
         let parsed = try CSVParser().parse(string: string)
 
         XCTAssertEqual(parsed, [["url", "username", "password,with,commas"]])
+    }
+
+    func testWhenSingleValueWithQuotedEscapedQuoteThenQuoteIsUnescaped() throws {
+        let string = #"""
+        "\""
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [["\""]])
+    }
+
+    func testSingleEnquotedBackslashValueIsParsedAsBackslash() throws {
+        let string = #"""
+        "\"
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [[#"\"#]])
+    }
+
+    func testBackslashValueWithDoubleQuoteIsParsedAsBackslashWithQuote() throws {
+        let string = #"""
+        \""
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [[#"\""#]])
+    }
+
+    func testEnquotedBackslashValueWithDoubleQuoteIsParsedAsBackslashWithQuote() throws {
+        let string = #"""
+        "\"""
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [[#"\""#]])
+    }
+
+    func testEscapedDoubleQuote() throws {
+        let string = #"""
+        """"
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [["\""]])
+    }
+
+    func testWhenValueIsDoubleQuotedThenQuotesAreUnescaped() throws {
+        let string = #"""
+        ""hello!""
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [["\"hello!\""]])
+    }
+
+    func testWhenExpressionIsParsableEitherAsDoubleQuoteEscapedOrBackslashEscapedThenEqualFieldsNumberIsPreferred() throws {
+        let string = #"""
+        1,2,3,4,5,6,
+        "\",b,c,d,e,f,
+        asdf,\"",hi there!,4,5,6,
+        a,b,c,d,e,f,
+        """#
+
+        let parsed = try CSVParser().parse(string: string)
+
+        XCTAssertEqual(parsed, [
+            ["1", "2", "3", "4", "5", "6", ""],
+            ["\\", "b", "c", "d", "e", "f", ""],
+            ["asdf", #"\""#, "hi there!", "4", "5", "6", ""],
+            ["a", "b", "c", "d", "e", "f", ""],
+        ])
     }
 
 }

--- a/UnitTests/DataImport/CSVParserTests.swift
+++ b/UnitTests/DataImport/CSVParserTests.swift
@@ -64,13 +64,17 @@ final class CSVParserTests: XCTestCase {
     }
 
     func testWhenParsingMalformedCsvWithExtraQuote_ParserAddsItToOutput() throws {
-        let string = """
+        let string = #"""
         "url","user"name","password",""
-        """
+        "a.b.com/usdf","my@name.is","\"mypass\wrd\",""
+        """#
 
         let parsed = try CSVParser().parse(string: string)
 
-        XCTAssertEqual(parsed, [["url", #"user"name"#, "password", ""]])
+        XCTAssertEqual(parsed, [
+            ["url", #"user"name"#, "password", ""],
+            ["a.b.com/usdf", "my@name.is", #""mypass\wrd\"#, ""],
+        ])
     }
 
     func testWhenParsingRowsWithDoubleQuoteEscapedQuoteThenQuoteIsUnescaped() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202406491309510/1208116635478553/f

**Description**:
- Adds support for backslash-escaped quotes in CSV parser to support 1Password export

**Steps to test this PR**:
1. Save something with a quote in 1Password
2. Export all in "iCloud CSV" format
3. Import passwords -> Validate passwords are imported
4. Validate regular (e.g. Bitwarden) passwords import still works correctly

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
