### PR TITLE
Do not use suggestion view controller visibility to set suggestion

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -554,7 +554,6 @@ final class AddressBarTextField: NSTextField {
             Logger.general.error("AddressBarTextField: Window not available")
             return
         }
-        guard suggestionWindow.isVisible else { return }
 
         guard let selectedSuggestionViewModel else {
             if let originalStringValue = suggestionContainerViewModel?.userStringValue {

--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -555,6 +555,8 @@ final class AddressBarTextField: NSTextField {
             return
         }
 
+        if !suggestionWindow.isVisible && selectedSuggestionViewModel == nil { return }
+
         guard let selectedSuggestionViewModel else {
             if let originalStringValue = suggestionContainerViewModel?.userStringValue {
                 self.value = Value(stringValue: originalStringValue, userTyped: true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208714740989844/f
Tech Design URL:
CC:

**Description**:
The problem seems to be a race condition when the selected suggestion view model is updated and the suggestion view. The solution I found was not to check the window visibility when setting the `.suggestion` value.

**Steps to test this PR**:
1. Search for amazon.com and load the site
2. Open a new tab and press `a`
3. amazon.com should be autocompleted

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
