### PR TITLE
DuckPlayer Overlay Pixels

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -2992,6 +2992,10 @@
 		D64A5FF92AEA5C2B00B6D6E7 /* HomeButtonMenuFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64A5FF72AEA5C2B00B6D6E7 /* HomeButtonMenuFactory.swift */; };
 		D6BC8AC62C5A95AA0025375B /* DuckPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D6BC8AC52C5A95AA0025375B /* DuckPlayer */; };
 		D6BC8AC82C5A95B10025375B /* DuckPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D6BC8AC72C5A95B10025375B /* DuckPlayer */; };
+		D6E0ACB12CE36DCA005D3486 /* DuckPlayerOverlayPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E0ACB02CE36DC4005D3486 /* DuckPlayerOverlayPixels.swift */; };
+		D6E0ACB22CE36DCA005D3486 /* DuckPlayerOverlayPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E0ACB02CE36DC4005D3486 /* DuckPlayerOverlayPixels.swift */; };
+		D6E0ACB42CE36FB0005D3486 /* DuckPlayerOverlayPixelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E0ACB32CE36FA8005D3486 /* DuckPlayerOverlayPixelsTests.swift */; };
+		D6E0ACB52CE36FB0005D3486 /* DuckPlayerOverlayPixelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E0ACB32CE36FA8005D3486 /* DuckPlayerOverlayPixelsTests.swift */; };
 		EA0BA3A9272217E6002A0B6C /* ClickToLoadUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0BA3A8272217E6002A0B6C /* ClickToLoadUserScript.swift */; };
 		EA18D1CA272F0DC8006DC101 /* social_images in Resources */ = {isa = PBXBuildFile; fileRef = EA18D1C9272F0DC8006DC101 /* social_images */; };
 		EA8AE76A279FBDB20078943E /* ClickToLoadTDSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8AE769279FBDB20078943E /* ClickToLoadTDSTests.swift */; };
@@ -4836,6 +4840,8 @@
 		CDE248A62C821FFE00F9399D /* filterSet.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = filterSet.json; sourceTree = "<group>"; };
 		CDE248A72C821FFE00F9399D /* PhishingDetectionStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhishingDetectionStateManager.swift; sourceTree = "<group>"; };
 		D64A5FF72AEA5C2B00B6D6E7 /* HomeButtonMenuFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeButtonMenuFactory.swift; sourceTree = "<group>"; };
+		D6E0ACB02CE36DC4005D3486 /* DuckPlayerOverlayPixels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerOverlayPixels.swift; sourceTree = "<group>"; };
+		D6E0ACB32CE36FA8005D3486 /* DuckPlayerOverlayPixelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerOverlayPixelsTests.swift; sourceTree = "<group>"; };
 		EA0BA3A8272217E6002A0B6C /* ClickToLoadUserScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClickToLoadUserScript.swift; sourceTree = "<group>"; };
 		EA18D1C9272F0DC8006DC101 /* social_images */ = {isa = PBXFileReference; lastKnownFileType = folder; path = social_images; sourceTree = "<group>"; };
 		EA8AE769279FBDB20078943E /* ClickToLoadTDSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickToLoadTDSTests.swift; sourceTree = "<group>"; };
@@ -5588,6 +5594,7 @@
 				315AA06F28CA5CC800200030 /* YoutubePlayerNavigationHandler.swift */,
 				31F28C4C28C8EEC500119F70 /* YoutubePlayerUserScript.swift */,
 				31F28C4E28C8EEC500119F70 /* YoutubeOverlayUserScript.swift */,
+				D6E0ACB02CE36DC4005D3486 /* DuckPlayerOverlayPixels.swift */,
 			);
 			path = YoutubePlayer;
 			sourceTree = "<group>";
