### PR TITLE
VPN status menu popover not getting focus

### DIFF
--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/NetworkProtectionPopover.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/NetworkProtectionPopover.swift
@@ -97,6 +97,10 @@ public final class NetworkProtectionPopover: NSPopover {
     }
 
     override public func show(relativeTo positioningRect: NSRect, of positioningView: NSView, preferredEdge: NSRectEdge) {
+
+        // Starting on macOS sequoia this is necessary to make sure the popover has focus
+        NSRunningApplication.current.activate(options: .activateIgnoringOtherApps)
+
         statusReporter.forceRefresh()
         statusViewModel.refreshLoginItemStatus()
         super.show(relativeTo: positioningRect, of: positioningView, preferredEdge: preferredEdge)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208550201256511/f

## Description

We're fixing two issues here:
- The VPN menu popover is not getting focus under macOS Sequoia.  This can be seen when opening the popover when the connection is already established - the toggle is grey.
- Clicking outside of the popover wasn't dismissing it properly as it had no focus to begin with.

## Testing

1. Connect to the VPN
2. Once the connection is up, click on the VPN menu icon in macOS's status bar and see that the toggle is not grey.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
