### PR TITLE
Fix UI tests failing 

### DIFF
--- a/UITests/OnboardingUITests.swift
+++ b/UITests/OnboardingUITests.swift
@@ -101,9 +101,9 @@ final class OnboardingUITests: XCTestCase {
         startBrowsingButton.click()
 
         // AfterOnboarding
-        let ddgLogo = app.windows.webViews.groups.containing(.image, identifier:"DuckDuckGo Logo").element
+        let ddgLogo = app.windows.webViews.groups.containing(.image, identifier: "DuckDuckGo Logo").element
         XCTAssertTrue(ddgLogo.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        let homePageSubTitle = app.windows.webViews.groups.containing(.staticText, identifier:"Your protection, our priority.").element
+        let homePageSubTitle = app.windows.webViews.groups.containing(.staticText, identifier: "Your protection, our priority.").element
         XCTAssertTrue(homePageSubTitle.waitForExistence(timeout: UITests.Timeouts.elementExistence))
     }
 

--- a/UITests/OnboardingUITests.swift
+++ b/UITests/OnboardingUITests.swift
@@ -101,9 +101,10 @@ final class OnboardingUITests: XCTestCase {
         startBrowsingButton.click()
 
         // AfterOnboarding
-        let duckduckgoPrivacySimplifiedWindow = app.windows["DuckDuckGo — Your protection, our priority."]
-        XCTAssertTrue(duckduckgoPrivacySimplifiedWindow.webViews["DuckDuckGo — Your protection, our priority."].waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        XCTAssertTrue(duckduckgoPrivacySimplifiedWindow.buttons["NavigationBarViewController.optionsButton"].isEnabled)
+        let ddgLogo = app.windows.webViews.groups.containing(.image, identifier:"DuckDuckGo Logo").element
+        XCTAssertTrue(ddgLogo.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        let homePageSubTitle = app.windows.webViews.groups.containing(.staticText, identifier:"Your protection, our priority.").element
+        XCTAssertTrue(homePageSubTitle.waitForExistence(timeout: UITests.Timeouts.elementExistence))
     }
 
     func resetApplicationData() throws {

--- a/UITests/PinnedTabsTests.swift
+++ b/UITests/PinnedTabsTests.swift
@@ -158,7 +158,7 @@ class PinnedTabsTests: XCTestCase {
         let newApp = XCUIApplication()
         newApp.launch()
 
-        sleep(2)
+        sleep(10) // This was increased from two to ten, because slower VMs needed more time to re-launch the app.
 
         /// Goes to Page #2 to check the state
         newApp.typeKey("[", modifierFlags: [.command, .shift])

--- a/UITests/PinnedTabsTests.swift
+++ b/UITests/PinnedTabsTests.swift
@@ -157,8 +157,8 @@ class PinnedTabsTests: XCTestCase {
     private func assertPinnedTabsRestoredState() {
         let newApp = XCUIApplication()
         newApp.launch()
-
-        sleep(10) // This was increased from two to ten, because slower VMs needed more time to re-launch the app.
+        _ = newApp.windows.firstMatch.waitForExistence(timeout: 30.0)
+//        sleep(10) // This was increased from two to ten, because slower VMs needed more time to re-launch the app.
 
         /// Goes to Page #2 to check the state
         newApp.typeKey("[", modifierFlags: [.command, .shift])

--- a/UITests/PinnedTabsTests.swift
+++ b/UITests/PinnedTabsTests.swift
@@ -157,8 +157,8 @@ class PinnedTabsTests: XCTestCase {
     private func assertPinnedTabsRestoredState() {
         let newApp = XCUIApplication()
         newApp.launch()
-        _ = newApp.windows.firstMatch.waitForExistence(timeout: 30.0)
-//        sleep(10) // This was increased from two to ten, because slower VMs needed more time to re-launch the app.
+        newApp.typeKey("n", modifierFlags: .command)
+        sleep(10) // This was increased from two to ten, because slower VMs needed more time to re-launch the app.
 
         /// Goes to Page #2 to check the state
         newApp.typeKey("[", modifierFlags: [.command, .shift])


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208683961540871/f
Tech Design URL:
CC:

**Description**:
Fixes onboarding testing failing and pinned tabs tests failing on macOS 13.

✅ https://github.com/duckduckgo/macos-browser/actions/runs/11689899520

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
