### PR TITLE
Use cookie to share subscription access token on DDG domains

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -203,6 +203,8 @@
 		1DFAB5232A8983E100A0F7F6 /* SetExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFAB51F2A89830D00A0F7F6 /* SetExtensionTests.swift */; };
 		1E0C72062ABC63BD00802009 /* SubscriptionPagesUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0C72052ABC63BD00802009 /* SubscriptionPagesUserScript.swift */; };
 		1E0C72072ABC63BD00802009 /* SubscriptionPagesUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0C72052ABC63BD00802009 /* SubscriptionPagesUserScript.swift */; };
+		1E25A4FE2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E25A4FD2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift */; };
+		1E25A4FF2CC9408A0080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E25A4FD2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift */; };
 		1E2BEAE42C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2BEAE32C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift */; };
 		1E2BEAE52C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2BEAE32C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift */; };
 		1E559BB12BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E559BB02BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift */; };
@@ -3287,6 +3289,7 @@
 		1DFAB51C2A8982A600A0F7F6 /* SetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetExtension.swift; sourceTree = "<group>"; };
 		1DFAB51F2A89830D00A0F7F6 /* SetExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetExtensionTests.swift; sourceTree = "<group>"; };
 		1E0C72052ABC63BD00802009 /* SubscriptionPagesUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPagesUserScript.swift; sourceTree = "<group>"; };
+		1E25A4FD2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionCookieManageEventPixelMapping.swift; sourceTree = "<group>"; };
 		1E2BEAE32C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPagesUseSubscriptionFeatureTests.swift; sourceTree = "<group>"; };
 		1E559BB02BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectNavigationResponder.swift; sourceTree = "<group>"; };
 		1E7E2E8F29029A2A00C01B54 /* ContentBlockingRulesUpdateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockingRulesUpdateObserver.swift; sourceTree = "<group>"; };
@@ -9206,6 +9209,7 @@
 				F1D042982BFBABA100A31506 /* SubscriptionManager+StandardConfiguration.swift */,
 				F1DA51852BF607D200CF29FA /* SubscriptionRedirectManager.swift */,
 				F1FDC9372BF51F41006B1435 /* VPNSettings+Environment.swift */,
+				1E25A4FD2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift */,
 			);
 			path = Subscription;
 			sourceTree = "<group>";
@@ -10854,6 +10858,7 @@
 				3706FB65293F65D500E42796 /* PrivacyDashboardWebView.swift in Sources */,
 				372BC2A22A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift in Sources */,
 				3706FB66293F65D500E42796 /* AppearancePreferences.swift in Sources */,
+				1E25A4FF2CC9408A0080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift in Sources */,
 				844D7DA52C9443EA00BE61D4 /* NSPrintInfoExtension.swift in Sources */,
 				3706FB67293F65D500E42796 /* DownloadListCoordinator.swift in Sources */,
 				C172E7382C93968E00521D9A /* SyncPromoPixelKitEvent.swift in Sources */,
@@ -12318,6 +12323,7 @@
 				B69B503A2726A12500758A2B /* StatisticsLoader.swift in Sources */,
 				37CD54C927F2FDD100F1F7B9 /* DataClearingPreferences.swift in Sources */,
 				B6F1C80B2761C45400334924 /* LocalUnprotectedDomains.swift in Sources */,
