### PR TITLE
Re-add manual sort test to the UI test plan

### DIFF
--- a/UITests/UI Tests.xctestplan
+++ b/UITests/UI Tests.xctestplan
@@ -36,7 +36,6 @@
   "testTargets" : [
     {
       "skippedTests" : [
-        "BookmarkSortTests\/testManualSortWorksAsExpectedOnBookmarksPanel()",
         "BookmarksAndFavoritesTests\/test_bookmarks_canBeAddedTo_byClickingBookmarksButtonInAddressBar()",
         "BookmarksAndFavoritesTests\/test_favorites_canBeAddedTo_byClickingAddFavoriteInAddBookmarkPopover()",
         "PermissionsTests"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208528710258901/f
Tech Design URL:
CC:

**Description**
Remove `testManualSortWorksAsExpectedOnBookmarksPanel` from the skipped test.

**Steps to test this PR**:
The https://github.com/duckduckgo/macos-browser/actions/runs/11293513680 shows that the other two tests are the one that are failing.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