@@ -5679,6 +5686,7 @@
 		376718FE28E58504003A2A15 /* YoutubePlayer */ = {
 			isa = PBXGroup;
 			children = (
+				D6E0ACB32CE36FA8005D3486 /* DuckPlayerOverlayPixelsTests.swift */,
 				3199AF812C80736B003AEBDC /* DuckPlayerOnboardingLocationValidatorTests.swift */,
 				3714B1E828EDBAAB0056C57A /* DuckPlayerTests.swift */,
 				567DA94429E95C3F008AC5EE /* YoutubeOverlayUserScriptTests.swift */,
@@ -11306,6 +11314,7 @@
 				3706FB2F293F65D500E42796 /* HomePageRecentlyVisitedModel.swift in Sources */,
 				C1935A152C88F958001AD72D /* SyncPromoView.swift in Sources */,
 				C126B35B2C820924005DC2A3 /* FreemiumDebugMenu.swift in Sources */,
+				D6E0ACB22CE36DCA005D3486 /* DuckPlayerOverlayPixels.swift in Sources */,
 				3707C718294B5D0F00682A9F /* AdClickAttributionTabExtension.swift in Sources */,
 				31EF1E812B63FFB800E6DB17 /* DataBrokerProtectionManager.swift in Sources */,
 				3706FEBA293F6EFF00E42796 /* BWStatus.swift in Sources */,
@@ -12125,6 +12134,7 @@
 				3706FE27293F661700E42796 /* AppPrivacyConfigurationTests.swift in Sources */,
 				B626A7652992506A00053070 /* SerpHeadersNavigationResponderTests.swift in Sources */,
 				9F6434712BECBA2800D2D8A0 /* SubscriptionRedirectManagerTests.swift in Sources */,
+				D6E0ACB52CE36FB0005D3486 /* DuckPlayerOverlayPixelsTests.swift in Sources */,
 				9F26060C2B85C20B00819292 /* AddEditBookmarkDialogViewModelTests.swift in Sources */,
 				567A23DF2C89980A0010F66C /* OnboardingNavigationDelegateTests.swift in Sources */,
 				562532A12BC069190034D316 /* ZoomPopoverViewModelTests.swift in Sources */,
@@ -13334,6 +13344,7 @@
 				EE66666F2B56EDE4001D898D /* VPNLocationsHostingViewController.swift in Sources */,
 				37CC53EC27E8A4D10028713D /* PreferencesDataClearingView.swift in Sources */,
 				4B0135CE2729F1AA00D54834 /* NSPasteboardExtension.swift in Sources */,
+				D6E0ACB12CE36DCA005D3486 /* DuckPlayerOverlayPixels.swift in Sources */,
 				85707F31276A7DCA00DC0649 /* OnboardingViewModel.swift in Sources */,
 				85AC3B0525D6B1D800C7D2AA /* ScriptSourceProviding.swift in Sources */,
 				848648A12C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */,
@@ -13664,6 +13675,7 @@
 				B630E7FE29C887ED00363609 /* NSErrorAdditionalInfo.swift in Sources */,
 				370270C02C78EB13002E44E4 /* HomePageSettingsModelTests.swift in Sources */,
 				4B9292BB2667103100AD2C21 /* BookmarkNodeTests.swift in Sources */,
+				D6E0ACB42CE36FB0005D3486 /* DuckPlayerOverlayPixelsTests.swift in Sources */,
 				4B0219A825E0646500ED7DEA /* WebsiteDataStoreTests.swift in Sources */,
 				AAC9C01E24CB6BEB00AD1325 /* TabCollectionViewModelTests.swift in Sources */,
 				56CE77612C7DFCF800AC1ED2 /* OnboardingSuggestedSearchesProviderTests.swift in Sources */,

--- a/DuckDuckGo/InfoPlist.xcstrings
+++ b/DuckDuckGo/InfoPlist.xcstrings
@@ -67,55 +67,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Lade Fotos und Videos hoch"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Allows you to upload photographs and videos"
+            "value" : "Lets websites ask permission to use your camera for video calls, recording and uploading videos, or taking and uploading photos."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Te permite subir fotos y vídeos"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vous permet de télécharger des photos et des vidéos"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Consente il caricamento di foto e video"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Hiermee kun je foto's en video's uploaden"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Umożliwia przesyłanie zdjęć i filmów"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permite-lhe carregar fotografias e vídeos"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Позволяет загружать фото и видео"
           }
         }
@@ -127,55 +127,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Speichere heruntergeladene Dateien in diesem Ordner."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Allows you to save downloaded files to this folder."
+            "value" : "Lets you save files to the Desktop folder on your computer."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Te permite guardar los archivos descargados en esta carpeta."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permet d'enregistrer les fichiers téléchargés dans ce dossier."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Consente di salvare in questa cartella i file scaricati."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Hiermee kun je gedownloade bestanden opslaan in deze map."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Umożliwia zapisywanie pobranych plików w tym folderze."
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permite guardar ficheiros transferidos nesta pasta."
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Позволяет сохранять загруженные файлы в эту папку."
           }
         }
