### PR TITLE
Respect new tab order preference

### DIFF
--- a/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -398,6 +398,9 @@ final class TabCollectionViewModel: NSObject {
     }
 
     func insertOrAppendNewTab(_ content: Tab.TabContent = .newtab, selected: Bool = true) {
+        if selectDisplayableTabIfPresent(content) {
+            return
+        }
         insertOrAppend(tab: Tab(content: content, shouldLoadInBackground: true, burnerMode: burnerMode), selected: selected)
     }
 

--- a/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -221,7 +221,7 @@ extension WindowControllersManager {
         } else {
             let newTab = Tab(content: url.map { .url($0, source: source) } ?? .newtab, shouldLoadInBackground: true, burnerMode: tabCollectionViewModel.burnerMode)
             newTab.setContent(url.map { .contentFromURL($0, source: source) } ?? .newtab)
-            tabCollectionViewModel.append(tab: newTab)
+            tabCollectionViewModel.insertOrAppend(tab: newTab, selected: true)
         }
     }
 

--- a/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -235,7 +235,7 @@ extension WindowControllersManager {
 
         let viewController = windowController.mainViewController
         let tabCollectionViewModel = viewController.tabCollectionViewModel
-        tabCollectionViewModel.appendNewTab(with: content)
+        tabCollectionViewModel.insertOrAppendNewTab(content)
         windowController.window?.orderFront(nil)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1208714110522205/f

**Description**:
Respect new tab order preference when using WindowManager.showTab

**Steps to test this PR**:
1. Change the Tabs settings to "Add to the right of the current tab"
2. Add a couple tabs to your tabbar 
3. Select the first tab
4. Click the ... to right menu
5. Open settings (make sure there was no settings opened before)
6. Check if settings is opened in between your tabs respecting the preference
7. Enable AI Chat shortcut
8. Select the first tab, and repeat
9. Try this with other shortcuts like "go to settings" from the appearance menu
10. Change the tab settings to "Add to the right of the current tab"
11. Repeat the steps above checking if the tab now is the last one in the tab bar
