### PR TITLE
Contextual onboarding privacy icon highlight

### DIFF
--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -574,9 +574,11 @@ extension MainViewController: BrowserTabViewControllerDelegate {
 
     func dismissViewHighlight() {
         tabBarViewController.stopFireButtonPulseAnimation()
+        navigationBarViewController.addressBarViewController?.addressBarButtonsViewController?.stopHighlightingPrivacyShield()
     }
 
     func highlightPrivacyShield() {
+        navigationBarViewController.addressBarViewController?.addressBarButtonsViewController?.highlightPrivacyShield()
     }
 
 }

--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -576,6 +576,9 @@ extension MainViewController: BrowserTabViewControllerDelegate {
         tabBarViewController.stopFireButtonPulseAnimation()
     }
 
+    func highlightPrivacyShield() {
+    }
+
 }
 
 #if DEBUG

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -153,6 +153,7 @@ final class AddressBarButtonsViewController: NSViewController {
     private var trackerAnimationTriggerCancellable: AnyCancellable?
     private var privacyEntryPointIconUpdateCancellable: AnyCancellable?
     private var isMouseOverAnimationVisibleCancellable: AnyCancellable?
+    private var privacyEntryPointIsMouseOverCancellable: AnyCancellable?
 
     private lazy var buttonsBadgeAnimator = {
         let animator = NavigationBarBadgeAnimator()
@@ -186,6 +187,7 @@ final class AddressBarButtonsViewController: NSViewController {
         subscribeToEffectiveAppearance()
         subscribeToIsMouseOverAnimationVisible()
         updateBookmarkButtonVisibility()
+        subscribeToPrivacyEntryPointIsMouseOver()
         bookmarkButton.sendAction(on: .leftMouseDown)
 
         privacyEntryPointButton.toolTip = UserText.privacyDashboardTooltip
@@ -968,6 +970,14 @@ final class AddressBarButtonsViewController: NSViewController {
                     self?.updatePrivacyEntryPointIcon()
                 }
             }
+    }
+
+    private func subscribeToPrivacyEntryPointIsMouseOver() {
+        privacyEntryPointIsMouseOverCancellable = privacyEntryPointButton.publisher(for: \.isMouseOver)
+            .first(where: { $0 }) // only interested when mouse is over
+            .sink(receiveValue: { [weak self] _ in
+                self?.stopHighlightingPrivacyShield()
+            })
     }
 
 }

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -227,7 +227,7 @@ final class AddressBarButtonsViewController: NSViewController {
             hasPrivacyInfoPulseQueuedAnimation = false
             // Give a bit of delay to have a better animation effect
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                ContextualOnboardingViewHighlighter.highlight(view: self.privacyEntryPointButton, inParent: self.view)
+                ViewHighlighter.highlight(view: self.privacyEntryPointButton, inParent: self.view)
             }
         }
     }