@@ -187,55 +187,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Speichere heruntergeladene Dateien in diesem Ordner."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Allows you to save downloaded files to this folder."
+            "value" : "Lets you save files to the Documents folder on your computer."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Te permite guardar los archivos descargados en esta carpeta."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permet d'enregistrer les fichiers téléchargés dans ce dossier."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Consente di salvare in questa cartella i file scaricati."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Hiermee kun je gedownloade bestanden opslaan in deze map."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Umożliwia zapisywanie pobranych plików w tym folderze."
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permite guardar ficheiros transferidos nesta pasta."
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Позволяет сохранять загруженные файлы в эту папку."
           }
         }
@@ -247,55 +247,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Speichere heruntergeladene Dateien in diesem Ordner."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Allows you to save downloaded files to this folder."
+            "value" : "Lets you save files to the Downloads folder on your computer."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Te permite guardar los archivos descargados en esta carpeta."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permet d'enregistrer les fichiers téléchargés dans ce dossier."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Consente di salvare in questa cartella i file scaricati."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Hiermee kun je gedownloade bestanden opslaan in deze map."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Umożliwia zapisywanie pobranych plików w tym folderze."
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permite guardar ficheiros transferidos nesta pasta."
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Позволяет сохранять загруженные файлы в эту папку."
           }
         }
@@ -367,55 +367,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Teile deinen Standort"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Allows you to share your geolocation"
+            "value" : "Lets websites ask permission to use your location to improve search results, provide weather and directions, or show nearby map locations."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Te permite compartir tu ubicación"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vous permet de partager votre géolocalisation"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Consente la condivisione della tua geolocalizzazione"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Hiermee kun je je geolocatie delen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Umożliwia udostępnianie geolokalizacji"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permite-te partilhar a tua localização geográfica"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Позволяет делиться геопозицией"
           }
         }
@@ -423,7 +423,7 @@
     },
     "NSLocationWhenInUseUsageDescription" : {
       "comment" : "Privacy - Location When In Use Usage Description",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -487,55 +487,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Teile deine Aufzeichnungen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Allows you to share recordings"
+            "value" : "Lets websites ask permission to use your microphone for audio and video calls or for recording and uploading audio."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Te permite compartir grabaciones"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vous permet de partager des enregistrements"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Consente la condivisione delle registrazioni"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Hiermee kun je opnames delen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Umożliwia udostępnianie nagrań"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Permite-lhe partilhar gravações"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Позволяет делиться аудиозаписями"
           }
         }

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -135,7 +135,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case duckPlayerNewTabSettingsOff
     case duckPlayerContingencySettingsDisplayed
     case duckPlayerContingencyLearnMoreClicked
-    
+
     // Temporary Overlay Pixels
     case duckPlayerYouTubeOverlayNavigationBack
     case duckPlayerYouTubeOverlayNavigationRefresh
@@ -143,7 +143,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case duckPlayerYouTubeOverlayNavigationOutsideYoutube
     case duckPlayerYouTubeOverlayNavigationClosed
     case duckPlayerYouTubeNavigationIdle30
-    
+
     // Dashboard
     case dashboardProtectionAllowlistAdd(triggerOrigin: String?)
     case dashboardProtectionAllowlistRemove(triggerOrigin: String?)