+				1E25A4FE2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift in Sources */,
 				B69A14FA2B4D705D00B9417D /* BookmarkFolderPicker.swift in Sources */,
 				1D36E658298AA3BA00AA485D /* InternalUserDeciderStore.swift in Sources */,
 				B634DBE5293C944700C3C99E /* NewWindowPolicy.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -3295,7 +3295,6 @@
 		1E7E2E8F29029A2A00C01B54 /* ContentBlockingRulesUpdateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockingRulesUpdateObserver.swift; sourceTree = "<group>"; };
 		1E7E2E932902AC0E00C01B54 /* PrivacyDashboardPermissionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDashboardPermissionHandler.swift; sourceTree = "<group>"; };
 		1E862A882A9FC01200F84D4B /* SubscriptionUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SubscriptionUI; sourceTree = "<group>"; };
-		1EB30C692CBFDB36003A6456 /* BrowserServicesKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserServicesKit; path = ../BrowserServicesKit; sourceTree = SOURCE_ROOT; };
 		1ED910D42B63BFB300936947 /* IdentityTheftRestorationPagesUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesUserScript.swift; sourceTree = "<group>"; };
 		1EEB2D792C986A40000D908B /* SubscriptionPagesUseSubscriptionFeatureTestsForStripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPagesUseSubscriptionFeatureTestsForStripe.swift; sourceTree = "<group>"; };
 		310E79BE294A19A8007C49E8 /* FireproofingReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireproofingReferenceTests.swift; sourceTree = "<group>"; };
@@ -7324,7 +7323,6 @@
 		AA585D75248FD31100E9A3E2 = {
 			isa = PBXGroup;
 			children = (
-				1EB30C692CBFDB36003A6456 /* BrowserServicesKit */,
 				378B5886295CF2A4002C0CC0 /* Configuration */,
 				378E279C2970217400FCADA2 /* LocalPackages */,
 				7BB108552A43375D000AB95F /* LocalThirdParty */,
@@ -14295,8 +14293,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 199.2.0;
+				branch = "michal/privacy-pro-cookie";
+				kind = branch;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -3292,6 +3292,7 @@
 		1E7E2E8F29029A2A00C01B54 /* ContentBlockingRulesUpdateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockingRulesUpdateObserver.swift; sourceTree = "<group>"; };
 		1E7E2E932902AC0E00C01B54 /* PrivacyDashboardPermissionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDashboardPermissionHandler.swift; sourceTree = "<group>"; };
 		1E862A882A9FC01200F84D4B /* SubscriptionUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SubscriptionUI; sourceTree = "<group>"; };
+		1EB30C692CBFDB36003A6456 /* BrowserServicesKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserServicesKit; path = ../BrowserServicesKit; sourceTree = SOURCE_ROOT; };
 		1ED910D42B63BFB300936947 /* IdentityTheftRestorationPagesUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesUserScript.swift; sourceTree = "<group>"; };
 		1EEB2D792C986A40000D908B /* SubscriptionPagesUseSubscriptionFeatureTestsForStripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPagesUseSubscriptionFeatureTestsForStripe.swift; sourceTree = "<group>"; };
 		310E79BE294A19A8007C49E8 /* FireproofingReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireproofingReferenceTests.swift; sourceTree = "<group>"; };
@@ -7320,6 +7321,7 @@
 		AA585D75248FD31100E9A3E2 = {
 			isa = PBXGroup;
 			children = (
+				1EB30C692CBFDB36003A6456 /* BrowserServicesKit */,
 				378B5886295CF2A4002C0CC0 /* Configuration */,
 				378E279C2970217400FCADA2 /* LocalPackages */,
 				7BB108552A43375D000AB95F /* LocalThirdParty */,

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "browserserviceskit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/BrowserServicesKit",
-      "state" : {
-        "revision" : "e0c0c85c18372f73fb97c5cf070f1de70c906a1f",
-        "version" : "199.1.0"
-      }
-    },
-    {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "browserserviceskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/BrowserServicesKit",
+      "state" : {
+        "branch" : "michal/privacy-pro-cookie",
+        "revision" : "22f61802e71f863b80110146336bf7a4db86fb1b"
+      }
+    },
+    {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -96,6 +96,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     public let subscriptionManager: SubscriptionManager
     public let subscriptionUIHandler: SubscriptionUIHandling
+    public let subscriptionCookieManager: SubscriptionCookieManaging
 
     public let vpnSettings = VPNSettings(defaults: .netP)
 
@@ -264,6 +265,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         subscriptionManager = DefaultSubscriptionManager()
         subscriptionUIHandler = SubscriptionUIHandler(windowControllersManagerProvider: {
             return WindowControllersManager.shared
+        })
+
+        subscriptionCookieManager = SubscriptionCookieManager(subscriptionManager: subscriptionManager, currentCookieStore: {
+            WKWebsiteDataStore.default().httpCookieStore
         })
 
         // Update VPN environment and match the Subscription environment
@@ -445,6 +450,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         Task { @MainActor in
             await vpnRedditSessionWorkaround.installRedditSessionWorkaround()
+        }
+
+        Task { @MainActor in
+            await subscriptionCookieManager.refreshSubscriptionCookie()
         }
     }
 

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -269,7 +269,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         subscriptionCookieManager = SubscriptionCookieManager(subscriptionManager: subscriptionManager, currentCookieStore: {
             WKWebsiteDataStore.default().httpCookieStore
-        })
+        }, eventMapping: SubscriptionCookieManageEventPixelMapping())
 
         // Update VPN environment and match the Subscription environment
         vpnSettings.alignTo(subscriptionEnvironment: subscriptionManager.currentEnvironment)