@@ -989,7 +989,7 @@ extension AddressBarButtonsViewController {
 
     func highlightPrivacyShield() {
         if !isAnyShieldAnimationPlaying && buttonsBadgeAnimator.queuedAnimation == nil {
-            ContextualOnboardingViewHighlighter.highlight(view: privacyEntryPointButton, inParent: self.view)
+            ViewHighlighter.highlight(view: privacyEntryPointButton, inParent: self.view)
         } else {
             hasPrivacyInfoPulseQueuedAnimation = true
         }
@@ -997,7 +997,7 @@ extension AddressBarButtonsViewController {
 
     func stopHighlightingPrivacyShield() {
         hasPrivacyInfoPulseQueuedAnimation = false
-        ContextualOnboardingViewHighlighter.stopHighlighting(view: privacyEntryPointButton)
+        ViewHighlighter.stopHighlighting(view: privacyEntryPointButton)
     }
 
 }

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -129,6 +129,7 @@ final class AddressBarButtonsViewController: NSViewController {
     var isTextFieldEditorFirstResponder = false {
         didSet {
             updateButtons()
+            stopHighlightingPrivacyShield()
         }
     }
     var textFieldValue: AddressBarTextField.Value? {

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -608,7 +608,6 @@ final class AddressBarButtonsViewController: NSViewController {
             subscribeToUrl()
             subscribeToPermissions()
             subscribeToPrivacyEntryPointIconUpdateTrigger()
-            subscribeToTrackerAnimationTrigger()
 
             updatePrivacyEntryPointIcon()
         }
@@ -627,6 +626,7 @@ final class AddressBarButtonsViewController: NSViewController {
                 stopAnimations()
                 updateBookmarkButtonImage()
                 updateButtons()
+                subscribeToTrackerAnimationTrigger()
             }
     }
 
@@ -643,6 +643,7 @@ final class AddressBarButtonsViewController: NSViewController {
 
     private func subscribeToTrackerAnimationTrigger() {
         trackerAnimationTriggerCancellable = tabViewModel?.trackersAnimationTriggerPublisher
+            .first()
             .sink { [weak self] _ in
                 self?.animateTrackers()
             }

--- a/DuckDuckGo/NavigationBar/View/Animations/BadgeAnimations/NavigationBarBadgeAnimator.swift
+++ b/DuckDuckGo/NavigationBar/View/Animations/BadgeAnimations/NavigationBarBadgeAnimator.swift
@@ -18,10 +18,15 @@
 
 import Cocoa
 
+protocol NavigationBarBadgeAnimatorDelegate: AnyObject {
+    func didFinishAnimating()
+}
+
 final class NavigationBarBadgeAnimator: NSObject {
     var queuedAnimation: QueueData?
     private var animationID: UUID?
     private(set) var isAnimating = false
+    weak var delegate: NavigationBarBadgeAnimatorDelegate?
 
     struct QueueData {
         var selectedTab: Tab?
@@ -55,6 +60,7 @@ final class NavigationBarBadgeAnimator: NSObject {
                                        buttonsContainer: buttonsContainer,
                                        notificationBadgeContainer: notificationBadgeContainer) {
                         self?.isAnimating = false
+                        self?.delegate?.didFinishAnimating()
                     }
                 }
             }

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -29,6 +29,7 @@ import Onboarding
 
 protocol BrowserTabViewControllerDelegate: AnyObject {
     func highlightFireButton()
+    func highlightPrivacyShield()
     func dismissViewHighlight()
 }
 
@@ -479,8 +480,11 @@ final class BrowserTabViewController: NSViewController {
           containerStackView.layoutSubtreeIfNeeded()
           webViewContainer?.layoutSubtreeIfNeeded()
 
-        if dialogType == .tryFireButton {
+        let currentState = onboardingDialogTypeProvider.state
+        if currentState == .showFireButton {
             delegate?.highlightFireButton()
+        } else if currentState == .showBlockedTrackers {
+            delegate?.highlightPrivacyShield()
         }
     }
 

--- a/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -389,7 +389,6 @@ final class BrowserTabViewController: NSViewController {
         let container = WebViewContainerView(tab: tab, webView: webView, frame: view.bounds)
         self.webViewContainer = container
         containerStackView.orientation = .vertical
-        containerStackView.distribution = .fill
         containerStackView.alignment = .leading
         containerStackView.distribution = .fillProportionally
 
@@ -477,8 +476,8 @@ final class BrowserTabViewController: NSViewController {
             hostingController.view.trailingAnchor.constraint(equalTo: containerStackView.trailingAnchor)
         ])
 
-          containerStackView.layoutSubtreeIfNeeded()
-          webViewContainer?.layoutSubtreeIfNeeded()
+        containerStackView.layoutSubtreeIfNeeded()
+        webViewContainer?.layoutSubtreeIfNeeded()
 
         let currentState = onboardingDialogTypeProvider.state
         if currentState == .showFireButton {

--- a/UnitTests/Onboarding/ContextualOnboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/UnitTests/Onboarding/ContextualOnboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -147,6 +147,7 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
     func testWhenNavigationCompletedAndStateIsShowFireButtonThenAskDelegateToHighlightFireButton() throws {
         // GIVEN
         dialogProvider.dialog = .tryFireButton
+        dialogProvider.state = .showFireButton
         let url = try XCTUnwrap(URL(string: "some.url"))
         let delegate = BrowserTabViewControllerDelegateSpy()
         viewController.delegate = delegate
@@ -158,6 +159,23 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
         // THEN
         wait(for: [expectation], timeout: 3.0)
         XCTAssertTrue(delegate.didCallHighlightFireButton)
+    }
+
+    func testWhenNavigationCompletedAndStateIsShowBlockedTrackersThenAskDelegateToHighlightPrivacyShield() throws {
+        // GIVEN
+        dialogProvider.dialog = .trackers(message: .init(string: ""), shouldFollowUp: true)
+        dialogProvider.state = .showBlockedTrackers
+        let url = try XCTUnwrap(URL(string: "some.url"))
+        let delegate = BrowserTabViewControllerDelegateMock()
+        viewController.delegate = delegate
+        XCTAssertFalse(delegate.didCallHighlightPrivacyShield)
+
+        // WHEN
+        tab.navigateTo(url: url)
+
+        // THEN
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertTrue(delegate.didCallHighlightPrivacyShield)
     }
 
     func testWhenNavigationCompletedViewHighlightsAreRemoved() throws {
@@ -285,14 +303,18 @@ class CapturingDialogFactory: ContextualDaxDialogsFactory {
 
 final class BrowserTabViewControllerDelegateSpy: BrowserTabViewControllerDelegate {
     private(set) var didCallHighlightFireButton = false
+    private(set) var didCallHighlightPrivacyShield = false
     private(set) var didCallDismissViewHighlight = false
 
     func highlightFireButton() {
         didCallHighlightFireButton = true
     }
 
+    func highlightPrivacyShield() {
+        didCallHighlightPrivacyShield = true
+    }
+
     func dismissViewHighlight() {
         didCallDismissViewHighlight = true
     }
-
 }

--- a/UnitTests/Onboarding/ContextualOnboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/UnitTests/Onboarding/ContextualOnboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -166,7 +166,7 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
         dialogProvider.dialog = .trackers(message: .init(string: ""), shouldFollowUp: true)
         dialogProvider.state = .showBlockedTrackers
         let url = try XCTUnwrap(URL(string: "some.url"))
-        let delegate = BrowserTabViewControllerDelegateMock()
+        let delegate = BrowserTabViewControllerDelegateSpy()
         viewController.delegate = delegate
         XCTAssertFalse(delegate.didCallHighlightPrivacyShield)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207994848838038

**Description**:

**Steps to test this PR**:

**Prerequisites:**
go to debug menu -> set internal user
go to debug menu → reset data → reset contextual onboarding

**Scenario 1: When blocked trackers dialog is shown then privacy shield should be highlighted**
1. Navigate to [DuckDuckGo.com](https://duckduckgo.com/)
2. Follow the linear onboarding.
3. Navigate to a site with known trackers e.g. bbc.com.
4. Once the blocked trackers dialog is shown and that privacy shield animation is triggered.

**Scenario 2: When Privacy Shield pulse animating then hovering on it should remove pulse animation**
1. Navigate to a site with known trackers e.g. bbc.com.
2. Hover on the privacy shield.
3. Ensure that the pulse animation is removed.

**Scenario 3: When Privacy Shield pulse animating then tapping on address bar should remove pulse animation**
1. Navigate to a site with known trackers e.g. bbc.com.
2. Tap on the address bar to navigate to another address..
3. Ensure that the pulse animation is removed.

**Scenario 4: When Privacy Shield pulse animating then opening a new tab should remove pulse animation**
1. Navigate to a site with known trackers e.g. bbc.com.
2. Open a new tab.
3. Ensure that the pulse animation is removed.

**Scenario 5: When Privacy Shield pulse animating then navigating to manage bookmarks should remove pulse animation**
1. Navigate to a site with known trackers e.g. bbc.com.
2. On main menu navigate to “Bookmarks” -> "Manage Bookmarks".
3. Ensure that the pulse animation is removed.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
