### PR TITLE
fix Suggestions not reacting to clicks after being interacted with using keyboard

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -656,14 +656,10 @@ final class AddressBarTextField: NSTextField {
     }
 
     func hideSuggestionWindow() {
-        guard let window = window, let suggestionWindow = suggestionWindowController?.window else {
-            return
-        }
+        guard let suggestionWindow = suggestionWindowController?.window, suggestionWindow.isVisible,
+              let parent = suggestionWindow.parent else { return }
 
-        if !suggestionWindow.isVisible { return }
-
-        window.removeChildWindow(suggestionWindow)
-        suggestionWindow.parent?.removeChildWindow(suggestionWindow)
+        parent.removeChildWindow(suggestionWindow)
         suggestionWindow.orderOut(nil)
     }
 

--- a/DuckDuckGo/Suggestions/View/SuggestionViewController.swift
+++ b/DuckDuckGo/Suggestions/View/SuggestionViewController.swift
@@ -85,9 +85,7 @@ final class SuggestionViewController: NSViewController {
         tableView.rowHeight = suggestionContainerViewModel.isHomePage ? 34 : 28
     }
 
-    override func viewWillDisappear() {
-        super.viewWillDisappear()
-
+    override func viewDidDisappear() {
         eventMonitorCancellables.removeAll()
         clearSelection()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202406491309510/1208622581232760/f

**Description**:
- Fix suggestion window `orderOut` called twice causing suggestions breakage

**Steps to test this PR**:
1. Run the app from main branch
2. Type a phrase in the address bar
3. Select a suggestion using keyboard
4. Type another phrase in the address bar
5. Click on a suggestion

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
