### PR TITLE
Update permission string for location popup

### DIFF
--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -546,9 +546,12 @@ struct UserText {
     static let failedToOpenExternally = NSLocalizedString("open.externally.failed", value: "The app required to open that link can’t be found", comment: "’Link’ is link on a website, it couldn't be opened due to the required app not being found")
 
     // MARK: Permission
+    static let locationPermissionAuthorizationFormat = NSLocalizedString("permission.authorization.location",
+                                                                         value: "“%@“ website would like to use your current location.",
+                                                                         comment: "Popover asking for domain %@ to use location")
     static let devicePermissionAuthorizationFormat = NSLocalizedString("permission.authorization.format",
                                                                        value: "Allow “%@“ to use your %@?",
-                                                                       comment: "Popover asking for domain %@ to use camera/mic/location (%@)")
+                                                                       comment: "Popover asking for domain %@ to use camera/mic (%@)")
     static let popupWindowsPermissionAuthorizationFormat = NSLocalizedString("permission.authorization.popups.format",
                                                                              value: "Allow “%@“ to open PopUp Window?",
                                                                              comment: "Popover asking for domain %@ to open Popup Window")

--- a/DuckDuckGo/Localizable.xcstrings
+++ b/DuckDuckGo/Localizable.xcstrings
@@ -43547,7 +43547,7 @@
       }
     },
     "permission.authorization.format" : {
-      "comment" : "Popover asking for domain %@ to use camera/mic/location (%@)",
+      "comment" : "Popover asking for domain %@ to use camera/mic (%@)",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
@@ -43602,6 +43602,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Открыть сайту %1$@ доступ (%2$@)?"
+          }
+        }
+      }
+    },
+    "permission.authorization.location" : {
+      "comment" : "Popover asking for domain %@ to use location",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "“%@“ website would like to use your current location."
           }
         }
       }

--- a/DuckDuckGo/Permissions/View/PermissionAuthorizationViewController.swift
+++ b/DuckDuckGo/Permissions/View/PermissionAuthorizationViewController.swift
@@ -93,7 +93,7 @@ final class PermissionAuthorizationViewController: NSViewController {
         else { return }
 
         switch query.permissions[0] {
-        case .camera, .microphone, .geolocation:
+        case .camera, .microphone:
             descriptionLabel.stringValue = String(format: UserText.devicePermissionAuthorizationFormat,
                                                   query.domain,
                                                   query.permissions.localizedDescription.lowercased())
@@ -108,6 +108,8 @@ final class PermissionAuthorizationViewController: NSViewController {
             descriptionLabel.stringValue = String(format: UserText.externalSchemePermissionAuthorizationFormat,
                                                   query.domain,
                                                   query.permissions.localizedDescription)
+        case .geolocation:
+            descriptionLabel.stringValue = String(format: UserText.locationPermissionAuthorizationFormat, query.domain)
         }
         alwaysAllowCheckbox.title = UserText.permissionAlwaysAllowOnDomainCheckbox
         domainNameLabel.stringValue = query.domain.isEmpty ? "" : "“" + query.domain + "”"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208705844672773/f
Tech Design URL:
CC:

**Description**:
Updates the permission string on the location popup.

**Steps to test this PR**:
1. Go to maps.google.com, tap on the use my location button
2. Check that the new format is the following: `www.site.com website would like to use your current location.`

![Screenshot 2024-11-07 at 9 39 47 AM](https://github.com/user-attachments/assets/cf1d9b93-644e-4672-832f-56735480a328)


**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
