### PR TITLE
Send pixel on sync secure storage read failure

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14777,8 +14777,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "graeme/send-pixel-on-sync-secure-storage-failure";
-				kind = branch;
+				kind = exactVersion;
+				version = 203.2.0;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -14777,8 +14777,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 203.1.0;
+				branch = "graeme/send-pixel-on-sync-secure-storage-failure";
+				kind = branch;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
         "branch" : "graeme/send-pixel-on-sync-secure-storage-failure",
-        "revision" : "691102a5470107f6c0545f5f7e09b63ba6c4f704"
+        "revision" : "ad32885472e561de7748b0a5ec16fd3fb3723101"
       }
     },
     {
@@ -75,7 +75,7 @@
     {
       "identity" : "lottie-spm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-spm.git",
+      "location" : "https://github.com/airbnb/lottie-spm",
       "state" : {
         "revision" : "1d29eccc24cc8b75bff9f6804155112c0ffc9605",
         "version" : "4.4.3"

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "graeme/send-pixel-on-sync-secure-storage-failure",
-        "revision" : "ad32885472e561de7748b0a5ec16fd3fb3723101"
+        "revision" : "56dbee74e34d37b6e699921a0b9bce2b8f22711d",
+        "version" : "203.2.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "19f1e5c945aa92562ad2d087e8d6c99801edf656",
-        "version" : "203.1.0"
+        "branch" : "graeme/send-pixel-on-sync-secure-storage-failure",
+        "revision" : "691102a5470107f6c0545f5f7e09b63ba6c4f704"
       }
     },
     {

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -409,6 +409,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case syncDeleteAccountError(error: Error)
     case syncLoginExistingAccountError(error: Error)
     case syncCannotCreateRecoveryPDF
+    case syncSecureStorageReadError(error: Error)
 
     case bookmarksCleanupFailed
     case bookmarksCleanupAttemptedWhileSyncWasEnabled
@@ -1038,6 +1039,7 @@ enum GeneralPixel: PixelKitEventV2 {
         case .syncDeleteAccountError: return "sync_delete_account_error"
         case .syncLoginExistingAccountError: return "sync_login_existing_account_error"
         case .syncCannotCreateRecoveryPDF: return "sync_cannot_create_recovery_pdf"
+        case .syncSecureStorageReadError: return "sync_secure_storage_read_error"
 
         case .bookmarksCleanupFailed: return "bookmarks_cleanup_failed"
         case .bookmarksCleanupAttemptedWhileSyncWasEnabled: return "bookmarks_cleanup_attempted_while_sync_was_enabled"
@@ -1093,6 +1095,7 @@ enum GeneralPixel: PixelKitEventV2 {
                 .syncRefreshDevicesError(let error),
                 .syncDeleteAccountError(let error),
                 .syncLoginExistingAccountError(let error),
+                .syncSecureStorageReadError(let error),
                 .bookmarksCouldNotLoadDatabase(let error?):
             return error
         default: return nil

--- a/DuckDuckGo/Sync/SyncErrorHandler.swift
+++ b/DuckDuckGo/Sync/SyncErrorHandler.swift
@@ -91,7 +91,12 @@ public class SyncErrorHandler: EventMapping<SyncError>, ObservableObject {
     public init(alertPresenter: SyncAlertsPresenting = SyncAlertsPresenter()) {
         self.alertPresenter = alertPresenter
         super.init { event, _, _, _ in
-            PixelKit.fire(DebugEvent(GeneralPixel.syncSentUnauthenticatedRequest, error: event))
+            switch event {
+            case .failedToReadSecureStore(let status):
+                PixelKit.fire(DebugEvent(GeneralPixel.syncSecureStorageReadError(error: event), error: event))
+            default:
+                PixelKit.fire(DebugEvent(GeneralPixel.syncSentUnauthenticatedRequest, error: event))
+            }
         }
     }
 

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "203.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "203.2.0"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../XPCHelper"),
         .package(path: "../Freemium"),

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "203.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "203.2.0"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.3"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "203.1.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "203.2.0"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201493110486074/1208686320819590/f
Tech Design URL:
CC:

**Description**:

On investigating a hard-to-reproduce issue with sync, I noticed there's a gap in error reporting when the secure storage (keychain) is not available. This adds a pixel for that case.

**Steps to test this PR**:
Just a pixel in an error case. Hard to test without altering code. But if you do want to do that:
1. Enable sync
2. Change `BSK.DDGSync.SecureStorage.account()` to throw every time
3. Go to the Settings -> Sync screen
4. You should see the `sync_secure_storage_read_error` Pixel in the debug console
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
