### PR TITLE
Fix crash when opening permission popover for NewTab page address bar

### DIFF
--- a/DuckDuckGo/Common/Extensions/NSViewExtension.swift
+++ b/DuckDuckGo/Common/Extensions/NSViewExtension.swift
@@ -85,6 +85,12 @@ extension NSView {
         set { isHidden = !newValue }
     }
 
+    var isVisible: Bool {
+        guard !isHiddenOrHasHiddenAncestor,
+              let window, window.isVisible else { return false }
+        return true
+    }
+
     func makeMeFirstResponder() {
         guard let window = window else {
             Logger.general.error("\(self.className): Window not available")

--- a/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
+++ b/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
@@ -119,7 +119,7 @@ extension NSPopover {
     // https://app.asana.com/0/1201037661562251/1206407295280737/f
     @objc(swizzled_showRelativeToRect:ofView:preferredEdge:)
     private dynamic func swizzled_show(relativeTo positioningRect: NSRect, of positioningView: NSView, preferredEdge: NSRectEdge) {
-        if positioningView.superview == nil {
+        if positioningView.window == nil {
             var observer: Cancellable?
             observer = positioningView.observe(\.window) { positioningView, _ in
                 if positioningView.window != nil {

--- a/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -61,7 +61,7 @@ final class AddressBarButtonsViewController: NSViewController {
     @IBOutlet weak var imageButtonWrapper: NSView!
     @IBOutlet weak var imageButton: NSButton!
     @IBOutlet weak var clearButton: NSButton!
-    @IBOutlet weak var buttonsContainer: NSStackView!
+    @IBOutlet private weak var buttonsContainer: NSStackView!
 
     @IBOutlet weak var animationWrapperView: NSView!
     var trackerAnimationView1: LottieAnimationView!
@@ -72,7 +72,7 @@ final class AddressBarButtonsViewController: NSViewController {
 
     @IBOutlet weak var notificationAnimationView: NavigationBarBadgeAnimationView!
 
-    @IBOutlet weak var permissionButtons: NSView!
+    @IBOutlet private weak var permissionButtons: NSView!
     @IBOutlet weak var cameraButton: PermissionButton! {
         didSet {
             cameraButton.isHidden = true
@@ -368,7 +368,7 @@ final class AddressBarButtonsViewController: NSViewController {
                 return
             }
         }
-        guard button.isShown, permissionButtons.isShown else { return }
+        guard button.isVisible else { return }
 
         (popover.contentViewController as? PermissionAuthorizationViewController)?.query = query
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202406491309510/1208667754274335/f

**Description**:
- Fixes crash when permission requested with NewTab  address bar experiment caused by permission popover tried to be presented on the NewTab page address bar

**Steps to test this PR**:
1. Activate the Address Bar on the NewTab home page experiment
2. Open New Tab page
3. Open a tab with https://permission.site
4. Request camera permission -> crash

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
