### PR TITLE
remove fire info sheet during onboarding

### DIFF
--- a/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualOnboardingStateMachine.swift
+++ b/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualOnboardingStateMachine.swift
@@ -141,14 +141,19 @@ final class ContextualOnboardingStateMachine: ContextualOnboardingDialogTypeProv
     private var stateString: String {
         didSet {
             if stateString == ContextualOnboardingState.notStarted.rawValue {
+                // This makes the home page DuckDuckGo during the onboarding
                 startUpPreferences.launchToCustomHomePage = true
+                // This avoids the info sheet on the Fire button popover to be shown during the onboarding
                 fireButtonInfoStateProvider.infoPresentedOnce = true
                 resetData()
             }
             if stateString == ContextualOnboardingState.onboardingCompleted.rawValue {
+                // If the user has not used the fire button 
+                // it will present the info sheet on the Fire button popover when they click on it for the first time
                 if !fireButtonUsedOnce {
                     fireButtonInfoStateProvider.infoPresentedOnce = false
                 }
+                // This resets the home page to be the new tab page after the onboarding
                 startUpPreferences.launchToCustomHomePage = false
                 resetData()
             }

--- a/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualOnboardingStateMachine.swift
+++ b/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualOnboardingStateMachine.swift
@@ -30,6 +30,15 @@ protocol ContextualOnboardingStateUpdater {
     func fireButtonUsed()
 }
 
+protocol FireButtonInfoStateProviding {
+    var infoPresentedOnce: Bool { get set }
+}
+
+final class FireButtonInfoStateProvider: FireButtonInfoStateProviding {
+    @UserDefaultsWrapper(key: .fireInfoPresentedOnce, defaultValue: false)
+     var infoPresentedOnce: Bool
+}
+
 enum ContextualDialogType: Equatable {
     case tryASearch
     case searchDone(shouldFollowUp: Bool)
@@ -125,15 +134,21 @@ final class ContextualOnboardingStateMachine: ContextualOnboardingDialogTypeProv
 
     private let trackerMessageProvider: TrackerMessageProviding
     private let startUpPreferences: StartupPreferences
+    private var fireButtonInfoStateProvider: FireButtonInfoStateProviding
+    private var fireButtonUsedOnce: Bool = false
 
     @UserDefaultsWrapper(key: .contextualOnboardingState, defaultValue: ContextualOnboardingState.onboardingCompleted.rawValue)
     private var stateString: String {
         didSet {
             if stateString == ContextualOnboardingState.notStarted.rawValue {
                 startUpPreferences.launchToCustomHomePage = true
+                fireButtonInfoStateProvider.infoPresentedOnce = true
                 resetData()
             }
             if stateString == ContextualOnboardingState.onboardingCompleted.rawValue {
+                if !fireButtonUsedOnce {
+                    fireButtonInfoStateProvider.infoPresentedOnce = false
+                }
                 startUpPreferences.launchToCustomHomePage = false
                 resetData()
             }
@@ -154,9 +169,11 @@ final class ContextualOnboardingStateMachine: ContextualOnboardingDialogTypeProv
     private var notBlockedTrackerSeen: Bool = false
 
     init(trackerMessageProvider: TrackerMessageProviding = TrackerMessageProvider(),
-         startupPreferences: StartupPreferences = StartupPreferences.shared) {
+         startupPreferences: StartupPreferences = StartupPreferences.shared,
+         fireButtonInfoStateProvider: FireButtonInfoStateProviding = FireButtonInfoStateProvider()) {
         self.trackerMessageProvider = trackerMessageProvider
         self.startUpPreferences = startupPreferences
+        self.fireButtonInfoStateProvider = fireButtonInfoStateProvider
     }
 
     func dialogTypeForTab(_ tab: Tab, privacyInfo: PrivacyInfo? = nil) -> ContextualDialogType? {
@@ -345,6 +362,7 @@ final class ContextualOnboardingStateMachine: ContextualOnboardingDialogTypeProv
     }
 
     func fireButtonUsed() {
+        fireButtonUsedOnce = true
         switch state {
         case .showTryASearch:
             state = .fireUsedTryASearchShown

--- a/UnitTests/Onboarding/ContextualOnboarding/ContextualOnboardingStateMachineTests.swift
+++ b/UnitTests/Onboarding/ContextualOnboarding/ContextualOnboardingStateMachineTests.swift
@@ -25,6 +25,8 @@ class ContextualOnboardingStateMachineTests: XCTestCase {
 
     var stateMachine: ContextualOnboardingStateMachine!
     var mockTrackerMessageProvider: MockTrackerMessageProvider!
+    var preferences: StartupPreferences!
+    var fireButtonInfoStateProvider: MockFireButtonInfoStateProvider!
     var tab: Tab!
     let expectation = XCTestExpectation()
 
@@ -32,7 +34,9 @@ class ContextualOnboardingStateMachineTests: XCTestCase {
         super.setUp()
         UserDefaultsWrapper<Any>.clearAll()
         mockTrackerMessageProvider = MockTrackerMessageProvider(expectation: expectation)
-        stateMachine = ContextualOnboardingStateMachine(trackerMessageProvider: mockTrackerMessageProvider)
+        fireButtonInfoStateProvider = MockFireButtonInfoStateProvider()
+        preferences = StartupPreferences(persistor: MockStartUpPreferencesPersistor())
+        stateMachine = ContextualOnboardingStateMachine(trackerMessageProvider: mockTrackerMessageProvider, startupPreferences: preferences, fireButtonInfoStateProvider: fireButtonInfoStateProvider)
         tab = Tab(url: URL.duckDuckGo)
     }
 
@@ -45,6 +49,42 @@ class ContextualOnboardingStateMachineTests: XCTestCase {
 
     func testDefaultStateIsOnboardingCompleted() {
         XCTAssertEqual(stateMachine.state, .onboardingCompleted)
+    }
+
+    func testWhenOnboardingCompletedThenLaunchToCustomHomePageIsFalse() {
+        preferences.launchToCustomHomePage = true
+        stateMachine.state = .onboardingCompleted
+
+        XCTAssertFalse(preferences.launchToCustomHomePage)
+    }
+
+    func testWhenOnboardingIsAboutToStartThenFireButtonInfoStateIsTrue() {
+        fireButtonInfoStateProvider.infoPresentedOnce = false
+        stateMachine.state = .notStarted
+
+        XCTAssertTrue(fireButtonInfoStateProvider.infoPresentedOnce)
+    }
+
+    func testWhenOnboardingFinishedAndFireButtonNotUsedThenFireButtonInfoStateIsFalse() {
+        fireButtonInfoStateProvider.infoPresentedOnce = true
+        stateMachine.state = .onboardingCompleted
+
+        XCTAssertFalse(fireButtonInfoStateProvider.infoPresentedOnce)
+    }
+
+    func testWhenOnboardingFinishedAndFireButtonUsedThenFireButtonInfoStateIsFalse() {
+        fireButtonInfoStateProvider.infoPresentedOnce = false
+        stateMachine.fireButtonUsed()
+        stateMachine.state = .onboardingCompleted
+
+        XCTAssertTrue(fireButtonInfoStateProvider.infoPresentedOnce)
+    }
+
+    func testWhenOnboardingIsAboutToStartLaunchToCustomHomePageIsTrue() {
+        preferences.launchToCustomHomePage = false
+        stateMachine.state = .onboardingCompleted
+
+        XCTAssertTrue(preferences.launchToCustomHomePage)
     }
 
     func test_OnSearch_WhenStateIsShowSearchDoneOrFireUsedShowSearchDone_returnsSearchDoneShouldFollowUp() {
@@ -657,4 +697,16 @@ class MockTrackerMessageProvider: TrackerMessageProviding {
         // Simulate fetching the tracker type
         return trackerType
     }
+}
+
+class MockStartUpPreferencesPersistor: StartupPreferencesPersistor {
+    var restorePreviousSession: Bool = false
+
+    var launchToCustomHomePage: Bool = false
+
+    var customHomePageURL: String = ""
+}
+
+class MockFireButtonInfoStateProvider: FireButtonInfoStateProviding {
+    var infoPresentedOnce: Bool = false
 }

--- a/UnitTests/Onboarding/ContextualOnboarding/ContextualOnboardingStateMachineTests.swift
+++ b/UnitTests/Onboarding/ContextualOnboarding/ContextualOnboardingStateMachineTests.swift
@@ -77,12 +77,12 @@ class ContextualOnboardingStateMachineTests: XCTestCase {
         stateMachine.fireButtonUsed()
         stateMachine.state = .onboardingCompleted
 
-        XCTAssertTrue(fireButtonInfoStateProvider.infoPresentedOnce)
+        XCTAssertFalse(fireButtonInfoStateProvider.infoPresentedOnce)
     }
 
     func testWhenOnboardingIsAboutToStartLaunchToCustomHomePageIsTrue() {
         preferences.launchToCustomHomePage = false
-        stateMachine.state = .onboardingCompleted
+        stateMachine.state = .notStarted
 
         XCTAssertTrue(preferences.launchToCustomHomePage)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208592739186210/f

**Description**: Removes the Fire popover info sheet during the onboarding

**Steps to test this PR**:
1. Run ./clean-app.sh debug
2. go to debug menu -> set internal user
3. go to debug menu → reset data → reset contextual onboarding
4. Navigate to [DuckDuckGo.com](https://duckduckgo.com/)
5. Go through the onboarding and test that when the fire-button popover appears it does not show the explanation sheet
6. Do not use the fire button
7. Complete the onboarding
8. Click on the fire button and check the explanation sheet does appear
9. Run steps 1 to 5 again
10. use the fire button
11. Complete the onboarding
12. Click on the fire button and check the explanation sheet does not appear

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
