### PR TITLE
Update OnboardingUserScript to use a weak script broker reference

### DIFF
--- a/DuckDuckGo/Onboarding/OnboardingUserScript.swift
+++ b/DuckDuckGo/Onboarding/OnboardingUserScript.swift
@@ -25,7 +25,7 @@ final class OnboardingUserScript: NSObject, Subfeature {
     let onboardingActionsManager: OnboardingActionsManaging
     var messageOriginPolicy: MessageOriginPolicy = .only(rules: [.exact(hostname: "onboarding")])
     let featureName: String = "onboarding"
-    var broker: UserScriptMessageBroker?
+    weak var broker: UserScriptMessageBroker?
 
     // MARK: - MessageNames
     enum MessageNames: String, CaseIterable {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1193060753475688/1208624804500029/f
Tech Design URL:
CC:

**Description**:

This PR fixes a memory leak in the `OnboardingUserScript`, where it was holding onto a strong reference to the user scripts broker.

**Steps to test this PR**:
1. Smoke test onboarding
2. Open and close a bunch of tab instances, then open the Memory Graph Debugger view in Xcode and check that there aren't many instances of the relevant classes hanging around

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
