### PR TITLE
Validate VPN errors before re-throwing them

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14683,8 +14683,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 202.1.0;
+				branch = "sam/validate-errors-before-throwing-them-to-the-os";
+				kind = branch;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "8a1bc5526e14c589ca2cc74e6e7d125952b79bc1",
-        "version" : "202.1.0"
+        "branch" : "sam/validate-errors-before-throwing-them-to-the-os",
+        "revision" : "aff5f0ca16cc9861157014c96752ec366d4f2c15"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208225499545869/f
Tech Design URL:
CC:

**Description**:

This PR updates the VPN to validate errors before throwing them to the OS.

**Steps to test this PR**:
1. Smoke test the VPN
2. See the [BSK PR](https://github.com/duckduckgo/BrowserServicesKit/pull/1054) for testing steps, though the focus is on iOS

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