@@ -1124,7 +1124,7 @@ enum GeneralPixel: PixelKitEventV2 {
         case .pageRefreshThreeTimesWithin20Seconds: return "m_mac_reload-three-times-within-20-seconds"
         case .siteNotWorkingShown: return "m_mac_site-not-working_shown"
         case .siteNotWorkingWebsiteIsBroken: return "m_mac_site-not-working_website-is-broken"
-            
+
         }
     }
 

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -135,7 +135,15 @@ enum GeneralPixel: PixelKitEventV2 {
     case duckPlayerNewTabSettingsOff
     case duckPlayerContingencySettingsDisplayed
     case duckPlayerContingencyLearnMoreClicked
-
+    
+    // Temporary Overlay Pixels
+    case duckPlayerYouTubeOverlayNavigationBack
+    case duckPlayerYouTubeOverlayNavigationRefresh
+    case duckPlayerYouTubeNavigationWithinYouTube
+    case duckPlayerYouTubeOverlayNavigationOutsideYoutube
+    case duckPlayerYouTubeOverlayNavigationClosed
+    case duckPlayerYouTubeNavigationIdle30
+    
     // Dashboard
     case dashboardProtectionAllowlistAdd(triggerOrigin: String?)
     case dashboardProtectionAllowlistRemove(triggerOrigin: String?)
@@ -659,6 +667,21 @@ enum GeneralPixel: PixelKitEventV2 {
             return "duckplayer_mac_contingency_settings-displayed"
         case .duckPlayerContingencyLearnMoreClicked:
             return "duckplayer_mac_contingency_learn-more-clicked"
+
+        // Duck Player Temporary Overlay Pixels
+        case .duckPlayerYouTubeOverlayNavigationBack:
+            return "duckplayer_youtube_overlay_navigation_back"
+        case .duckPlayerYouTubeOverlayNavigationRefresh:
+            return "duckplayer_youtube_overlay_navigation_refresh"
+        case .duckPlayerYouTubeNavigationWithinYouTube:
+            return "duckplayer_youtube_overlay_navigation_within-youtube"
+        case .duckPlayerYouTubeOverlayNavigationOutsideYoutube:
+            return "duckplayer_youtube_overlay_navigation_outside-youtube"
+        case .duckPlayerYouTubeOverlayNavigationClosed:
+            return "duckplayer_youtube_overlay_navigation_closed"
+        case .duckPlayerYouTubeNavigationIdle30:
+            return "duckplayer_youtube_overlay_idle-30"
+
         case .dashboardProtectionAllowlistAdd:
             return "mp_wla"
         case .dashboardProtectionAllowlistRemove:
@@ -1101,6 +1124,7 @@ enum GeneralPixel: PixelKitEventV2 {
         case .pageRefreshThreeTimesWithin20Seconds: return "m_mac_reload-three-times-within-20-seconds"
         case .siteNotWorkingShown: return "m_mac_site-not-working_shown"
         case .siteNotWorkingWebsiteIsBroken: return "m_mac_site-not-working_website-is-broken"
+            
         }
     }
 

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -215,6 +215,11 @@ extension DuckPlayerTabExtension: NavigationResponder {
                 duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)
             }
         }
+        
+        // Fire DuckPlayer temporary pixels on navigating outside Youtube
+        if let url = navigationAction.request.url, !url.isYoutube {
+            duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)
+        }
 
         // when in Private Player, don't directly reload current URL when it‘s a Private Player target URL
         if case .reload = navigationAction.navigationType,
@@ -396,6 +401,8 @@ extension DuckPlayerTabExtension: NavigationResponder {
     @MainActor
     func navigationDidFinish(_ navigation: Navigation) {
         setUpYoutubeScriptsIfNeeded(for: navigation.url)
+        
+        
     }
 
 }

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -182,7 +182,7 @@ extension DuckPlayerTabExtension: NewWindowPolicyDecisionMaker {
 }
 
 extension DuckPlayerTabExtension: NavigationResponder {
-
+    // swiftlint:disable:next cyclomatic_complexity
     @MainActor
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
         // only proceed when Private Player is enabled
@@ -215,7 +215,7 @@ extension DuckPlayerTabExtension: NavigationResponder {
                 duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)
             }
         }
-        
+
         // Fire DuckPlayer temporary pixels on navigating outside Youtube
         if let url = navigationAction.request.url, !url.isYoutube {
             duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)
@@ -401,8 +401,7 @@ extension DuckPlayerTabExtension: NavigationResponder {
     @MainActor
     func navigationDidFinish(_ navigation: Navigation) {
         setUpYoutubeScriptsIfNeeded(for: navigation.url)
-        
-        
+
     }
 
 }

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -208,14 +208,14 @@ extension DuckPlayerTabExtension: NavigationResponder {
                 navigator.load(URLRequest(url: .duckPlayer(videoID, timestamp: timestamp)))
             }
         }
