### PR TITLE
Fix RemoteMessagingClient flaky unit tests

### DIFF
--- a/DuckDuckGo/RemoteMessaging/RemoteMessagingClient.swift
+++ b/DuckDuckGo/RemoteMessaging/RemoteMessagingClient.swift
@@ -85,15 +85,14 @@ final class RemoteMessagingClient: RemoteMessagingProcessing {
         )
     }
 
-    init(
+    convenience init(
         database: CoreDataDatabase,
         configMatcherProvider: RemoteMessagingConfigMatcherProviding,
         configurationStore: ConfigurationStoring,
         remoteMessagingAvailabilityProvider: RemoteMessagingAvailabilityProviding,
         remoteMessagingStoreProvider: RemoteMessagingStoreProviding = DefaultRemoteMessagingStoreProvider()
     ) {
-        self.database = database
-        self.configFetcher = RemoteMessagingConfigFetcher(
+        let configFetcher = RemoteMessagingConfigFetcher(
             configurationFetcher: ConfigurationFetcher(
                 store: configurationStore,
                 urlSession: .session(),
@@ -101,6 +100,28 @@ final class RemoteMessagingClient: RemoteMessagingProcessing {
             ),
             configurationStore: configurationStore
         )
+
+        self.init(
+            database: database,
+            configFetcher: configFetcher,
+            configMatcherProvider: configMatcherProvider,
+            remoteMessagingAvailabilityProvider: remoteMessagingAvailabilityProvider,
+            remoteMessagingStoreProvider: remoteMessagingStoreProvider
+        )
+    }
+
+    /**
+     * This designated initializer is used in unit tests where `configFetcher` needs mocking.
+     */
+    init(
+        database: CoreDataDatabase,
+        configFetcher: RemoteMessagingConfigFetching,
+        configMatcherProvider: RemoteMessagingConfigMatcherProviding,
+        remoteMessagingAvailabilityProvider: RemoteMessagingAvailabilityProviding,
+        remoteMessagingStoreProvider: RemoteMessagingStoreProviding = DefaultRemoteMessagingStoreProvider()
+    ) {
+        self.database = database
+        self.configFetcher = configFetcher
         self.configMatcherProvider = configMatcherProvider
         self.remoteMessagingAvailabilityProvider = remoteMessagingAvailabilityProvider
         self.remoteMessagingStoreProvider = remoteMessagingStoreProvider

--- a/UnitTests/Onboarding/ContextualOnboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/UnitTests/Onboarding/ContextualOnboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import SwiftUI
+import struct SwiftUI.AnyView
 import Onboarding
 import Combine
 import BrowserServicesKit

--- a/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
+++ b/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
@@ -29,6 +29,15 @@ struct MockRemoteMessagingStoreProvider: RemoteMessagingStoreProviding {
     }
 }
 
+final class MockRemoteMessagingConfigFetcher: RemoteMessagingConfigFetching {
+    func fetchRemoteMessagingConfig() async throws -> RemoteMessageResponse.JsonRemoteMessagingConfig {
+        let json = #"{ "version": 1, "messages": [], "rules": [] }"#
+        let jsonData = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        return try decoder.decode(RemoteMessageResponse.JsonRemoteMessagingConfig.self, from: jsonData)
+    }
+}
+
 final class RemoteMessagingClientTests: XCTestCase {
 
     var client: RemoteMessagingClient!
@@ -92,6 +101,7 @@ final class RemoteMessagingClientTests: XCTestCase {
     private func makeClient() {
         client = RemoteMessagingClient(
             database: remoteMessagingDatabase,
+            configFetcher: MockRemoteMessagingConfigFetcher(),
             configMatcherProvider: RemoteMessagingConfigMatcherProvider(
                 bookmarksDatabase: bookmarksDatabase,
                 appearancePreferences: AppearancePreferences(persistor: AppearancePreferencesPersistorMock()),
@@ -100,7 +110,6 @@ final class RemoteMessagingClientTests: XCTestCase {
                 statisticsStore: MockStatisticsStore(),
                 variantManager: MockVariantManager()
             ),
-            configurationStore: MockConfigurationStore(),
             remoteMessagingAvailabilityProvider: availabilityProvider
         )
     }

--- a/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
+++ b/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
@@ -25,7 +25,7 @@ import XCTest
 
 struct MockRemoteMessagingStoreProvider: RemoteMessagingStoreProviding {
     func makeRemoteMessagingStore(database: CoreDataDatabase, availabilityProvider: RemoteMessagingAvailabilityProviding) -> RemoteMessagingStoring {
-        RemoteMessagingStore(database: database, errorEvents: nil, remoteMessagingAvailabilityProvider: availabilityProvider)
+        MockRemoteMessagingStore()
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201621708115095/1208377696019992/f

**Description**:
Mock RemoteMessagingConfigFetcher so that it doesn't fire a network request during unit tests.
Mock RemoteMessagingStore so that it doesn't try to access database - the store is tested
in BSK anyway and the tests here are merely about the feature flag.

**Steps to test this PR**:
Verify that CI is green.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
