### PR TITLE
Fix add to favorites and open in new tabs action not working on manager

### DIFF
--- a/DuckDuckGo/Bookmarks/Extensions/Bookmarks+Tab.swift
+++ b/DuckDuckGo/Bookmarks/Extensions/Bookmarks+Tab.swift
@@ -29,7 +29,7 @@ extension Tab {
     }
 
     @MainActor
-    static func withContentOfBookmark(bookmarks: [Bookmark], burnerMode: BurnerMode) -> [Tab] {
+    static func with(contentsOf bookmarks: [Bookmark], burnerMode: BurnerMode) -> [Tab] {
         bookmarks.compactMap { bookmark -> Tab? in
             guard let url = bookmark.urlObject else { return nil }
             return Tab(content: .url(url, source: .bookmark), shouldLoadInBackground: true, burnerMode: burnerMode)

--- a/DuckDuckGo/Bookmarks/Extensions/Bookmarks+Tab.swift
+++ b/DuckDuckGo/Bookmarks/Extensions/Bookmarks+Tab.swift
@@ -28,6 +28,13 @@ extension Tab {
         }
     }
 
+    @MainActor
+    static func withContentOfBookmark(bookmarks: [Bookmark], burnerMode: BurnerMode) -> [Tab] {
+        bookmarks.compactMap { bookmark -> Tab? in
+            guard let url = bookmark.urlObject else { return nil }
+            return Tab(content: .url(url, source: .bookmark), shouldLoadInBackground: true, burnerMode: burnerMode)
+        }
+    }
 }
 
 extension TabCollection {

--- a/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
+++ b/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
@@ -308,13 +308,17 @@ extension BookmarksContextMenu: BookmarkMenuItemSelectors {
     }
 
     @objc func toggleBookmarkAsFavorite(_ sender: NSMenuItem) {
-        guard let bookmark = sender.representedObject as? Bookmark else {
+        if let bookmark = sender.representedObject as? Bookmark{
+            bookmark.isFavorite.toggle()
+            bookmarkManager.update(bookmark: bookmark)
+        } else if let bookmarks = sender.representedObject as? [Bookmark] {
+            bookmarks.forEach { bookmark in
+                bookmark.isFavorite.toggle()
+                bookmarkManager.update(bookmark: bookmark)
+            }
+        } else {
             assertionFailure("Failed to cast menu represented object to Bookmark")
-            return
         }
-
-        bookmark.isFavorite.toggle()
-        bookmarkManager.update(bookmark: bookmark)
     }
 
     @MainActor

--- a/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
+++ b/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
@@ -438,7 +438,7 @@ extension BookmarksContextMenu: FolderMenuItemSelectors {
             tabCollection.append(tabs: tabs)
             PixelExperiment.fireOnboardingBookmarkUsed5to7Pixel()
         } else if let bookmarks = sender.representedObject as? [Bookmark] {
-            let tabs = Tab.withContentOfBookmark(bookmarks: bookmarks, burnerMode: tabCollection.burnerMode)
+            let tabs = Tab.with(contentsOf: bookmarks, burnerMode: tabCollection.burnerMode)
             tabCollection.append(tabs: tabs)
             PixelExperiment.fireOnboardingBookmarkUsed5to7Pixel()
         }

--- a/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
+++ b/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
@@ -424,16 +424,20 @@ extension BookmarksContextMenu: FolderMenuItemSelectors {
 
     @MainActor
     @objc func openInNewTabs(_ sender: NSMenuItem) {
-        guard let tabCollection = windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel,
-              let folder = sender.representedObject as? BookmarkFolder
-        else {
+        guard let tabCollection = windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel else {
             assertionFailure("Cannot open all in new tabs")
             return
         }
 
-        let tabs = Tab.withContentOfBookmark(folder: folder, burnerMode: tabCollection.burnerMode)
-        tabCollection.append(tabs: tabs)
-        PixelExperiment.fireOnboardingBookmarkUsed5to7Pixel()
+        if let folder = sender.representedObject as? BookmarkFolder {
+            let tabs = Tab.withContentOfBookmark(folder: folder, burnerMode: tabCollection.burnerMode)
+            tabCollection.append(tabs: tabs)
+            PixelExperiment.fireOnboardingBookmarkUsed5to7Pixel()
+        } else if let bookmarks = sender.representedObject as? [Bookmark] {
+            let tabs = Tab.withContentOfBookmark(bookmarks: bookmarks, burnerMode: tabCollection.burnerMode)
+            tabCollection.append(tabs: tabs)
+            PixelExperiment.fireOnboardingBookmarkUsed5to7Pixel()
+        }
     }
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208523846260390/f
Tech Design URL:
CC:

**Description**:
Fix add to favorites and open in new tabs action not working on the bookmark manager when selecting multiple bookmarks.

**Steps to test this PR**:
1. Open Bookmarks Manager
2. Select multiple bookmarks
3. Right tap, select `Open in New Tabs`
4. All the bookmarks should be opened in new tabs
5. Select the bookmarks again (they should not be favorites), right-tap, and select `Add to favorites`
6. The bookmarks should be added to favorites

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