-        
+
         // Fire DuckPlayer Temporary Pixels on Reload
         if case .reload = navigationAction.navigationType {
             if let url = navigationAction.request.url {
                 duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)
             }
         }
-        
+
         // when in Private Player, don't directly reload current URL when it‘s a Private Player target URL
         if case .reload = navigationAction.navigationType,
            navigationAction.url.isDuckPlayer {
@@ -281,7 +281,7 @@ extension DuckPlayerTabExtension: NavigationResponder {
             webView.goBack()
             webView.load(URLRequest(url: .duckPlayer(videoID, timestamp: timestamp)))
         }
-        
+
         // Fire DuckPlayer Overlay Temporary Pixels
         if let url = navigation.request.url {
             duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -182,7 +182,7 @@ extension DuckPlayerTabExtension: NewWindowPolicyDecisionMaker {
 }
 
 extension DuckPlayerTabExtension: NavigationResponder {
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable cyclomatic_complexity
     @MainActor
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
         // only proceed when Private Player is enabled
@@ -258,6 +258,7 @@ extension DuckPlayerTabExtension: NavigationResponder {
         // Navigating to a Youtube URL
         return handleYoutubeNavigation(for: navigationAction)
     }
+    // swiftlint:enable cyclomatic_complexity
 
     @MainActor
     private func handleYoutubeNavigation(for navigationAction: NavigationAction) -> NavigationActionPolicy? {

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -401,7 +401,6 @@ extension DuckPlayerTabExtension: NavigationResponder {
     @MainActor
     func navigationDidFinish(_ navigation: Navigation) {
         setUpYoutubeScriptsIfNeeded(for: navigation.url)
-
     }
 
 }

--- a/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
+++ b/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
@@ -20,7 +20,7 @@ import PixelKit
 protocol DuckPlayerOverlayPixelFiring {
 
     var pixelFiring: PixelFiring? { get set }
-    var navigationHistory: [URL] { get set }
+    var navigationHistory: [URL] { get set }    
 
     func handleNavigationAndFirePixels(url: URL?, duckPlayerMode: DuckPlayerMode)
 }
@@ -38,12 +38,6 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
          timeoutInterval: TimeInterval = 30.0) {
         self.pixelFiring = pixelFiring
         self.idleTimeInterval = timeoutInterval
-    }
-
-    // Method to reset the idle timer
-    private func resetIdleTimer() {
-        idleTimer?.invalidate()
-        idleTimer = nil
     }
 
     func handleNavigationAndFirePixels(url: URL?, duckPlayerMode: DuckPlayerMode) {
@@ -85,16 +79,22 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
             } else if previousURL.isYoutubeWatch && !currentURL.isYoutube && !currentURL.isDuckPlayer {
                 // Navigation outside YouTube
                 pixelFiring?.fire(GeneralPixel.duckPlayerYouTubeOverlayNavigationOutsideYoutube)
+                navigationHistory.removeAll()
             }
         }
 
         // Truncation logic: Remove all URLs up to the last occurrence of the current URL in normalized form
-        if let lastOccurrenceIndex = (0..<navigationHistory.count - 1).last(where: { navigationHistory[$0].forComparison() == comparisonURL }) {
-            navigationHistory = Array(navigationHistory.prefix(upTo: lastOccurrenceIndex + 1))
+        if navigationHistory.count > 0 {
+            if let lastOccurrenceIndex = (0..<navigationHistory.count - 1).last(where: { navigationHistory[$0].forComparison() == comparisonURL }) {
+                navigationHistory = Array(navigationHistory.prefix(upTo: lastOccurrenceIndex + 1))
+            }
         }
-
-        // Cancel and reset the idle timer whenever a new navigation occurs
-        resetIdleTimer()
+        
     }
+    
+    private func firePixel(_ pixel: PixelKitEventV2) {
+        pixelFiring?.fire(pixel)
+    }
+    
 
 }

--- a/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
+++ b/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
@@ -63,7 +63,8 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
         var isReload = false
         // Check for a reload condition: when current videoID is the same as Previous
         if let currentVideoID = currentURL.youtubeVideoParams?.videoID,
-           let previousVideoID = previousURL.youtubeVideoParams?.videoID {
+           let previousVideoID = previousURL.youtubeVideoParams?.videoID,
+           !previousURL.isDuckPlayer, !currentURL.isDuckPlayer {
             isReload = currentVideoID == previousVideoID
         }
 
@@ -81,7 +82,7 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
             } else if previousURL.isYoutubeWatch && currentURL.isYoutube {
                 // Forward navigation within YouTube (including non-video URLs)
                 pixelFiring?.fire(GeneralPixel.duckPlayerYouTubeNavigationWithinYouTube)
-            } else if previousURL.isYoutubeWatch && !currentURL.isYoutube {
+            } else if previousURL.isYoutubeWatch && !currentURL.isYoutube && !currentURL.isDuckPlayer {
                 // Navigation outside YouTube
                 pixelFiring?.fire(GeneralPixel.duckPlayerYouTubeOverlayNavigationOutsideYoutube)
             }

--- a/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
+++ b/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
@@ -1,0 +1,99 @@
+//
+//  DuckPlayerOverlayPixels.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import PixelKit
+
+protocol DuckPlayerOverlayPixelFiring {
+
+    var pixelFiring: PixelFiring? { get set }
+    var navigationHistory: [URL] { get set }
+
+    func handleNavigationAndFirePixels(url: URL?, duckPlayerMode: DuckPlayerMode)
+}
+
+final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
+
+    var pixelFiring: PixelFiring?
+    var navigationHistory: [URL] = []
+
+    private var idleTimer: Timer?
+    private var idleTimeInterval: TimeInterval
+
+    init(pixelFiring: PixelFiring? = PixelKit.shared,
+         navigationHistory: [URL] = [],
+         timeoutInterval: TimeInterval = 30.0) {
+        self.pixelFiring = pixelFiring
+        self.idleTimeInterval = timeoutInterval
+    }
+
+    // Method to reset the idle timer
+    private func resetIdleTimer() {
+        idleTimer?.invalidate()
+        idleTimer = nil
+    }
+
+    func handleNavigationAndFirePixels(url: URL?, duckPlayerMode: DuckPlayerMode) {
+        guard let url = url else { return }
+        let comparisonURL = url.forComparison()
+
+        // Only append the URL if it's different from the last entry in normalized form
+        navigationHistory.append(comparisonURL)
+
+        // DuckPlayer is in Ask Mode, there's navigation history, and last URL is a YouTube Watch Video
+        guard duckPlayerMode == .alwaysAsk,
+              navigationHistory.count > 1,
+              let currentURL = navigationHistory.last,
+              let previousURL = navigationHistory.dropLast().last,
+              previousURL.isYoutubeWatch else { return }
+
+        var isReload = false
+        // Check for a reload condition: when current videoID is the same as Previous
+        if let currentVideoID = currentURL.youtubeVideoParams?.videoID,
+           let previousVideoID = previousURL.youtubeVideoParams?.videoID {
+            isReload = currentVideoID == previousVideoID
+        }
+
+        // Fire the reload pixel if this is a reload navigation
+        if isReload {
+            pixelFiring?.fire(GeneralPixel.duckPlayerYouTubeOverlayNavigationRefresh)
+        } else {
+            // Determine if it’s a back navigation by looking further back in history
+            let isBackNavigation = navigationHistory.count > 2 &&
+                                   navigationHistory[navigationHistory.count - 3].forComparison() == currentURL.forComparison()
+
+            // Fire the appropriate pixel based on navigation type
+            if isBackNavigation {
+                pixelFiring?.fire(GeneralPixel.duckPlayerYouTubeOverlayNavigationBack)
+            } else if previousURL.isYoutubeWatch && currentURL.isYoutube {
+                // Forward navigation within YouTube (including non-video URLs)
+                pixelFiring?.fire(GeneralPixel.duckPlayerYouTubeNavigationWithinYouTube)
+            } else if previousURL.isYoutubeWatch && !currentURL.isYoutube {
+                // Navigation outside YouTube
+                pixelFiring?.fire(GeneralPixel.duckPlayerYouTubeOverlayNavigationOutsideYoutube)
+            }
+        }
+
+        // Truncation logic: Remove all URLs up to the last occurrence of the current URL in normalized form
+        if let lastOccurrenceIndex = (0..<navigationHistory.count - 1).last(where: { navigationHistory[$0].forComparison() == comparisonURL }) {
+            navigationHistory = Array(navigationHistory.prefix(upTo: lastOccurrenceIndex + 1))
+        }
+
+        // Cancel and reset the idle timer whenever a new navigation occurs
+        resetIdleTimer()
+    }
+
+}

