### PR TITLE
Updates to NTP Search Box

### DIFF
--- a/DuckDuckGo/HomePage/Model/HomePageAddressBarModel.swift
+++ b/DuckDuckGo/HomePage/Model/HomePageAddressBarModel.swift
@@ -44,7 +44,20 @@ extension HomePage.Models {
                 }
             }
         }
-        @Published var value: AddressBarTextField.Value = .text("", userTyped: false)
+        @Published var value: AddressBarTextField.Value = .text("", userTyped: false) {
+            didSet {
+                if shouldDisplayInitialPlaceholder && !value.string.isEmpty {
+                    shouldDisplayInitialPlaceholder = false
+                }
+            }
+        }
+
+        /**
+         * This property is a workaround for placeholder not being displayed on the address bar in SwiftUI until focused.
+         *
+         * It's cleared after first edit on the field.
+         */
+        @Published var shouldDisplayInitialPlaceholder = true
 
         var addressBarTextField: AddressBarTextField? {
             guard shouldShowAddressBar else {

--- a/DuckDuckGo/HomePage/View/AddressBarTextFieldView.swift
+++ b/DuckDuckGo/HomePage/View/AddressBarTextFieldView.swift
@@ -72,6 +72,9 @@ struct BigSearchBox: View {
     let isCompact: Bool
     let supportsFixedColorScheme: Bool
 
+    @EnvironmentObject var addressBarModel: HomePage.Models.AddressBarModel
+    @Environment(\.colorScheme) private var colorScheme
+
     init(isCompact: Bool, supportsFixedColorScheme: Bool = true) {
         self.isCompact = isCompact
         self.supportsFixedColorScheme = supportsFixedColorScheme
@@ -106,9 +109,22 @@ struct BigSearchBox: View {
 
     @ViewBuilder
     func searchField() -> some View {
-        AddressBarTextFieldView(supportsFixedColorScheme: supportsFixedColorScheme)
-            .frame(height: Const.searchBoxHeight)
-            .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 3)
-            .shadow(color: .black.opacity(0.15), radius: 0, x: 0, y: 0)
+        ZStack {
+            AddressBarTextFieldView(supportsFixedColorScheme: supportsFixedColorScheme)
+                .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 3)
+                .shadow(color: .black.opacity(0.15), radius: 0, x: 0, y: 0)
+            if #available(macOS 12.0, *), addressBarModel.shouldDisplayInitialPlaceholder {
+                HStack {
+                    Text(UserText.addressBarPlaceholder)
+                        .foregroundColor(Color(nsColor: NSColor.placeholderTextColor))
+                        .background(Color.homePageAddressBarBackground)
+                        .font(.system(size: 15))
+                        .padding(.leading, 38)
+                        .animation(.none, value: colorScheme) // don't animate color scheme change because NSTextField doesn't
+                    Spacer()
+                }
+            }
+        }
+        .frame(height: Const.searchBoxHeight)
     }
 }

--- a/DuckDuckGo/HomePage/View/HomePageViewController.swift
+++ b/DuckDuckGo/HomePage/View/HomePageViewController.swift
@@ -276,7 +276,7 @@ final class HomePageViewController: NSViewController {
     }
 
     private func showSettingsOnboardingIfNeeded() {
-        if !settingsVisibilityModel.didShowSettingsOnboarding {
+        if addressBarModel.shouldShowAddressBar && !settingsVisibilityModel.didShowSettingsOnboarding {
             // async dispatch in order to get the final value for self.view.bounds
             DispatchQueue.main.async {
                 guard let superview = self.view.superview else {

--- a/DuckDuckGo/HomePage/View/HomePageViewController.swift
+++ b/DuckDuckGo/HomePage/View/HomePageViewController.swift
@@ -126,7 +126,6 @@ final class HomePageViewController: NSViewController {
     override func viewDidAppear() {
         super.viewDidAppear()
         refreshModels()
-        addressBarModel.addressBarTextField?.makeMeFirstResponder()
 
         showSettingsOnboardingIfNeeded()
     }

--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -476,14 +476,7 @@ final class MainViewController: NSViewController {
         let tabContent = tabContent ?? selectedTabViewModel.tab.content
 
         if case .newtab = tabContent {
-            let homeAddressBarTextField = browserTabViewController.homePageViewController?.addressBarModel?.addressBarTextField
-            let isHomeAddressBarVisible = browserTabViewController.homePageViewController?.appearancePreferences.isSearchBarVisible == true
-            if isHomeAddressBarVisible, let homeAddressBarTextField {
-                homeAddressBarTextField.makeMeFirstResponder()
-            } else {
-                navigationBarViewController.addressBarViewController?.addressBarTextField.makeMeFirstResponder()
-            }
-
+            navigationBarViewController.addressBarViewController?.addressBarTextField.makeMeFirstResponder()
         } else {
             // ignore published tab switch: BrowserTabViewController
             // adjusts first responder itself


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208612667210680/f

**Description**:
This change changes focus on New Tab Page to always be on the top address bar,
and also disables NTP settings onboarding popover for users not in the experiment.

**Steps to test this PR**:
1. Run the app.
2. Select _Main Menu -> Debug -> Reset Data -> Reset Home Page Settings Onboarding_, open new tab and verify that you don't see a popover. Quit the app.
3. Update `DefaultNewTabPageSearchBoxExperimentCohortDecider.cohort` to just `return .experiment`
4. Update line 100 in `HomeAddressBarModel.swift` to say `isExperimentActive = true` and comment out lines 103-105.
5. Run the app
6. Verify that you've seen the popover.
7. Open a few new tab pages, verify that focus stays on the top address bar at all times
8. Select Main Menu -> Debug -> Tab -> Append Tabs -> 10 tabs
9. Type amazon.com in the search field, select the website suggestion.
10. Open a new tab and verify that suggestions window doesn't get presented immediately without typing text in the text field.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
