### PR TITLE
Only share one URL

### DIFF
--- a/DuckDuckGo/Sharing/SharingMenu.swift
+++ b/DuckDuckGo/Sharing/SharingMenu.swift
@@ -53,7 +53,7 @@ final class SharingMenu: NSMenu {
 
         let sharingData = DuckPlayer.shared.sharingData(for: tabViewModel.title, url: url) ?? (tabViewModel.title, url)
 
-        return (sharingData.title, [url, url.absoluteString])
+        return (sharingData.title, [url])
     }
 
     @objc func openSharingPreferences(_ sender: NSMenuItem) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202926619870900/1208232402549171/f

**Description**:

When sharing a website to mail, the link gets inserted twice in the message body

**Steps to test this PR**:
1. Open a site
2. Go to settings
3. Click on Share
4. Pick email
5. Your apple email should automatically open
6. Only one link is shared (previously duplicated)

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