--- a/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
+++ b/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
@@ -20,7 +20,7 @@ import PixelKit
 protocol DuckPlayerOverlayPixelFiring {
 
     var pixelFiring: PixelFiring? { get set }
-    var navigationHistory: [URL] { get set }    
+    var navigationHistory: [URL] { get set }
 
     func handleNavigationAndFirePixels(url: URL?, duckPlayerMode: DuckPlayerMode)
 }
@@ -89,12 +89,11 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
                 navigationHistory = Array(navigationHistory.prefix(upTo: lastOccurrenceIndex + 1))
             }
         }
-        
+
     }
-    
+
     private func firePixel(_ pixel: PixelKitEventV2) {
         pixelFiring?.fire(pixel)
     }
-    
 
 }

--- a/UnitTests/YoutubePlayer/DuckPlayerOverlayPixelsTests.swift
+++ b/UnitTests/YoutubePlayer/DuckPlayerOverlayPixelsTests.swift
@@ -1,0 +1,133 @@
+//
+//  DuckPlayerOverlayPixelsTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import PixelKit
+@testable import DuckDuckGo_Privacy_Browser
+
+final class PixelFiringMock: PixelFiring {
+
+    static var lastPixelsFired = [PixelKitEventV2]()
+
+    static func tearDown() {
+        lastPixelsFired.removeAll()
+    }
+
+    func fire(_ event: PixelKitEventV2) {
+        Self.lastPixelsFired.append(event)
+    }
+
+    func fire(_ event: PixelKitEventV2, frequency: PixelKit.Frequency) {
+        Self.lastPixelsFired.append(event)
+    }
+}
+
+class DuckPlayerOverlayUsagePixelsTests: XCTestCase {
+
+    var duckPlayerOverlayPixels: DuckPlayerOverlayUsagePixels!
+
+    override func setUp() {
+        super.setUp()
+        PixelFiringMock.tearDown()
+        duckPlayerOverlayPixels = DuckPlayerOverlayUsagePixels(pixelFiring: PixelFiringMock(), timeoutInterval: 3.0)
+    }
+
+    override func tearDown() {
+        PixelFiringMock.tearDown()
+        duckPlayerOverlayPixels = nil
+        super.tearDown()
+    }
+
+    func testRegisterNavigationAppendsURLToHistory() {
+        let testURL1 = URL(string: "https://www.youtube.com/watch?v=example1")!
+        let testURL2 = URL(string: "https://www.youtube.com/playlist?list=PL-example")!
+        let testURL3 = URL(string: "https://www.example.com")!
+
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: testURL1, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: testURL2, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: testURL3, duckPlayerMode: .alwaysAsk)
+
+        XCTAssertEqual(duckPlayerOverlayPixels.navigationHistory.count, 3)
+        XCTAssertEqual(duckPlayerOverlayPixels.navigationHistory[0], testURL1)
+        XCTAssertEqual(duckPlayerOverlayPixels.navigationHistory[1], testURL2)
+        XCTAssertEqual(duckPlayerOverlayPixels.navigationHistory[2], testURL3)
+    }
+
+    func testBackNavigationTriggersBackPixel() {
+        let firstURL = URL(string: "https://www.youtube.com/watch?v=example1")!
+        let secondURL = URL(string: "https://www.youtube.com/watch?v=example2")!
+
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: firstURL, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: secondURL, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: firstURL, duckPlayerMode: .alwaysAsk)
+
+        XCTAssertEqual(PixelFiringMock.lastPixelsFired.last?.name, GeneralPixel.duckPlayerYouTubeOverlayNavigationBack.name)
+    }
+
+    func testReloadNavigationTriggersRefreshPixel() {
+        let testURL = URL(string: "https://www.youtube.com/watch?v=XTWWSS")!
+
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: testURL, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: testURL, duckPlayerMode: .alwaysAsk)
+
+        XCTAssertEqual(PixelFiringMock.lastPixelsFired.last?.name, GeneralPixel.duckPlayerYouTubeOverlayNavigationRefresh.name)
+    }
+
+    func testNavigateWithinYoutubeTriggersWithinYouTubePixel() {
+        let videoURL = URL(string: "https://www.youtube.com/watch?v=example1")!
+        let playlistURL = URL(string: "https://www.youtube.com/playlist?list=PL-example")!
+
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: videoURL, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: playlistURL, duckPlayerMode: .alwaysAsk)
+
+        XCTAssertEqual(PixelFiringMock.lastPixelsFired.last?.name, GeneralPixel.duckPlayerYouTubeNavigationWithinYouTube.name)
+    }
+
+    func testNavigateOutsideYoutubeTriggersOutsideYouTubePixel() {
+        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=example1")!
+        let outsideURL = URL(string: "https://www.example.com")!
+
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: youtubeURL, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: outsideURL, duckPlayerMode: .alwaysAsk)
+
+        XCTAssertEqual(PixelFiringMock.lastPixelsFired.last?.name, GeneralPixel.duckPlayerYouTubeOverlayNavigationOutsideYoutube.name)
+    }
+
+    func testBackNavigationDoesNotTriggerWithinOrOutsideYouTubePixel() {
+        let firstURL = URL(string: "https://www.youtube.com/watch?v=example1")!
+        let secondURL = URL(string: "https://www.youtube.com/watch?v=example2")!
+        let backURL = URL(string: "https://www.youtube.com/watch?v=example1")!
+
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: firstURL, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: secondURL, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: backURL, duckPlayerMode: .alwaysAsk)
+
+        XCTAssertNotEqual(PixelFiringMock.lastPixelsFired.last?.name, GeneralPixel.duckPlayerYouTubeNavigationWithinYouTube.name)
+        XCTAssertNotEqual(PixelFiringMock.lastPixelsFired.last?.name, GeneralPixel.duckPlayerYouTubeOverlayNavigationOutsideYoutube.name)
+    }
+
+    func testReloadNavigationDoesNotTriggerWithinOrOutsideYouTubePixel() {
+        let testURL = URL(string: "https://www.youtube.com/watch?v=example")!
+
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: testURL, duckPlayerMode: .alwaysAsk)
+        duckPlayerOverlayPixels.handleNavigationAndFirePixels(url: testURL, duckPlayerMode: .alwaysAsk)
+
+        XCTAssertNotEqual(PixelFiringMock.lastPixelsFired.last?.name, GeneralPixel.duckPlayerYouTubeNavigationWithinYouTube.name)
+        XCTAssertNotEqual(PixelFiringMock.lastPixelsFired.last?.name, GeneralPixel.duckPlayerYouTubeOverlayNavigationOutsideYoutube.name)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208739766555303/f

