### PR TITLE
Add pixels to help diagnose sync deactivation

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -2948,6 +2948,8 @@
 		EED9A6762C37FE6900E0FAB9 /* login_deduplication_test_data.csv in Resources */ = {isa = PBXBuildFile; fileRef = EED9A6732C37FE6800E0FAB9 /* login_deduplication_test_data.csv */; };
 		EED9A6772C37FE6900E0FAB9 /* login_deduplication_starting_data.csv in Resources */ = {isa = PBXBuildFile; fileRef = EED9A6742C37FE6900E0FAB9 /* login_deduplication_starting_data.csv */; };
 		EED9A6782C37FE6900E0FAB9 /* login_deduplication_starting_data.csv in Resources */ = {isa = PBXBuildFile; fileRef = EED9A6742C37FE6900E0FAB9 /* login_deduplication_starting_data.csv */; };
+		EEDFA38A2CD148DE00D1C558 /* SyncDiagnosisHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDFA3892CD148DE00D1C558 /* SyncDiagnosisHelper.swift */; };
+		EEDFA38B2CD148DE00D1C558 /* SyncDiagnosisHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDFA3892CD148DE00D1C558 /* SyncDiagnosisHelper.swift */; };
 		EEE0E1CD2C32F5690058E148 /* CSVImporterIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0E1CC2C32F5690058E148 /* CSVImporterIntegrationTests.swift */; };
 		EEE0E1CF2C32F6530058E148 /* mock_login_data_large.csv in Resources */ = {isa = PBXBuildFile; fileRef = EEE0E1CE2C32F6530058E148 /* mock_login_data_large.csv */; };
 		EEE0E1D02C32F6530058E148 /* mock_login_data_large.csv in Resources */ = {isa = PBXBuildFile; fileRef = EEE0E1CE2C32F6530058E148 /* mock_login_data_large.csv */; };
@@ -4706,6 +4708,8 @@
 		EED735352BB46B6000F173D6 /* AutocompleteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTests.swift; sourceTree = "<group>"; };
 		EED9A6732C37FE6800E0FAB9 /* login_deduplication_test_data.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = login_deduplication_test_data.csv; sourceTree = "<group>"; };
 		EED9A6742C37FE6900E0FAB9 /* login_deduplication_starting_data.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = login_deduplication_starting_data.csv; sourceTree = "<group>"; };
+		EEDFA3882CCFFC5D00D1C558 /* BrowserServicesKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserServicesKit; path = ../BrowserServicesKit; sourceTree = "<group>"; };
+		EEDFA3892CD148DE00D1C558 /* SyncDiagnosisHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDiagnosisHelper.swift; sourceTree = "<group>"; };
 		EEE0E1CC2C32F5690058E148 /* CSVImporterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVImporterIntegrationTests.swift; sourceTree = "<group>"; };
 		EEE0E1CE2C32F6530058E148 /* mock_login_data_large.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mock_login_data_large.csv; sourceTree = "<group>"; };
 		EEE11C5D2C7F54AD000ABD7E /* AutofillLoginImportState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillLoginImportState.swift; sourceTree = "<group>"; };
@@ -5518,6 +5522,7 @@
 				37CEFCA82A6737A2001EF741 /* CredentialsCleanupErrorHandling.swift */,
 				37A6A8F02AFCC988008580A3 /* FaviconsFetcherOnboarding.swift */,
 				37A6A8F52AFCCA59008580A3 /* FaviconsFetcherOnboardingViewController.swift */,
+				EEDFA3892CD148DE00D1C558 /* SyncDiagnosisHelper.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -7467,6 +7472,7 @@
 		AA585D75248FD31100E9A3E2 = {
 			isa = PBXGroup;
 			children = (
+				EEDFA3882CCFFC5D00D1C558 /* BrowserServicesKit */,
 				378B5886295CF2A4002C0CC0 /* Configuration */,
 				378E279C2970217400FCADA2 /* LocalPackages */,
 				7BB108552A43375D000AB95F /* LocalThirdParty */,
