### PR TITLE
Disable NTP animation when toggling Privacy Feed

### DIFF
--- a/DuckDuckGo/HomePage/View/HomePageView.swift
+++ b/DuckDuckGo/HomePage/View/HomePageView.swift
@@ -88,6 +88,7 @@ extension HomePage.Views {
                                         scrollOffsetReader
                                     }
                                 }
+                                .animation(.none, value: recentlyVisitedModel.showRecentlyVisited)
                                 .coordinateSpace(name: Const.scrollViewCoordinateSpaceName)
                                 .onPreferenceChange(ScrollOffsetPreferenceKey.self, perform: hideSuggestionWindowIfScrolled)
                                 .if(addressBarModel.shouldShowAddressBar) { view in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208626779582462/f

**Description**:
This is to avoid weird implicit animation of the NTP layout.

**Steps to test this PR**:
1. Run the app (can be without the NTP search bar experiment)
2. Have content in privacy feed (visit websites).
3. Toggle privacy feed visibility by expanding and shrinking it (arrow icon on the right hand side).
4. Verify that there's no animation.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
