### PR TITLE
Update to subscription cookie

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14509,8 +14509,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 201.0.0;
+				branch = "michal/update-subs-cookie";
+				kind = branch;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "e5946eee6af859690cc1cc5e51daef3c8368981b",
-        "version" : "201.0.0"
+        "branch" : "michal/update-subs-cookie",
+        "revision" : "9506581ae99273681073f9993fc6d881d3edaa7f"
       }
     },
     {

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -96,7 +96,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     public let subscriptionManager: SubscriptionManager
     public let subscriptionUIHandler: SubscriptionUIHandling
-    public let subscriptionCookieManager: SubscriptionCookieManaging
+    private let subscriptionCookieManager: SubscriptionCookieManaging
+    private var subscriptionCookieManagerFeatureFlagCancellable: AnyCancellable?
 
     public let vpnSettings = VPNSettings(defaults: .netP)
 
@@ -344,6 +345,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         subscriptionManager.loadInitialData()
 
+        let privacyConfigurationManager = ContentBlocking.shared.privacyConfigurationManager
+
+        // Enable subscriptionCookieManager if feature flag is present
+        if privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(PrivacyProSubfeature.setAccessTokenCookieForSubscriptionDomains) {
+            subscriptionCookieManager.enableSettingSubscriptionCookie()
+        }
+
+        // Keep track of feature flag changes
+        subscriptionCookieManagerFeatureFlagCancellable = privacyConfigurationManager.updatesPublisher
+            .sink { [weak self, weak privacyConfigurationManager] in
+                guard let self, let privacyConfigurationManager else { return }
+
+                let isEnabled = privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(PrivacyProSubfeature.setAccessTokenCookieForSubscriptionDomains)
+
+                Task { [weak self] in
+                    if isEnabled {
+                        self?.subscriptionCookieManager.enableSettingSubscriptionCookie()
+                        await self?.subscriptionCookieManager.refreshSubscriptionCookie()
+                    } else {
+                        await self?.subscriptionCookieManager.disableSettingSubscriptionCookie()
+                    }
+                }
+            }
+
         if [.normal, .uiTests].contains(NSApp.runType) {
             stateRestorationManager.applicationDidFinishLaunching()
         }
@@ -454,6 +479,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             await subscriptionCookieManager.refreshSubscriptionCookie()
         }
+
+
     }
 
     private func initializeSync() {

--- a/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
+++ b/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
@@ -24,21 +24,18 @@ import Subscription
 enum SubscriptionCookieManagerPixel: PixelKitEventV2 {
 
     case missingTokenOnSignIn
-    case missingCookieOnSignOut
-    case cookieRefreshedWithUpdate
-    case cookieRefreshedWithDelete
+    case cookieRefreshedWithAccessToken
+    case cookieRefreshedWithEmptyValue
     case failedToSetSubscriptionCookie
 
     var name: String {
         switch self {
         case .missingTokenOnSignIn:
             return "m_mac_privacy-pro_subscription-cookie-missing_token_on_sign_in"
-        case .missingCookieOnSignOut:
-            return "m_mac_privacy-pro_subscription-cookie-missing_cookie_on_sign_out"
-        case .cookieRefreshedWithUpdate:
-            return "m_mac_privacy-pro_subscription-cookie-refreshed_with_update"
-        case .cookieRefreshedWithDelete:
-            return "m_mac_privacy-pro_subscription-cookie-refreshed_with_delete"
+        case .cookieRefreshedWithAccessToken:
+            return "m_mac_privacy-pro_subscription-cookie-refreshed_with_access_token"
+        case .cookieRefreshedWithEmptyValue:
+            return "m_mac_privacy-pro_subscription-cookie-refreshed_with_empty_value"
         case .failedToSetSubscriptionCookie:
             return "m_mac_privacy-pro_subscription-cookie-failed_to_set_subscription_cookie"
         }
@@ -61,12 +58,10 @@ public final class SubscriptionCookieManageEventPixelMapping: EventMapping<Subsc
                 switch event {
                 case .errorHandlingAccountDidSignInTokenIsMissing:
                     return .missingTokenOnSignIn
-                case .errorHandlingAccountDidSignOutCookieIsMissing:
-                    return .missingCookieOnSignOut
-                case .subscriptionCookieRefreshedWithUpdate:
-                    return .cookieRefreshedWithUpdate
-                case .subscriptionCookieRefreshedWithDelete:
-                    return .cookieRefreshedWithDelete
+                case .subscriptionCookieRefreshedWithAccessToken:
+                    return .cookieRefreshedWithAccessToken
+                case .subscriptionCookieRefreshedWithEmptyValue:
+                    return .cookieRefreshedWithEmptyValue
                 case .failedToSetSubscriptionCookie:
                     return .failedToSetSubscriptionCookie
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1108686900785972/1208264562025859/f

**Description**:
Update to how the subscription cookie operates:
- constraint the cookie to `subscriptions.duckduckgo.com`
- on sign out do not fully remove the cookie - just clear the value
- gate the feature behind the `setAccessTokenCookieForSubscriptionDomains` privacy config feature flag 

**Steps to test this PR**:
To inspect website cookies first navigate to https://subscriptions.duckduckgo.com/ and use Developer Tools -> Storage

1. Verify feature that feature flag gates the operation ([JSON BLOB](https://jsonblob.com/api/jsonBlob/1301685977817669632) and its [editor](https://jsonblob.com/1301685977817669632))
2. Ensure that cookie is set properly for the new domain
3. Test that when feature flag is enabled after the purchase the token is set in the cookie
4. Test that when feature flag is enabled after signing out of the subscription the cookie is updated with empty value 
5. Test that when feature flag is turned to disabled the cookie independent of its value is cleared
6. 
**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
