### PR TITLE
Back up appcast2.xml file as soon as it's downloaded by appcastManager.swift

### DIFF
--- a/scripts/appcast_manager/appcastManager.swift
+++ b/scripts/appcast_manager/appcastManager.swift
@@ -346,6 +346,7 @@ final class AppcastDownloader {
         prepareDirectories()
         downloadAppcast()
         dispatchGroup.wait()
+        backupAppcast()
         parseAndDownloadFilesFromAppcast()
         dispatchGroup.wait()
 
@@ -511,6 +512,26 @@ final class AppcastDownloader {
                 print("✅ Appcast downloaded to: \(appcastFilePath.path)")
                 self.dispatchGroup.leave()
             }
+        }
+    }
+
+    private func backupAppcast() {
+        // Check if backup file already exists and remove it
+        if FileManager.default.fileExists(atPath: backupFileURL.path) {
+            do {
+                try FileManager.default.removeItem(at: backupFileURL)
+            } catch {
+                print("❌ Error removing existing backup file: \(error)")
+                exit(1)
+            }
+        }
+
+        // Create a new backup of the appcast file
+        do {
+            try FileManager.default.copyItem(at: appcastFilePath, to: backupFileURL)
+        } catch {
+            print("❌ Error backing up appcast2.xml: \(error)")
+            exit(1)
         }
     }
 
@@ -773,24 +794,6 @@ func writeAppcastContent(_ content: String, to filePath: URL) {
 // MARK: - Generating of New Appcast
 
 func runGenerateAppcast(with versionNumber: String, channel: String? = nil, rolloutInterval: String? = nil, keyFile: String? = nil) {
-    // Check if backup file already exists and remove it
-    if FileManager.default.fileExists(atPath: backupFileURL.path) {
-        do {
-            try FileManager.default.removeItem(at: backupFileURL)
-        } catch {
-            print("❌ Error removing existing backup file: \(error)")
-            exit(1)
-        }
-    }
-
-    // Create a new backup of the appcast file
-    do {
-        try FileManager.default.copyItem(at: appcastFilePath, to: backupFileURL)
-    } catch {
-        print("❌ Error backing up appcast2.xml: \(error)")
-        exit(1)
-    }
-
     let maximumVersions = "2"
     let maximumDeltas = "2"
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1208492347129471/f

**Description**:
This change fixes appcast diff generation for public releases, where prior to running generate_appcast
we remove the promoted version from the appcast completely, to allow Sparkle to re-add it from scratch.
The change ensures that the appcast file backup (used for generating the diff) is always created from the
original appcast file, freshly downloaded from the CDN.

**Steps to test this PR**:
1. Set up Sparkle binary tools as instructed in [this task](https://app.asana.com/0/1199230911884351/1208493161720355/f).
2. Create a file called `release-notes.txt` in the root directory of the macOS repository, containing a single line: `Bug fixes and improvements.`.
3. Call appcastManager to prepare the public release of the latest internal build:
  * `./scripts/appcast_manager/appcastManager.swift --release-to-public-channel --version 1.109.0.277 --release-notes ./release-notes.txt`
4. Please note that this script doesn't change appcast remotely. It will only update it locally and open a directory with new appcast and other Sparkle files.
5. Verify that appcast_diff.txt only changes pubDate and replaces `internal-channel` with phased rollout definition for the topmost appcast item. Other changes in the diff should be: updates to delta files, and the removal of the penultimate item from the appcast.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
