### PR TITLE
Remove com.apple.security.device.usb entitlement

### DIFF
--- a/DuckDuckGo/DuckDuckGoAppStore.entitlements
+++ b/DuckDuckGo/DuckDuckGoAppStore.entitlements
@@ -23,8 +23,6 @@
 	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
-	<key>com.apple.security.device.usb</key>
-	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>

--- a/DuckDuckGo/DuckDuckGoAppStoreCI.entitlements
+++ b/DuckDuckGo/DuckDuckGoAppStoreCI.entitlements
@@ -16,8 +16,6 @@
 	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
-	<key>com.apple.security.device.usb</key>
-	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>

--- a/DuckDuckGo/DuckDuckGoAppStoreDebug.entitlements
+++ b/DuckDuckGo/DuckDuckGoAppStoreDebug.entitlements
@@ -21,8 +21,6 @@
 	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
-	<key>com.apple.security.device.usb</key>
-	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208672609826736/f

**Description**:
This change removes unneeded com.apple.security.device.usb entitlement usage.

**Steps to test this PR**:
1. Run the review app from [this workflow](https://github.com/duckduckgo/macos-browser/actions/runs/11652598220).
2. Connect an external drive.
3. Verify that you can download files to the external drive and upload files from it to web forms. 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
