### PR TITLE
Fix testWhenChangingSortingInThePanelIsReflectedInTheManager UI Test

### DIFF
--- a/UITests/BookmarkSortTests.swift
+++ b/UITests/BookmarkSortTests.swift
@@ -61,6 +61,7 @@ class BookmarkSortTests: XCTestCase {
         app.dismissPopover(buttonIdentifier: "Hide")
         app.openBookmarksPanel()
         selectSortByName(mode: .panel)
+        app.openBookmarksPanel() // Here we do not open the panel, we close it by tapping the shortcut button again.
         app.openBookmarksManager()
 
         app.buttons[AccessibilityIdentifiers.sortBookmarksButtonManager].tap()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208616327102876/f
Tech Design URL:
CC:

**Description**:
Fixes ` testWhenChangingSortingInThePanelIsReflectedInTheManager` UI test. The problem is that depending on the window size, the bookmarks panel might be above the sort button in the manager, causing it not to be tappable.

This started happening in the latest internal because we added a new option (delete bookmark) on the bookmarks manager, which pushed the sort button to the right.

**Steps to test this PR**:
We should run the workflow and see if it works.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
