### PR TITLE
Extract Common Logic to DBPUIDataBrokerProfileMatch for DBP UI Scan Results

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/DBPUICommunicationModel.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/DBPUICommunicationModel.swift
@@ -224,6 +224,57 @@ extension DBPUIDataBrokerProfileMatch {
                   dataBrokerParentURL: dataBroker.parent,
                   parentBrokerOptOutJobData: parentBrokerOptOutJobData)
     }
+
+    /// Generates an array of `DBPUIDataBrokerProfileMatch` objects from the provided query data.
+    ///
+    /// This method processes an array of `BrokerProfileQueryData` to create a list of profile matches for data brokers.
+    /// It takes into account the opt-out data associated with each data broker, as well as any parent data brokers and their opt-out data.
+    /// Additionally, it includes mirror sites for each data broker, if applicable, based on the conditions defined in `shouldWeIncludeMirrorSite()`.
+    ///
+    /// - Parameter queryData: An array of `BrokerProfileQueryData` objects, which contains data brokers and their respective opt-out data.
+    /// - Returns: An array of `DBPUIDataBrokerProfileMatch` objects representing matches for each data broker, including parent brokers and mirror sites.
+    static func profileMatches(from queryData: [BrokerProfileQueryData]) -> [DBPUIDataBrokerProfileMatch] {
+        // Group the query data by data broker URL to easily find parent data broker opt-outs later.
+        let brokerURLsToQueryData = Dictionary(grouping: queryData, by: { $0.dataBroker.url })
+
+        return queryData.flatMap {
+            var profiles = [DBPUIDataBrokerProfileMatch]()
+
+            for optOutJobData in $0.optOutJobData {
+                let dataBroker = $0.dataBroker
+
+                // Find opt-out job data for the parent broker, if applicable.
+                var parentBrokerOptOutJobData: [OptOutJobData]?
+                if let parent = dataBroker.parent,
+                   let parentsQueryData = brokerURLsToQueryData[parent] {
+                    parentBrokerOptOutJobData = parentsQueryData.flatMap { $0.optOutJobData }
+                }
+
+                // Create a profile match for the current data broker and append it to the list of profiles.
+                profiles.append(DBPUIDataBrokerProfileMatch(optOutJobData: optOutJobData,
+                                                            dataBroker: dataBroker,
+                                                            parentBrokerOptOutJobData: parentBrokerOptOutJobData))
+
+                // Handle mirror sites associated with the data broker.
+                if !dataBroker.mirrorSites.isEmpty {
+                    // Create profile matches for each mirror site if it meets the inclusion criteria.
+                    let mirrorSitesMatches = dataBroker.mirrorSites.compactMap { mirrorSite in
+                        if mirrorSite.shouldWeIncludeMirrorSite() {
+                            return DBPUIDataBrokerProfileMatch(optOutJobData: optOutJobData,
+                                                               dataBrokerName: mirrorSite.name,
+                                                               dataBrokerURL: mirrorSite.url,
+                                                               dataBrokerParentURL: dataBroker.parent,
+                                                               parentBrokerOptOutJobData: parentBrokerOptOutJobData)
+                        }
+                        return nil
+                    }
+                    profiles.append(contentsOf: mirrorSitesMatches)
+                }
+            }
+
+            return profiles
+        }
+    }
 }
 
 /// Protocol to represent a message that can be passed from the host to the UI

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/UIMapper.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/UI/UIMapper.swift
@@ -44,49 +44,9 @@ struct MapperToUI {
                                              totalScans: totalScans,
                                              scannedBrokers: partiallyScannedBrokers)
 
-        let matches = mapMatchesToUI(withoutDeprecated)
+        let matches = DBPUIDataBrokerProfileMatch.profileMatches(from: withoutDeprecated)
 
         return .init(resultsFound: matches, scanProgress: scanProgress)
