### PR TITLE
Check the config test pixel from the subscription monitor

### DIFF
--- a/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -388,9 +388,7 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
 
             configurationSubscription = privacyConfigurationManager.updatesPublisher
                 .sink { [weak self] in
-                    if self?.privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(BackgroundAgentPixelTestSubfeature.pixelTest) ?? false {
-                        PixelKit.fire(NetworkProtectionPixelEvent.networkProtectionConfigurationPixelTest, frequency: .daily)
-                    }
+                    self?.firePrivacyConfigTestPixelIfNecessary()
                 }
 
             if launchedOnStartup {
@@ -428,6 +426,9 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
 
     private func setUpSubscriptionMonitoring() {
         guard accountManager.isUserAuthenticated else { return }
+
+        self.firePrivacyConfigTestPixelIfNecessary()
+
         let entitlementsCheck = {
             await self.accountManager.hasEntitlement(forProductName: .networkProtection, cachePolicy: .reloadIgnoringLocalCacheData)
         }
@@ -454,6 +455,13 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
             }
         }
     }
+
+    private func firePrivacyConfigTestPixelIfNecessary() {
+        if privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(BackgroundAgentPixelTestSubfeature.pixelTest) {
+            PixelKit.fire(NetworkProtectionPixelEvent.networkProtectionConfigurationPixelTest, frequency: .daily)
+        }
+    }
+
 }
 
 extension DuckDuckGoVPNAppDelegate: AccountManagerKeychainAccessDelegate {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1208624508308744/f
Tech Design URL:
CC:

**Description**:

This PR fixes the VPN config test pixel. The issue was that it wasn't being fired from the right location, so it is now additionally checked at the same time as the subscription entitlements.

**Steps to test this PR**:
1. Run `defaults write com.duckduckgo.macos.vpn.debug config.backgroundAgentPixelTest.pixelTest.enabled 1` to bypass the rollout calculation (it's currently set to 10%)
2. Run the VPN agent via Xcode
3. Filter the logs for `m_mac_netp_ev_configuration_pixel_test_d` to ensure that the pixel is fired

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
