### PR TITLE
remove version retry limit for metadata upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -160,7 +160,8 @@ platform :mac do
   lane :upload_metadata do |options|
     deliver(common_deliver_arguments(options).merge({
       skip_binary_upload: true,
-      skip_metadata: false
+      skip_metadata: false,
+      version_check_wait_retry_limit: 0
     }))
   end
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205419239275955/1208635844633824/f
Tech Design URL:
CC: @ayoy 

**Description**:
- Removes retry check for `upload_metadata` lane to remove the constant checking for `[20:00:09]: Cannot find edit app info... Retrying after 300 seconds (remaining: 0)` for app info

**Steps to test this PR**:
1. Run promotion flow

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
