### PR TITLE
Freemium PIR: Subscription Attribution

### DIFF
--- a/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
+++ b/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
@@ -23,7 +23,6 @@ import OSLog
 import DataBrokerProtection
 import Common
 
-
 /// Default implementation of `FreemiumDBPPromotionViewCoordinating`, responsible for managing
 /// the visibility of the promotion and responding to user interactions with the promotion view.
 @MainActor

--- a/DuckDuckGo/Subscription/SubscriptionAttributionPixelHandler.swift
+++ b/DuckDuckGo/Subscription/SubscriptionAttributionPixelHandler.swift
@@ -27,6 +27,11 @@ protocol SubscriptionAttributionPixelHandler: AnyObject {
 // MARK: - SubscriptionAttributionPixelHandler
 
 final class PrivacyProSubscriptionAttributionPixelHandler: SubscriptionAttributionPixelHandler {
+
+    enum Consts {
+        static let freemiumOrigin = "funnel_pro_mac_freemium"
+    }
+
     var origin: String?
     private let decoratedAttributionPixelHandler: AttributionPixelHandler
 

--- a/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
@@ -196,8 +196,8 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature {
 
         let message = original
 
-        // Extract the origin from the webview URL to use for attribution pixel.
-        subscriptionSuccessPixelHandler.origin = await originFrom(originalMessage: message)
+        await setPixelOrigin(from: message)
+
         if subscriptionManager.currentEnvironment.purchasePlatform == .appStore {
             if #available(macOS 12.0, *) {
                 guard let subscriptionSelection: SubscriptionSelection = DecodableHelper.decode(from: params) else {
@@ -488,6 +488,18 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature {
         default: return
         }
     }
+
+    // MARK: - Attribution
+    /// Sets the appropriate origin for the subscription success tracking pixel.
+    ///
+    /// - Note: This method is asynchronous when extracting the origin from the webview URL.
+    private func setPixelOrigin(from message: WKScriptMessage) async {
+        // If the user has performed a Freemium scan, set a Freemium origin and return
+        guard !setFreemiumOriginIfScanPerformed() else { return }
+
+        // Else, Extract the origin from the webview URL to use for attribution pixel.
+        subscriptionSuccessPixelHandler.origin = await originFrom(originalMessage: message)
+    }
 }
 
 extension SubscriptionPagesUseSubscriptionFeature: SubscriptionAccessActionHandling {
@@ -560,5 +572,22 @@ private extension SubscriptionPagesUseSubscriptionFeature {
         if freemiumDBPUserStateManager.didActivate && freemiumDBPUserStateManager.upgradeToSubscriptionTimestamp == nil {
             freemiumDBPUserStateManager.upgradeToSubscriptionTimestamp = Date()
         }
+    }
+
+    /// Sets the origin for attribution if the user has posted their first profile saved notification.
+    ///
+    /// This method checks whether the user has completed the action of posting their first profile saved notification.
+    /// If they have, the method sets the subscription success tracking origin to `"funnel_pro_mac_freemium"` and returns `true`.
+    ///
+    /// - Returns:
+    ///   - `true` if the origin is set because the user has posted their first profile saved notification.
+    ///   - `false` if the notification has not been posted and the origin is not set.
+    func setFreemiumOriginIfScanPerformed() -> Bool {
+        let origin = "funnel_pro_mac_freemium"
+        if freemiumDBPUserStateManager.didPostFirstProfileSavedNotification {
+            subscriptionSuccessPixelHandler.origin = origin
+            return true
+        }
+        return false
     }
 }

--- a/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
@@ -576,7 +576,7 @@ private extension SubscriptionPagesUseSubscriptionFeature {
 
     /// Sets the origin for attribution if the user has started their first Freemium PIR scan
     ///
-    /// This method checks whether the user has started their first Freemim PIR scan.
+    /// This method checks whether the user has started their first Freemium PIR scan.
     /// If they have, the method sets the subscription success tracking origin to `"funnel_pro_mac_freemium"` and returns `true`.
     ///
     /// - Returns:

--- a/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
@@ -574,14 +574,14 @@ private extension SubscriptionPagesUseSubscriptionFeature {
         }
     }
 
-    /// Sets the origin for attribution if the user has posted their first profile saved notification.
+    /// Sets the origin for attribution if the user has started their first Freemium PIR scan
     ///
-    /// This method checks whether the user has completed the action of posting their first profile saved notification.
+    /// This method checks whether the user has started their first Freemim PIR scan.
     /// If they have, the method sets the subscription success tracking origin to `"funnel_pro_mac_freemium"` and returns `true`.
     ///
     /// - Returns:
-    ///   - `true` if the origin is set because the user has posted their first profile saved notification.
-    ///   - `false` if the notification has not been posted and the origin is not set.
+    ///   - `true` if the origin is set because the user has started their first Freemim PIR scan.
+    ///   - `false` if a first scan has not been started and the origin is not set.
     func setFreemiumOriginIfScanPerformed() -> Bool {
         let origin = "funnel_pro_mac_freemium"
         if freemiumDBPUserStateManager.didPostFirstProfileSavedNotification {

--- a/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
@@ -583,7 +583,7 @@ private extension SubscriptionPagesUseSubscriptionFeature {
     ///   - `true` if the origin is set because the user has started their first Freemim PIR scan.
     ///   - `false` if a first scan has not been started and the origin is not set.
     func setFreemiumOriginIfScanPerformed() -> Bool {
-        let origin = "funnel_pro_mac_freemium"
+        let origin = PrivacyProSubscriptionAttributionPixelHandler.Consts.freemiumOrigin
         if freemiumDBPUserStateManager.didPostFirstProfileSavedNotification {
             subscriptionSuccessPixelHandler.origin = origin
             return true

--- a/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatorTests.swift
+++ b/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatorTests.swift
@@ -361,4 +361,3 @@ class MockFreemiumDBPExperimentPixelHandler: EventMapping<FreemiumDBPExperimentP
         lastPassedParameters = nil
     }
 }
-

--- a/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -1121,6 +1121,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = true
         feature.with(broker: broker)
+        let freeiumOrigin = PrivacyProSubscriptionAttributionPixelHandler.Consts.freemiumOrigin
 
         // When
         let subscriptionSelectedParams = ["id": "some-subscription-id"]
@@ -1128,7 +1129,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
         // Then
         XCTAssertNil(result)
-        XCTAssertEqual(subscriptionAttributionPixelHandler.origin, "funnel_pro_mac_freemium")
+        XCTAssertEqual(subscriptionAttributionPixelHandler.origin, freeiumOrigin)
     }
 
     func testFreemiumPixelOriginNotSetWhenSubscriptionSelectedSuccessNotFromFreemium() async throws {
@@ -1152,6 +1153,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = false
         feature.with(broker: broker)
+        let freeiumOrigin = PrivacyProSubscriptionAttributionPixelHandler.Consts.freemiumOrigin
 
         // When
         let subscriptionSelectedParams = ["id": "some-subscription-id"]
@@ -1159,7 +1161,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
         // Then
         XCTAssertNil(result)
-        XCTAssertNotEqual(subscriptionAttributionPixelHandler.origin, "funnel_pro_mac_freemium")
+        XCTAssertNotEqual(subscriptionAttributionPixelHandler.origin, freeiumOrigin)
     }
 }
 

--- a/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -89,6 +89,8 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
     var appStoreAccountManagementFlow: AppStoreAccountManagementFlow!
     var stripePurchaseFlow: StripePurchaseFlow!
 
+    var subscriptionAttributionPixelHandler: SubscriptionAttributionPixelHandler!
+
     var subscriptionFeatureAvailability: SubscriptionFeatureAvailabilityMock!
 
     var accountManager: AccountManager!
@@ -160,6 +162,8 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
                                                        authEndpointService: authService,
                                                        accountManager: accountManager)
 
+        subscriptionAttributionPixelHandler = PrivacyProSubscriptionAttributionPixelHandler()
+
         subscriptionFeatureAvailability = SubscriptionFeatureAvailabilityMock(isFeatureAvailable: true,
                                                                               isSubscriptionPurchaseAllowed: true,
                                                                               usesUnifiedFeedbackForm: false)
@@ -176,6 +180,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         mockFreemiumDBPUserStateManager = MockFreemiumDBPUserStateManager()
 
         feature = SubscriptionPagesUseSubscriptionFeature(subscriptionManager: subscriptionManager,
+                                                          subscriptionSuccessPixelHandler: subscriptionAttributionPixelHandler,
                                                           stripePurchaseFlow: stripePurchaseFlow,
                                                           uiHandler: uiHandler,
                                                           subscriptionFeatureAvailability: subscriptionFeatureAvailability,
@@ -1047,28 +1052,18 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
                                                                                      entitlements: Constants.entitlements,
                                                                                      subscription: SubscriptionMockFactory.subscription))
 
-        let mockfreemiumDBPUserStateManager = MockFreemiumDBPUserStateManager()
-        mockfreemiumDBPUserStateManager.didActivate = true
-
-        let mockNotificationCenter = MockNotificationCenter()
-
-        feature = SubscriptionPagesUseSubscriptionFeature(subscriptionManager: subscriptionManager,
-                                                          stripePurchaseFlow: stripePurchaseFlow,
-                                                          uiHandler: uiHandler,
-                                                          subscriptionFeatureAvailability: subscriptionFeatureAvailability,
-                                                          freemiumDBPUserStateManager: mockfreemiumDBPUserStateManager,
-                                                          freemiumDBPPixelExperimentManager: mockFreemiumDBPExperimentManager,
-                                                          notificationCenter: mockNotificationCenter)
+        mockFreemiumDBPUserStateManager.didActivate = true
         feature.with(broker: broker)
+        let notificationPostedExpectation = expectation(forNotification: .subscriptionUpgradeFromFreemium, object: nil)
 
         // When
         let subscriptionSelectedParams = ["id": "some-subscription-id"]
         let result = try await feature.subscriptionSelected(params: subscriptionSelectedParams, original: Constants.mockScriptMessage)
 
+        await fulfillment(of: [notificationPostedExpectation], timeout: 1)
+
         // Then
         XCTAssertNil(result)
-        XCTAssertTrue(mockNotificationCenter.didCallPostNotification)
-        XCTAssertEqual(mockNotificationCenter.lastPostedNotification, .subscriptionUpgradeFromFreemium)
     }
 
     func testSubscriptionUpgradeNotificationNotSentWhenSubscriptionSelectedSuccessNotFromFreemium() async throws {
@@ -1090,18 +1085,41 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
                                                                                      entitlements: Constants.entitlements,
                                                                                      subscription: SubscriptionMockFactory.subscription))
 
