### PR TITLE
Upload DMG to S3 test builds by default

### DIFF
--- a/.github/workflows/build_notarized.yml
+++ b/.github/workflows/build_notarized.yml
@@ -123,7 +123,7 @@ jobs:
         if [[ "${{ env.is-official-release }}" == "true" ]]; then
           echo "upload-to=s3" >> $GITHUB_OUTPUT
           echo "upload-to=s3" >> $GITHUB_ENV
-        elif [[ -n "${{ env.asana-task-url }}" ]]; then
+        else
           echo "upload-to=s3testbuilds" >> $GITHUB_OUTPUT
           echo "upload-to=s3testbuilds" >> $GITHUB_ENV
         fi
@@ -349,9 +349,11 @@ jobs:
         echo "🔗 [${DMG_S3_PATH}](${DMG_URL})" >> $GITHUB_STEP_SUMMARY
         echo "🔗 [${DSYM_S3_PATH}](${DSYM_URL})" >> $GITHUB_STEP_SUMMARY
 
-        bundle exec fastlane run asana_add_comment \
-          task_url:"${{ env.asana-task-url }}" \
-          comment:"New build is available at ${DMG_URL}."
+        if [[ -n "${{ env.asana-task-url }}" ]]; then
+          bundle exec fastlane run asana_add_comment \
+            task_url:"${{ env.asana-task-url }}" \
+            comment:"New build is available at ${DMG_URL}."
+        fi
 
   mattermost:
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1208498816479865/f

**Description**:
This change updates build_notarized.yml so that it uploads dSYMs and DMGs to S3 test builds location
also when Asana task URL is not provided.

**Steps to test this PR**:
Verify that [this workflow](https://github.com/duckduckgo/macos-browser/actions/runs/11237833287) completed successfully, and that it contains links to the build and dSYMs posted in "Create DMG summary" on the bottom of the workflow summary page.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
