### PR TITLE
Restore calling run-publish-dmg-release on tag_release.yml failure

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -103,6 +103,19 @@ jobs:
           is_prerelease:"${{ env.prerelease }}" \
           is_scheduled_release:"${{ github.event_name == 'schedule' }}"
 
+    - name: Create Publish DMG Release task on failure
+      id: create-publish-dmg-task-on-failure
+      if: failure() && env.internal-release-bump == 'true'
+      env:
+        ASANA_TASK_URL: ${{ env.asana-task-url }}
+        ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+      run: |
+        bundle exec fastlane run asana_create_action_item \
+          task_url:"${{ env.asana-task-url }}" \
+          template_name:"run-publish-dmg-release" \
+          github_handle:"${{ github.actor }}" \
+          is_scheduled_release:"${{ github.event_name == 'schedule' }}"
+
     - name: Store created tag in a file artifact
       run: echo ${{ steps.tag-release.outputs.tag }} > .github/tag
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 02d98693a58a9c76cdc0425dda38ca059eecf61c
-  tag: 0.11.0
+  revision: 1e74c8fc23acb18f896f766ac008a6707847190d
+  tag: 0.11.2
   specs:
-    fastlane-plugin-ddg_apple_automation (0.11.0)
+    fastlane-plugin-ddg_apple_automation (0.11.2)
       asana
       climate_control
       httpparty

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '0.11.0'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '0.11.2'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1208705384164248/f

**Description**:
run-publish-dmg-release task needs to be created directly from the GHA workflow because we want to
address the actual workflow failure (i.e. when the dependent workflow can't run). This is impossible
to check from the fastlane action.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