-    }
-
-    private func mapMatchesToUI(_ brokerProfileQueryData: [BrokerProfileQueryData]) -> [DBPUIDataBrokerProfileMatch] {
-
-        // Used to find opt outs on the parent
-        let brokerURLsToQueryData =  Dictionary(grouping: brokerProfileQueryData, by: { $0.dataBroker.url })
-
-        return brokerProfileQueryData.flatMap {
-            var profiles = [DBPUIDataBrokerProfileMatch]()
-            for optOutJobData in $0.optOutJobData {
-                let dataBroker = $0.dataBroker
-
-                var parentBrokerOptOutJobData: [OptOutJobData]?
-                if let parent = dataBroker.parent,
-                   let parentsQueryData = brokerURLsToQueryData[parent] {
-                    parentBrokerOptOutJobData = parentsQueryData.flatMap { $0.optOutJobData }
-                }
-
-                profiles.append(DBPUIDataBrokerProfileMatch(optOutJobData: optOutJobData,
-                                                            dataBroker: dataBroker,
-                                                            parentBrokerOptOutJobData: parentBrokerOptOutJobData))
-
-                if !dataBroker.mirrorSites.isEmpty {
-                    let mirrorSitesMatches = dataBroker.mirrorSites.compactMap { mirrorSite in
-                        if mirrorSite.shouldWeIncludeMirrorSite() {
-                            return DBPUIDataBrokerProfileMatch(optOutJobData: optOutJobData,
-                                                               dataBrokerName: mirrorSite.name,
-                                                               dataBrokerURL: mirrorSite.url,
-                                                               dataBrokerParentURL: dataBroker.parent,
-                                                               parentBrokerOptOutJobData: parentBrokerOptOutJobData)
-                        }
-
-                        return nil
-                    }
-                    profiles.append(contentsOf: mirrorSitesMatches)
-                }
-            }
-
-            return profiles
-        }
     }
 
     func maintenanceScanState(_ brokerProfileQueryData: [BrokerProfileQueryData]) -> DBPUIScanAndOptOutMaintenanceState {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionDataManagingTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerProtectionDataManagingTests.swift
@@ -56,12 +56,14 @@ final class DataBrokerProtectionDataManagingTests: XCTestCase {
         // We expect:
         // - 5 matches:
         //   - 1 extracted profile + 2 mirror sites for Broker A (3 total)
+        //   - 1 extracted profile + 0 mirror sites for Broker A again (1 total)
         //   - Broker B is deprecated, so it should be skipped (0 total)
         //   - 1 extracted profile + 1 mirror site for Broker C (2 total)
-        //   - Total = 3 + 0 + 2 = 5
-        // - 2 brokers with matches (Broker A and Broker C)
-        XCTAssertEqual(result.matchCount, 5)
-        XCTAssertEqual(result.brokerCount, 2)
+        //   - 1 extracted profile + 1 mirror site for Broker D (2 total)
+        //   - Total = 3 + 1 + 0 + 2 + 1 = 7
+        // - 6 brokers with matches (Broker A (with Mirror 1 & 2), Broker C (with Mirror 3), Broker D)
+        XCTAssertEqual(result.matchCount, 7)
+        XCTAssertEqual(result.brokerCount, 6)
     }
 
     func testWhenAllBrokersAreDeprecated_thenZeroMatchesAndZeroBrokersAreReturned() throws {
@@ -214,7 +216,37 @@ private extension DataBrokerProtectionDataManagingTests {
                 deprecated: false
             ),
 
-            // Second item: Deprecated broker with no matches
+            // Second item: Broker A again
+            BrokerProfileQueryData.mock(
+                dataBrokerName: "Broker A",
+                url: "https://broker-a.com",
+                extractedProfile: ExtractedProfile(
+                    id: 1,
+                    name: "John Doe",
+                    alternativeNames: nil,
+                    addressFull: nil,
+                    addresses: nil,
+                    phoneNumbers: nil,
+                    relatives: nil,
+                    profileUrl: nil,
+                    reportId: nil,
+                    age: nil,
+                    email: nil,
+                    removedDate: nil,
+                    identifier: "id1"
+                ), scanHistoryEvents: [
+                    HistoryEvent(
+                        extractedProfileId: 1,
+                        brokerId: 1,
+                        profileQueryId: 1,
+                        type: .scanStarted,
+                        date: Date()
+                    )
+                ], mirrorSites: [],
+                deprecated: false
+            ),
+
+            // Third item: Deprecated broker with no matches
             BrokerProfileQueryData.mock(
                 dataBrokerName: "Broker B",
                 url: "https://broker-b.com",
@@ -230,7 +262,7 @@ private extension DataBrokerProtectionDataManagingTests {
                 deprecated: true
             ),
 
-            // Third item: Active broker with 2 extracted profiles and 1 mirror site
+            // Fourth item: Active broker with 2 extracted profiles and 1 mirror site
             BrokerProfileQueryData.mock(
                 dataBrokerName: "Broker C",
                 url: "https://broker-c.com",
@@ -259,6 +291,36 @@ private extension DataBrokerProtectionDataManagingTests {
                 ], mirrorSites: [
                     MirrorSite(name: "Mirror 3", url: "https://mirror3.com", addedAt: Date(), removedAt: nil)
                 ],
+                deprecated: false
+            ),
+
+            // Third item: Active broker with 2 extracted profiles and 1 mirror site
+            BrokerProfileQueryData.mock(
+                dataBrokerName: "Broker D",
+                url: "https://broker-d.com",
+                extractedProfile: ExtractedProfile(
+                    id: 2,
+                    name: "Alice",
+                    alternativeNames: nil,
+                    addressFull: nil,
+                    addresses: nil,
+                    phoneNumbers: nil,
+                    relatives: nil,
+                    profileUrl: nil,
+                    reportId: nil,
+                    age: nil,
+                    email: nil,
+                    removedDate: nil,
+                    identifier: "id2"
+                ), scanHistoryEvents: [
+                    HistoryEvent(
+                        extractedProfileId: 2,
+                        brokerId: 3,
+                        profileQueryId: 3,
+                        type: .scanStarted,
+                        date: Date()
+                    )
+                ], mirrorSites: [],
                 deprecated: false
             )
         ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208507342220062/f

**Description**: This PR fixes an issue with Freemium PIR where the results displayed on the new tab page do not match the results displayed on the dashboard

**Test Prerequisites**
1. Set yourself as an internal user via Debug menu → Set Internal User State
2. Disable/Signout of Privacy Pro via Settings menu → PP →  Remove from this device
3. Select Debug menu → Freemium -> Enroll into Experiment
4. Set the custom frontend UI URL via Debug menu → Personal Information Removal → Web UI → Set Custom URL. Enter `https://abrown.duckduckgo.com/dbp`
5. Use the custom frontend UI URL via Debug menu → Personal Information Removal → Web UI → Use Custom URL
Relaunch the browser

**Steps to test this PR**:
1. Relaunch the browser
2. Open Freemium PIR via the banner on the new tab page
3. Enter profile data and perform a scan
4. Wait until it completes (or gets stuck 😅, a separate issue)
5. Note the scan results - the count of matches and broker sites (e.g 20 matches on 14 sites)
6. Relaunch the browser
7. You should see a banner on the new tab page and the results should match the previous results from the PIR dashboard

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
