### PR TITLE
Hiding of tab previews for pinned tabs fixed

### DIFF
--- a/DuckDuckGo/Common/Logger+Multiple.swift
+++ b/DuckDuckGo/Common/Logger+Multiple.swift
@@ -28,4 +28,5 @@ extension Logger {
     static var tabSnapshots = { Logger(subsystem: "Tab Snapshots", category: "") }()
     static var tabLazyLoading = { Logger(subsystem: "Lazy Loading", category: "") }()
     static var updates = { Logger(subsystem: "Updates", category: "") }()
+    static var tabPreview = { Logger(subsystem: "Tab Preview", category: "") }()
 }

--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -215,6 +215,7 @@ final class MainViewController: NSViewController {
 
     func windowDidResignKey() {
         browserTabViewController.windowDidResignKey()
+        tabBarViewController.hideTabPreview()
     }
 
     func showBookmarkPromptIfNeeded() {

--- a/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
+++ b/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
@@ -73,10 +73,10 @@ final class TabPreviewWindowController: NSWindowController {
     }
 
     func show(parentWindow: NSWindow, topLeftPointInWindow: CGPoint) {
-        Logger.tabPreview.log("TabPreviewWindowController showing tab preview")
+        Logger.tabPreview.log("Showing tab preview")
 
         func presentPreview(tabPreviewWindow: NSWindow) {
-            Logger.tabPreview.log("TabPreviewWindowController presenting tab preview")
+            Logger.tabPreview.log("Presenting tab preview")
 
             parentWindow.addChildWindow(tabPreviewWindow, ordered: .above)
             self.layout(topLeftPoint: parentWindow.convertPoint(toScreen: topLeftPointInWindow))
@@ -87,7 +87,7 @@ final class TabPreviewWindowController: NSWindowController {
 
         guard let childWindows = parentWindow.childWindows,
               let tabPreviewWindow = self.window else {
-            Logger.general.error("TabPreviewWindowController: Showing tab preview window failed")
+            Logger.general.error("Showing tab preview window failed")
             return
         }
 
@@ -111,10 +111,10 @@ final class TabPreviewWindowController: NSWindowController {
     }
 
     func hide(allowQuickRedisplay: Bool = false, withDelay delay: Bool = false) {
-        Logger.tabPreview.log("TabPreviewWindowController hiding tab preview allowQuickRedisplay:\(allowQuickRedisplay) delay:\(delay)")
+        Logger.tabPreview.log("Hiding tab preview allowQuickRedisplay:\(allowQuickRedisplay) delay:\(delay)")
 
         func removePreview(allowQuickRedisplay: Bool) {
-            Logger.tabPreview.log("TabPreviewWindowController removing tab preview allowQuickRedisplay:\(allowQuickRedisplay)")
+            Logger.tabPreview.log("Removing tab preview allowQuickRedisplay:\(allowQuickRedisplay)")
 
             guard let window = window else {
                 lastHideTime = nil

--- a/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
+++ b/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
@@ -73,7 +73,11 @@ final class TabPreviewWindowController: NSWindowController {
     }
 
     func show(parentWindow: NSWindow, topLeftPointInWindow: CGPoint) {
+        Logger.tabPreview.log("TabPreviewWindowController showing tab preview")
+
         func presentPreview(tabPreviewWindow: NSWindow) {
+            Logger.tabPreview.log("TabPreviewWindowController presenting tab preview")
+
             parentWindow.addChildWindow(tabPreviewWindow, ordered: .above)
             self.layout(topLeftPoint: parentWindow.convertPoint(toScreen: topLeftPointInWindow))
         }
@@ -107,7 +111,11 @@ final class TabPreviewWindowController: NSWindowController {
     }
 
     func hide(allowQuickRedisplay: Bool = false, withDelay delay: Bool = false) {
+        Logger.tabPreview.log("TabPreviewWindowController hiding tab preview allowQuickRedisplay:\(allowQuickRedisplay) delay:\(delay)")
+
         func removePreview(allowQuickRedisplay: Bool) {
+            Logger.tabPreview.log("TabPreviewWindowController removing tab preview allowQuickRedisplay:\(allowQuickRedisplay)")
+
             guard let window = window else {
                 lastHideTime = nil
                 return
@@ -117,11 +125,12 @@ final class TabPreviewWindowController: NSWindowController {
                 if !allowQuickRedisplay {
                     lastHideTime = nil
                 }
+                window.orderOut(nil)
                 return
             }
 
             parentWindow.removeChildWindow(window)
-            (window).orderOut(nil)
+            window.orderOut(nil)
 
             // Record the hide time
             lastHideTime = allowQuickRedisplay ? Date() : nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1148564399326804/1208347387296425/f

**Description**:
Stuck tab preview fixed

**Steps to test this PR**:
1. Open a new window with bunch of tabs
2. Pin one tab
3. Hover mouse cursor over the pinned tab until the preview is shown and don't move with your mouse cursor
4. Use keyboard to switch to another app (CMD + TAB)
5. Move the mouse cursor to other position on the screen
6. Use keyboard to switch back to the DuckDuckGo app
7. Verify the preview is hidden 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
