### PR TITLE
Workaround for stuck scans on Xcode 16

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/CCF/WebViewHandler.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/CCF/WebViewHandler.swift
@@ -46,6 +46,8 @@ final class DataBrokerProtectionWebViewHandler: NSObject, WebViewHandler {
     private var webView: WebView?
     private var window: NSWindow?
 
+    private var timer: Timer?
+
     init(privacyConfig: PrivacyConfigurationManaging, prefs: ContentScopeProperties, delegate: CCFCommunicationDelegate, isFakeBroker: Bool = false) {
         let configuration = WKWebViewConfiguration()
         configuration.applyDataBrokerConfiguration(privacyConfig: privacyConfig, prefs: prefs, delegate: delegate)
@@ -78,6 +80,8 @@ final class DataBrokerProtectionWebViewHandler: NSObject, WebViewHandler {
             window?.makeKeyAndOrderFront(nil)
         }
 
+        installTimer()
+
         try? await load(url: URL(string: "\(WebViewSchemeHandler.dataBrokerProtectionScheme)://blank")!)
     }
 
@@ -100,6 +104,8 @@ final class DataBrokerProtectionWebViewHandler: NSObject, WebViewHandler {
         WKWebsiteDataStore.default().removeData(ofTypes: [WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache], modifiedSince: Date(timeIntervalSince1970: 0)) {
             Logger.action.debug("WKWebView data store deleted correctly")
         }
+
+        stopTimer()
 
         webViewConfiguration = nil
         userContentController = nil
@@ -193,6 +199,24 @@ final class DataBrokerProtectionWebViewHandler: NSObject, WebViewHandler {
             print("Error png data was not respresented")
         }
     }
+
+    /// Workaround for stuck scans
+    /// https://app.asana.com/0/0/1208502720748038/1208596554608118/f
+
+    private func installTimer() {
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { _ in
+            Task {
+                try await self.webView?.evaluateJavaScript("1+1") as Void?
+            }
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
 }
 
 extension DataBrokerProtectionWebViewHandler: WKNavigationDelegate {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205591970852438/1208502720748038/f
Tech Design URL: 
CC:

**Description**:

Implements a workaround for scans being stuck when built against Xcode 16

**Steps to test this PR**:
1. Start PIR and use a sample profile
2. Scan should finish

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
