### PR TITLE
Delay loading Identity Theft Restoration until Content Blocking rules are loaded in the tab

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
@@ -103,7 +103,9 @@ extension ContentBlockingTabExtension: NavigationResponder {
             // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/email/
             || navigationAction.url.absoluteString.hasPrefix(URL.duckDuckGoEmailLogin.absoluteString)
             // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/subscriptions
-            || navigationAction.url.absoluteString.hasPrefix(SubscriptionURL.baseURL.subscriptionURL(environment: .production).absoluteString) {
+            || navigationAction.url.absoluteString.hasPrefix(SubscriptionURL.baseURL.subscriptionURL(environment: .production).absoluteString)
+            // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/identity-theft-restoration
+            || navigationAction.url.absoluteString.hasPrefix(SubscriptionURL.identityTheftRestoration.subscriptionURL(environment: .production).absoluteString) {
             await prepareForContentBlocking()
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207104330327543/1208508938068402/f

**Steps to test this PR**:
1. Run the app from Xcode (or grab a review build from [here](https://staticcdn.duckduckgo.com/macos-desktop-browser/a81f9679-e41d-404d-81a6-fd4a461d82f7/testbuilds/1a36e72/duckduckgo-1.109.0.278.dmg)).
2. Subscribe to Privacy Pro.
3. Go to Main Menu -> Debug -> Tab -> Append Tabs -> 50 Tabs
4. While tabs are loading, go to meatball menu -> Privacy Pro -> Identity Theft Restoration.
5. Verify that ITR landing page loads, and you're not redirected to SERP.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
