### PR TITLE
fix icon in dark mode

### DIFF
--- a/DuckDuckGo/Assets.xcassets/Images/Import-16D.imageset/Contents.json
+++ b/DuckDuckGo/Assets.xcassets/Images/Import-16D.imageset/Contents.json
@@ -8,5 +8,9 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204186595873227/1208423163807230/f

**Description**: Fix import bookmarks icon in dark mode

**Steps to test this PR**:
1. Make the bookmark bar visible
2. Ensure you don’t have any bookmarks on
3. You should see the import bookmark button and related icon 
4. Check the icon is visible in both dark and light mode

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
