### PR TITLE
Update autoconsent to v10.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "macos-browser",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^10.16.0"
+        "@duckduckgo/autoconsent": "^10.17.0"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -53,9 +53,10 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "10.16.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.16.0.tgz",
-      "integrity": "sha512-731vJAQ/wOu+zpGOgXgnuTyhpF7LCuiVmmOFVLUU9RNHX1357aEm+7D2SdyPAuHj+uDpGkhTbaz/MPX6qFoInQ==",
+      "version": "10.17.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.17.0.tgz",
+      "integrity": "sha512-zMB4BE5fpiqvjXPA0k8bCorWgh6eFMlkedRfuRVQYhbWqwLgrnsA7lv4U0ORTIJkvbBjABuYaprwr1yd/15D/w==",
+      "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^6.1.37"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^10.16.0"
+    "@duckduckgo/autoconsent": "^10.17.0"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208659004342409/1208659004342409
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v10.17.0


## Description
Updates Autoconsent to version [v10.17.0](https://github.com/duckduckgo/autoconsent/releases/tag/v10.17.0).

### Autoconsent v10.17.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v10.17.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI