### PR TITLE
Send auth state with sync unexpectedly disabled pixel

### DIFF
--- a/DuckDuckGo/Sync/SyncDiagnosisHelper.swift
+++ b/DuckDuckGo/Sync/SyncDiagnosisHelper.swift
@@ -21,6 +21,10 @@ import DDGSync
 import PixelKit
 
 struct SyncDiagnosisHelper {
+    private enum Const {
+        static let authStatePixelParamKey = "authState"
+    }
+
     private let userDefaults = UserDefaults.standard
     private let syncService: DDGSyncing
 
@@ -46,7 +50,11 @@ struct SyncDiagnosisHelper {
             // Nil value means sync was never on in the first place. So don't fire in this case.
             if syncManuallyDisabled == false,
                !syncWasDisabledUnexpectedlyPixelFired {
-                PixelKit.fire(DebugEvent(GeneralPixel.syncDebugWasDisabledUnexpectedly), frequency: .dailyAndCount)
+                PixelKit.fire(
+                    DebugEvent(GeneralPixel.syncDebugWasDisabledUnexpectedly),
+                    frequency: .dailyAndCount,
+                    withAdditionalParameters: [Const.authStatePixelParamKey : syncService.authState.rawValue]
+                )
                 syncWasDisabledUnexpectedlyPixelFired = true
             }
         } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208706849695203/f

**Description**:

Adds an `authState` parameter to the `m_mac_sync_was_disabled_unexpectedly` pixel.

**Steps to test this PR**:

1. (just for testing) Add a line of code to easily deactivate sync in a non-typical way (e.g by calling try await syncService.deleteAccount() from updateDeviceName) so you can mimic unexpected deactivation.
2. Make sure Sync is enabled
3. Trigger the fake unexpected deactivation
4. Minimize the browser and maximise again.
5. Make sure the m_mac_sync_was_disabled_unexpectedly pixel is fired.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