--- a/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -146,4 +146,3 @@ enum PrivacyProErrorPixel: PixelKitEventV2 {
     }
 
 }
-

--- a/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -146,3 +146,4 @@ enum PrivacyProErrorPixel: PixelKitEventV2 {
     }
 
 }
+

--- a/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
+++ b/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
@@ -32,15 +32,15 @@ enum SubscriptionCookieManagerPixel: PixelKitEventV2 {
     var name: String {
         switch self {
         case .errorHandlingAccountDidSignInTokenIsMissing:
-            return "m_mac_privacy-pro_subscription_cookie_error_handling_accountdidsignin_token_is_missing"
+            return "m_mac_privacy-pro_subscription-cookie-missing_token_on_sign_in"
         case .errorHandlingAccountDidSignOutCookieIsMissing:
-            return "m_mac_privacy-pro_subscription_cookie_error_handling_accountdidsignout_cookie_is_missing"
+            return "m_mac_privacy-pro_subscription-cookie-missing_cookie_on_sign_out"
         case .subscriptionCookieRefreshedWithUpdate:
-            return "m_mac_privacy-pro_subscription_cookie_subscription_cookie_refreshed_with_update"
+            return "m_mac_privacy-pro_subscription-cookie-refreshed_with_update"
         case .subscriptionCookieRefreshedWithDelete:
-            return "m_mac_privacy-pro_subscription_cookie_subscription_cookie_refreshed_with_delete"
+            return "m_mac_privacy-pro_subscription-cookie-refreshed_with_delete"
         case .failedToSetSubscriptionCookie:
-            return "m_mac_privacy-pro_subscription_cookie_failed_to_set_subscription_cookie"
+            return "m_mac_privacy-pro_subscription-cookie-failed_to_set_subscription_cookie"
         }
     }
 

--- a/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
+++ b/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
@@ -23,21 +23,21 @@ import Subscription
 
 enum SubscriptionCookieManagerPixel: PixelKitEventV2 {
 
-    case errorHandlingAccountDidSignInTokenIsMissing
-    case errorHandlingAccountDidSignOutCookieIsMissing
-    case subscriptionCookieRefreshedWithUpdate
-    case subscriptionCookieRefreshedWithDelete
+    case missingTokenOnSignIn
+    case missingCookieOnSignOut
+    case cookieRefreshedWithUpdate
+    case cookieRefreshedWithDelete
     case failedToSetSubscriptionCookie
 
     var name: String {
         switch self {
-        case .errorHandlingAccountDidSignInTokenIsMissing:
+        case .missingTokenOnSignIn:
             return "m_mac_privacy-pro_subscription-cookie-missing_token_on_sign_in"
-        case .errorHandlingAccountDidSignOutCookieIsMissing:
+        case .missingCookieOnSignOut:
             return "m_mac_privacy-pro_subscription-cookie-missing_cookie_on_sign_out"
-        case .subscriptionCookieRefreshedWithUpdate:
+        case .cookieRefreshedWithUpdate:
             return "m_mac_privacy-pro_subscription-cookie-refreshed_with_update"
-        case .subscriptionCookieRefreshedWithDelete:
+        case .cookieRefreshedWithDelete:
             return "m_mac_privacy-pro_subscription-cookie-refreshed_with_delete"
         case .failedToSetSubscriptionCookie:
             return "m_mac_privacy-pro_subscription-cookie-failed_to_set_subscription_cookie"
@@ -59,14 +59,14 @@ public final class SubscriptionCookieManageEventPixelMapping: EventMapping<Subsc
         super.init { event, _, _, _ in
             let pixel: SubscriptionCookieManagerPixel = {
                 switch event {
-                case .errorHandlingAccountDidSignInTokenIsMissing: 
-                    return .errorHandlingAccountDidSignInTokenIsMissing
+                case .errorHandlingAccountDidSignInTokenIsMissing:
+                    return .missingTokenOnSignIn
                 case .errorHandlingAccountDidSignOutCookieIsMissing:
-                    return .errorHandlingAccountDidSignOutCookieIsMissing
+                    return .missingCookieOnSignOut
                 case .subscriptionCookieRefreshedWithUpdate:
-                    return .subscriptionCookieRefreshedWithUpdate
+                    return .cookieRefreshedWithUpdate
                 case .subscriptionCookieRefreshedWithDelete:
-                    return .subscriptionCookieRefreshedWithDelete
+                    return .cookieRefreshedWithDelete
                 case .failedToSetSubscriptionCookie:
                     return .failedToSetSubscriptionCookie
                 }

--- a/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
+++ b/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
@@ -1,0 +1,82 @@
+//
+//  SubscriptionCookieManageEventPixelMapping.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+import PixelKit
+import Subscription
+
+enum SubscriptionCookieManagerPixel: PixelKitEventV2 {
+
+    case errorHandlingAccountDidSignInTokenIsMissing
+    case errorHandlingAccountDidSignOutCookieIsMissing
+    case subscriptionCookieRefreshedWithUpdate
+    case subscriptionCookieRefreshedWithDelete
+    case failedToSetSubscriptionCookie
+
+    var name: String {
+        switch self {
+        case .errorHandlingAccountDidSignInTokenIsMissing:
+            return "m_mac_privacy-pro_subscription_cookie_error_handling_accountdidsignin_token_is_missing"
+        case .errorHandlingAccountDidSignOutCookieIsMissing:
+            return "m_mac_privacy-pro_subscription_cookie_error_handling_accountdidsignout_cookie_is_missing"
+        case .subscriptionCookieRefreshedWithUpdate:
+            return "m_mac_privacy-pro_subscription_cookie_subscription_cookie_refreshed_with_update"
+        case .subscriptionCookieRefreshedWithDelete:
+            return "m_mac_privacy-pro_subscription_cookie_subscription_cookie_refreshed_with_delete"
+        case .failedToSetSubscriptionCookie:
+            return "m_mac_privacy-pro_subscription_cookie_failed_to_set_subscription_cookie"
+        }
+    }
+
+    var error: (any Error)? {
+        return nil
+    }
+
+    var parameters: [String: String]? {
+        return nil
+    }
+}
+
+public final class SubscriptionCookieManageEventPixelMapping: EventMapping<SubscriptionCookieManagerEvent> {
+
+    public init() {
+        super.init { event, _, _, _ in
+            let pixel: SubscriptionCookieManagerPixel = {
+                switch event {
+                case .errorHandlingAccountDidSignInTokenIsMissing: 
+                    return .errorHandlingAccountDidSignInTokenIsMissing
+                case .errorHandlingAccountDidSignOutCookieIsMissing:
+                    return .errorHandlingAccountDidSignOutCookieIsMissing
+                case .subscriptionCookieRefreshedWithUpdate:
+                    return .subscriptionCookieRefreshedWithUpdate
+                case .subscriptionCookieRefreshedWithDelete:
+                    return .subscriptionCookieRefreshedWithDelete
+                case .failedToSetSubscriptionCookie:
+                    return .failedToSetSubscriptionCookie
+                }
+            }()
+
+            PixelKit.fire(pixel)
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<SubscriptionCookieManagerEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1108686900785972/1208264562025859/f

**Description**:
Store and keep in sync the subscription access token for the duckduckgo.com domain cookie. For the implementation guidelines please see description of the linked task.

**Steps to test this PR**:
To inspect website cookies use Developer Tools

1. Ensure no subscription is on device
2. Open SERP -> subscription cookie should not be present
3. Purchase a subscription
4. Open SERP -> subscription cookie should be present
5. Restart the browser
6. Open SERP -> subscription cookie should still be present
7. Manually alter the value of cookie via Developer Tools
8. Restart the browser
9. Open SERP -> subscription cookie should restore correct value
10. Manually remove the subscription cookie via Developer Tools
11. Restart the browser
12. Open SERP -> subscription cookie should be present
13. Open DDG subdomain page e.g. staging.duckduckgo.com -> subscription cookie should be present
14. Remove subscription
15. Open SERP -> subscription cookie should not be present
16. Restart the browser
17. Open SERP -> subscription cookie should still not be present

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