-        let mockfreemiumDBPUserStateManager = MockFreemiumDBPUserStateManager()
-        mockfreemiumDBPUserStateManager.didActivate = false
+        mockFreemiumDBPUserStateManager.didActivate = false
+        feature.with(broker: broker)
+        let notificationPostedExpectation = expectation(forNotification: .subscriptionUpgradeFromFreemium, object: nil)
+        notificationPostedExpectation.isInverted = true
 
-        let mockNotificationCenter = MockNotificationCenter()
+        // When
+        let subscriptionSelectedParams = ["id": "some-subscription-id"]
+        let result = try await feature.subscriptionSelected(params: subscriptionSelectedParams, original: Constants.mockScriptMessage)
 
-        feature = SubscriptionPagesUseSubscriptionFeature(subscriptionManager: subscriptionManager,
-                                                          stripePurchaseFlow: stripePurchaseFlow,
-                                                          uiHandler: uiHandler,
-                                                          subscriptionFeatureAvailability: subscriptionFeatureAvailability,
-                                                          freemiumDBPUserStateManager: mockfreemiumDBPUserStateManager,
-                                                          freemiumDBPPixelExperimentManager: mockFreemiumDBPExperimentManager,
-                                                          notificationCenter: mockNotificationCenter)
+        await fulfillment(of: [notificationPostedExpectation], timeout: 1)
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    func testFreemiumPixelOriginSetWhenSubscriptionSelectedSuccessFromFreemium() async throws {
+        // Given
+        ensureUserUnauthenticatedState()
+        XCTAssertEqual(subscriptionEnvironment.purchasePlatform, .appStore)
+        XCTAssertFalse(accountManager.isUserAuthenticated)
+
+        storePurchaseManager.hasActiveSubscriptionResult = false
+        storePurchaseManager.mostRecentTransactionResult = nil
+
+        authService.createAccountResult = .success(CreateAccountResponse(authToken: Constants.authToken,
+                                                                         externalID: Constants.externalID,
+                                                                         status: "created"))
+        authService.getAccessTokenResult = .success(AccessTokenResponse(accessToken: Constants.accessToken))
+        authService.validateTokenResult = .success(Constants.validateTokenResponse)
+        storePurchaseManager.purchaseSubscriptionResult = .success(Constants.mostRecentTransactionJWS)
+        subscriptionService.confirmPurchaseResult = .success(ConfirmPurchaseResponse(email: Constants.email,
+                                                                                     entitlements: Constants.entitlements,
+                                                                                     subscription: SubscriptionMockFactory.subscription))
+
+        mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = true
         feature.with(broker: broker)
 
         // When
@@ -1110,8 +1128,38 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
         // Then
         XCTAssertNil(result)
-        XCTAssertFalse(mockNotificationCenter.didCallPostNotification)
-        XCTAssertNil(mockNotificationCenter.lastPostedNotification)
+        XCTAssertEqual(subscriptionAttributionPixelHandler.origin, "funnel_pro_mac_freemium")
+    }
+
+    func testFreemiumPixelOriginNotSetWhenSubscriptionSelectedSuccessNotFromFreemium() async throws {
+        // Given
+        ensureUserUnauthenticatedState()
+        XCTAssertEqual(subscriptionEnvironment.purchasePlatform, .appStore)
+        XCTAssertFalse(accountManager.isUserAuthenticated)
+
+        storePurchaseManager.hasActiveSubscriptionResult = false
+        storePurchaseManager.mostRecentTransactionResult = nil
+
+        authService.createAccountResult = .success(CreateAccountResponse(authToken: Constants.authToken,
+                                                                         externalID: Constants.externalID,
+                                                                         status: "created"))
+        authService.getAccessTokenResult = .success(AccessTokenResponse(accessToken: Constants.accessToken))
+        authService.validateTokenResult = .success(Constants.validateTokenResponse)
+        storePurchaseManager.purchaseSubscriptionResult = .success(Constants.mostRecentTransactionJWS)
+        subscriptionService.confirmPurchaseResult = .success(ConfirmPurchaseResponse(email: Constants.email,
+                                                                                     entitlements: Constants.entitlements,
+                                                                                     subscription: SubscriptionMockFactory.subscription))
+
+        mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = false
+        feature.with(broker: broker)
+
+        // When
+        let subscriptionSelectedParams = ["id": "some-subscription-id"]
+        let result = try await feature.subscriptionSelected(params: subscriptionSelectedParams, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        XCTAssertNotEqual(subscriptionAttributionPixelHandler.origin, "funnel_pro_mac_freemium")
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208081037247873/f

**Description**: When a user has performed a Freemium PIR scan, and then subscribed - either from the Freemium dashboard or from outside it, e.g from the Privacy Pro landing page - we will attribute the Subscription to Freemium. (i.e if the user has performed a Freemium PIR scan, and then Subscribes via any entry point, we are attributing the Subscription to Freemium)

Note: I have also improved some notification tests by using the notification expectation approach.

**Test Prerequisites**
1. Set yourself as an internal user via Debug menu → Set Internal User State
2. Disable/Signout of Privacy Pro via Settings menu → PP →  Remove from this device
4. Select Debug menu → Freemium -> Enroll into Experiment
5. Set the custom frontend UI URL via Debug menu → Personal Information Removal → Web UI → Set Custom URL. Enter `https://abrown.duckduckgo.com/dbp`
6. Use the custom frontend UI URL via Debug menu → Personal Information Removal → Web UI → Use Custom URL
7. Set the Subscription environment to staging and the platform to Stripe via the debug menu
8. Relaunch the browser

**Steps to test this PR**:
* Test 1 - Subscription after a Freemium Scan
1. Relaunch the browser
2. Enter Freemium PIR via the new tab banner or meatball menu
3. Follow the prompt to ’Start a Free Scan’
4. Enter a profile, start a scan
5. Wait for some results, then close the tab
6. Open the Privacy Pro landing page via the meatball menu
7. Buy a Subscription using the test credentials
8. Filter the Xcode console by `_subscribe`
9. Ensure you see the following pixel with a origin value of `funnel_pro_mac_freemium` - `[Standard-Fired] m_mac_direct_subscribe ["pixelSource": "browser-dmg", "locale": "en_US@rg=iezzzz", "appVersion": "1.109.0", "origin": "funnel_pro_mac_freemium”]`

* Test 2 - Subscription after a Freemium Scan
1. Remove PP from the app
2. Reset Freemium State by selecting Debug -> Freemium -> Reset all Freemium Feature State
3. Relaunch the browser
4. Open the Privacy Pro landing page via the meatball menu
7. Buy a Subscription using the test credentials
8. Filter the Xcode console by `_subscribe`
9. Ensure you see the following pixel WITHOUT an origin value of `funnel_pro_mac_freemium` - `[Standard-Fired] m_mac_direct_subscribe ["pixelSource": "browser-dmg", "locale": "en_US@rg=iezzzz", "appVersion": "1.109.0"]`

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