**Description**:
- Adds temporary Overlay usage pixels
- This uses the same approach we use on iOS: https://github.com/duckduckgo/iOS/pull/3565

**Steps to test this PR**:

- [x] Set DuckPlayer to Always ask
- [x] Filter console messages with `duckplayer_youtube_overlay`
- [x] Go to Youtube.com, search for 'Metallica' and open a video ([link](https://m.youtube.com/results?sp=mAEA&search_query=Metallica))
- [x] While seeing the overlay, tap 'Back'
- [x] **Confirm `duckplayer.youtube.overlay.navigation.back` is fired.**
- [x] Select another from the list
- [ ] While seeing the overlay, tap 'Reload'
- [x] **Confirm `duckplayer.youtube.overlay.navigation.refresh` is fired.**
- [x] Scroll down to the recommended videos, and tap another video or a playlist
- [x] **Confirm `duckplayer.youtube.overlay.navigation.within-youtube` is fired.**
- [ ] Tap the "Watch in Duck Player" button
- [ ] **Confirm No pixels are fired**
- [ ] Go back
- [ ] Tap the URL bar and enter a URL that's not Youtube, such as https://www.example.com
- [ ] **Confirm `duckplayer.youtube.overlay.navigation.outside-youtube` is fired.**

Notes: 
- `duckplayer.youtube.overlay.navigation.back` is only fired when navigating directly to a video.  Further back navigation will `duckplayer.youtube.overlay.navigation.within-youtube`.  This is fine as we only want to track bounces on overlay after navigating directly to a video.
- All the pixels above include unit tests
