### PR TITLE
Fixes a retain cycle in the VPN status view

### DIFF
--- a/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/TunnelControllerView/TunnelControllerViewModel.swift
+++ b/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/TunnelControllerView/TunnelControllerViewModel.swift
@@ -195,11 +195,15 @@ public final class TunnelControllerViewModel: ObservableObject {
         }
 
         refreshTimeLapsed()
-        let call = refreshTimeLapsed
 
-        let newTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+        let newTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+
+            guard let self else {
+                return
+            }
+
             Task { @MainActor in
-                call()
+                self.refreshTimeLapsed()
             }
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206580121312550/1208597821920525/f

## Description

Fixes a retain cycle.

<img width="708" alt="Screenshot 2024-10-22 at 9 46 20 AM" src="https://github.com/user-attachments/assets/b0596307-938d-4402-aef1-dda42a20a04f">

## Testing:

Note: the testing steps can be used in `main` to see the retain cycle in action.

1. Connect the VPN
2. Open and close the in-browser status view several times
3. Go to the memory graph in Xcode and see the instances of `TunnelControllerViewModel`.  You'll notice there's one instance per click.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