@@ -10798,6 +10804,7 @@
 				3706FAD4293F65D500E42796 /* DataExtension.swift in Sources */,
 				3706FAD6293F65D500E42796 /* ConfigurationStore.swift in Sources */,
 				FD22255E2C64B68500199373 /* AutoconsentExperiment.swift in Sources */,
+				EEDFA38B2CD148DE00D1C558 /* SyncDiagnosisHelper.swift in Sources */,
 				3706FAD7293F65D500E42796 /* Feedback.swift in Sources */,
 				1D0DE9422C3BB9CC0037ABC2 /* ReleaseNotesParser.swift in Sources */,
 				EED4D3D92C874AE200C79EEA /* PopoverInfoViewController.swift in Sources */,
@@ -12744,6 +12751,7 @@
 				856CADF0271710F400E79BB0 /* HoverUserScript.swift in Sources */,
 				B6DE57F62B05EA9000CD54B9 /* SheetHostingWindow.swift in Sources */,
 				AA6EF9B525081B4C004754E6 /* MainMenuActions.swift in Sources */,
+				EEDFA38A2CD148DE00D1C558 /* SyncDiagnosisHelper.swift in Sources */,
 				EED4D3D82C874AE200C79EEA /* PopoverInfoViewController.swift in Sources */,
 				56A0541F2C1CA1F5007D8FAB /* OnboardingTabExtension.swift in Sources */,
 				B63D466925BEB6C200874977 /* WKWebView+SessionState.swift in Sources */,

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -433,8 +433,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard didFinishLaunching else { return }
 
         PixelExperiment.fireOnboardingTestPixels()
-        syncService?.initializeIfNeeded()
-        syncService?.scheduler.notifyAppLifecycleEvent()
+        initializeSync()
 
         NetworkProtectionAppEvents(featureGatekeeper: DefaultVPNFeatureGatekeeper(subscriptionManager: subscriptionManager)).applicationDidBecomeActive()
 
@@ -455,6 +454,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             await subscriptionCookieManager.refreshSubscriptionCookie()
         }
+    }
+
+    private func initializeSync() {
+        guard let syncService else { return }
+        syncService.initializeIfNeeded()
+        syncService.scheduler.notifyAppLifecycleEvent()
+        SyncDiagnosisHelper(syncService: syncService).diagnoseAccountStatus()
     }
 
     func applicationDidResignActive(_ notification: Notification) {

--- a/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -376,6 +376,7 @@ final class SyncPreferences: ObservableObject, SyncUI.ManagementViewModel {
                 let registeredDevices = try await syncService.fetchDevices()
                 mapDevices(registeredDevices)
             } catch {
+                PixelKit.fire(DebugEvent(GeneralPixel.syncRefreshDevicesError(error: error)))
                 Logger.sync.debug("Failed to refresh devices: \(error)")
             }
         }

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -174,6 +174,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case syncBookmarksValidationErrorDaily
     case syncCredentialsValidationErrorDaily
     case syncSettingsValidationErrorDaily
+    case syncDebugWasDisabledUnexpectedly
 
     // Remote Messaging Framework
     case remoteMessageShown
@@ -397,6 +398,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case syncLogoutError(error: Error)
     case syncUpdateDeviceError(error: Error)
     case syncRemoveDeviceError(error: Error)
+    case syncRefreshDevicesError(error: Error)
     case syncDeleteAccountError(error: Error)
     case syncLoginExistingAccountError(error: Error)
     case syncCannotCreateRecoveryPDF
@@ -687,6 +689,7 @@ enum GeneralPixel: PixelKitEventV2 {
         case .syncBookmarksValidationErrorDaily: return "m_mac_sync_bookmarks_validation_error_daily"
         case .syncCredentialsValidationErrorDaily: return "m_mac_sync_credentials_validation_error_daily"
         case .syncSettingsValidationErrorDaily: return "m_mac_sync_settings_validation_error_daily"
+        case .syncDebugWasDisabledUnexpectedly: return "m_mac_sync_was_disabled_unexpectedly"
 
         case .remoteMessageShown: return "m_mac_remote_message_shown"
         case .remoteMessageShownUnique: return "m_mac_remote_message_shown_unique"
@@ -1010,6 +1013,7 @@ enum GeneralPixel: PixelKitEventV2 {
         case .syncLogoutError: return "sync_logout_error"
         case .syncUpdateDeviceError: return "sync_update_device_error"
         case .syncRemoveDeviceError: return "sync_remove_device_error"
+        case .syncRefreshDevicesError: return "sync_refresh_devices_error"
         case .syncDeleteAccountError: return "sync_delete_account_error"
         case .syncLoginExistingAccountError: return "sync_login_existing_account_error"
         case .syncCannotCreateRecoveryPDF: return "sync_cannot_create_recovery_pdf"
@@ -1065,6 +1069,7 @@ enum GeneralPixel: PixelKitEventV2 {
                 .syncLogoutError(let error),
                 .syncUpdateDeviceError(let error),
                 .syncRemoveDeviceError(let error),
+                .syncRefreshDevicesError(let error),
                 .syncDeleteAccountError(let error),
                 .syncLoginExistingAccountError(let error),
                 .bookmarksCouldNotLoadDatabase(let error?):

--- a/DuckDuckGo/Sync/SyncDiagnosisHelper.swift
+++ b/DuckDuckGo/Sync/SyncDiagnosisHelper.swift
@@ -1,0 +1,58 @@
+//
+//  SyncDiagnosisHelper.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import DDGSync
+import PixelKit
+
+final class SyncDiagnosisHelper {
+    private struct Consts {
+        static let syncManuallyDisabledKey = "com.duckduckgo.app.key.debug.SyncManuallyDisabled"
+        static let syncWasDisabledUnexpectedlyPixelFired = "com.duckduckgo.app.key.debug.SyncWasDisabledUnexpectedlyPixelFired"
+    }
+
+    private let userDefaults = UserDefaults.standard
+    private let syncService: DDGSyncing
+
+    init(syncService: DDGSyncing) {
+        self.syncService = syncService
+    }
+
+// Non-user-initiated deactivation
+// For events to help understand the impact of https://app.asana.com/0/1201493110486074/1208538487332133/f
+
+    func didManuallyDisableSync() {
+        userDefaults.set(true, forKey: Consts.syncManuallyDisabledKey)
+    }
+
+    func diagnoseAccountStatus() {
+        if syncService.account == nil {
+            // Nil value means sync was never on in the first place. So don't fire in this case.
+            let syncWasManuallyDisabled = userDefaults.value(forKey: Consts.syncManuallyDisabledKey) as? Bool
+            if syncWasManuallyDisabled == false,
+               !userDefaults.bool(forKey: Consts.syncWasDisabledUnexpectedlyPixelFired) {
+                PixelKit.fire(DebugEvent(GeneralPixel.syncDebugWasDisabledUnexpectedly), frequency: .dailyAndCount)
+                userDefaults.set(true, forKey: Consts.syncWasDisabledUnexpectedlyPixelFired)
+            }
+        } else {
+            userDefaults.set(false, forKey: Consts.syncManuallyDisabledKey)
+            userDefaults.set(false, forKey: Consts.syncWasDisabledUnexpectedlyPixelFired)
+        }
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201493110486074/1208640658073530/f

**Description**:

Sync is being randomly deactivated for some users and we don't know why. This PR:
- Sends a missing pixel when device refresh fails (which can result in deactivation)
- Sends a high-level pixels which recreates this scenario so we can assess the impact of this issue and know when we've fixed it.

**Steps to test this PR**:
1. (just for testing) Add a line of code to easily deactivate sync in a non-typical way (e.g by calling `try await syncService.deleteAccount()` from `updateDeviceName`) so you can mimic unexpected deactivation.
2. Make sure Sync is enabled
3. Trigger the fake unexpected deactivation
4. Minimize the browser and maximise again.
5. Make sure the `m_mac_sync_was_disabled_unexpectedly` pixel is fired.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
