### PR TITLE
Add cohort assignment pixel for NTP Search Box Experiment

### DIFF
--- a/DuckDuckGo/HomePage/Model/HomePageAddressBarModel.swift
+++ b/DuckDuckGo/HomePage/Model/HomePageAddressBarModel.swift
@@ -98,6 +98,14 @@ extension HomePage.Models {
             return addressBarViewController.view
         }
 
+        func setUpExperimentIfNeeded() {
+            if isExperimentActive {
+                let ntpExperiment = NewTabPageSearchBoxExperiment()
+                ntpExperiment.assignUserToCohort()
+                shouldShowAddressBar = ntpExperiment.cohort?.isExperiment == true
+            }
+        }
+
         let tabCollectionViewModel: TabCollectionViewModel
 
         private var isExperimentActive: Bool = false {
@@ -115,14 +123,6 @@ extension HomePage.Models {
 
             privacyConfigCancellable = privacyConfigurationManager.updatesPublisher.sink { [weak self, weak privacyConfigurationManager] in
                 self?.isExperimentActive = privacyConfigurationManager?.privacyConfig.isEnabled(featureKey: .newTabSearchField) == true
-            }
-        }
-
-        private func setUpExperimentIfNeeded() {
-            if isExperimentActive {
-                let ntpExperiment = NewTabPageSearchBoxExperiment()
-                ntpExperiment.assignUserToCohort()
-                shouldShowAddressBar = ntpExperiment.cohort?.isExperiment == true
             }
         }
 

--- a/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
+++ b/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
@@ -96,6 +96,11 @@ struct DefaultNewTabPageSearchBoxExperimentCohortDecider: NewTabPageSearchBoxExp
 }
 
 protocol NewTabPageSearchBoxExperimentPixelReporting {
+    func fireNTPSearchBoxExperimentCohortAssignmentPixel(
+        cohort: NewTabPageSearchBoxExperiment.Cohort,
+        onboardingCohort: PixelExperiment?
+    )
+
     func fireNTPSearchBoxExperimentPixel(
         day: Int,
         count: Int,
@@ -106,6 +111,11 @@ protocol NewTabPageSearchBoxExperimentPixelReporting {
 }
 
 struct DefaultNewTabPageSearchBoxExperimentPixelReporter: NewTabPageSearchBoxExperimentPixelReporting {
+
+    func fireNTPSearchBoxExperimentCohortAssignmentPixel(cohort: NewTabPageSearchBoxExperiment.Cohort, onboardingCohort: PixelExperiment?) {
+        PixelKit.fire(NewTabSearchBoxExperimentPixel.cohortAssigned(cohort: cohort, onboardingCohort: onboardingCohort))
+    }
+
     func fireNTPSearchBoxExperimentPixel(
         day: Int,
         count: Int,
@@ -155,10 +165,10 @@ final class NewTabPageSearchBoxExperiment {
     }
 
     enum Cohort: String {
-        case control
-        case experiment = "ntp_search_box"
-        case controlExistingUser = "control_existing_user"
-        case experimentExistingUser = "ntp_search_box_existing_user"
+        case control = "control_v2"
+        case experiment = "ntp_search_box_v2"
+        case controlExistingUser = "control_existing_user_v2"
+        case experimentExistingUser = "ntp_search_box_existing_user_v2"
 
         var isExperiment: Bool {
             switch self {
@@ -211,6 +221,7 @@ final class NewTabPageSearchBoxExperiment {
         dataStore.didRunEnrollment = true
 
         Logger.newTabPageSearchBoxExperiment.debug("User assigned to cohort \(cohort.rawValue)")
+        pixelReporter.fireNTPSearchBoxExperimentCohortAssignmentPixel(cohort: cohort, onboardingCohort: onboardingExperimentCohortProvider.onboardingExperimentCohort)
     }
 
     func recordSearch(from source: SearchSource) {

--- a/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
+++ b/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
@@ -136,10 +136,15 @@ struct DefaultNewTabPageSearchBoxExperimentPixelReporter: NewTabPageSearchBoxExp
 }
 
 protocol OnboardingExperimentCohortProviding {
+    var isOnboardingFinished: Bool { get }
     var onboardingExperimentCohort: PixelExperiment? { get }
 }
 
 struct DefaultOnboardingExperimentCohortProvider: OnboardingExperimentCohortProviding {
+    var isOnboardingFinished: Bool {
+        UserDefaultsWrapper<Bool>(key: .onboardingFinished, defaultValue: false).wrappedValue
+    }
+
     var onboardingExperimentCohort: PixelExperiment? {
         PixelExperiment.logic.cohort
     }
@@ -215,8 +220,7 @@ final class NewTabPageSearchBoxExperiment {
             return
         }
 
-        let isOnboardingFinished = UserDefaultsWrapper<Bool>(key: .onboardingFinished, defaultValue: false).wrappedValue
-        guard isOnboardingFinished else {
+        guard onboardingExperimentCohortProvider.isOnboardingFinished else {
             Logger.newTabPageSearchBoxExperiment.debug("Skipping cohort assignment until onboarding is finished...")
             return
         }

--- a/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
+++ b/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
@@ -215,6 +215,12 @@ final class NewTabPageSearchBoxExperiment {
             return
         }
 
+        let isOnboardingFinished = UserDefaultsWrapper<Bool>(key: .onboardingFinished, defaultValue: false).wrappedValue
+        guard isOnboardingFinished else {
+            Logger.newTabPageSearchBoxExperiment.debug("Skipping cohort assignment until onboarding is finished...")
+            return
+        }
+
         guard let cohort = cohortDecider.cohort else {
             Logger.newTabPageSearchBoxExperiment.debug("User is not eligible for the experiment, skipping cohort assignment...")
             dataStore.experimentCohort = nil

--- a/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
+++ b/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
@@ -169,14 +169,20 @@ final class NewTabPageSearchBoxExperiment {
         case experiment = "ntp_search_box_v2"
         case controlExistingUser = "control_existing_user_v2"
         case experimentExistingUser = "ntp_search_box_existing_user_v2"
+        case legacyControl = "control"
+        case legacyExperiment = "ntp_search_box"
+        case legacyControlExistingUser = "control_existing_user"
+        case legacyExperimentExistingUser = "ntp_search_box_existing_user"
+
+        static let allExperimentCohortValues: Set<Cohort> = [
+            .legacyExperiment,
+            .legacyExperimentExistingUser,
+            .experiment,
+            .experimentExistingUser
+        ]
 
         var isExperiment: Bool {
-            switch self {
-            case .experiment, .experimentExistingUser:
-                return true
-            default:
-                return false
-            }
+            return Self.allExperimentCohortValues.contains(self)
         }
     }
 

--- a/DuckDuckGo/HomePage/View/HomePageViewController.swift
+++ b/DuckDuckGo/HomePage/View/HomePageViewController.swift
@@ -125,6 +125,7 @@ final class HomePageViewController: NSViewController {
             PixelKit.fire(GeneralPixel.newTabInitial, frequency: .legacyInitial)
         }
         subscribeToHistory()
+        addressBarModel.setUpExperimentIfNeeded()
     }
 
     override func viewDidAppear() {

--- a/DuckDuckGo/Statistics/NewTabSearchBoxExperimentPixel.swift
+++ b/DuckDuckGo/Statistics/NewTabSearchBoxExperimentPixel.swift
@@ -28,10 +28,13 @@ import PixelKit
  */
 enum NewTabSearchBoxExperimentPixel: PixelKitEventV2 {
 
+    case cohortAssigned(cohort: NewTabPageSearchBoxExperiment.Cohort, onboardingCohort: PixelExperiment?)
     case initialSearch(day: Int, count: Int, from: NewTabPageSearchBoxExperiment.SearchSource, cohort: NewTabPageSearchBoxExperiment.Cohort, onboardingCohort: PixelExperiment?)
 
     var name: String {
         switch self {
+        case .cohortAssigned:
+            return "m_mac_initial-search-day-1"
         case .initialSearch(let day, _, _, _, _):
             return "m_mac_initial-search-day-\(day)"
         }
@@ -39,6 +42,16 @@ enum NewTabSearchBoxExperimentPixel: PixelKitEventV2 {
 
     var parameters: [String: String]? {
         switch self {
+        case let .cohortAssigned(cohort, onboardingCohort):
+            var parameters = [
+                Parameters.count: "0",
+                Parameters.cohort: cohort.rawValue
+            ]
+            if let onboardingCohort {
+                parameters[Parameters.onboardingCohort] = onboardingCohort.rawValue
+            }
+            return parameters
+
         case let .initialSearch(_, count, from, cohort, onboardingCohort):
             var parameters = [
                 Parameters.count: String(count),

--- a/UnitTests/HomePage/NewTabPageSearchBoxExperimentTests.swift
+++ b/UnitTests/HomePage/NewTabPageSearchBoxExperimentTests.swift
@@ -38,6 +38,12 @@ class CapturingNewTabPageSearchBoxExperimentPixelReporter: NewTabPageSearchBoxEx
     }
     var calls: [PixelArguments] = []
 
+    var cohortAssignmentCalls: [NewTabPageSearchBoxExperiment.Cohort] = []
+
+    func fireNTPSearchBoxExperimentCohortAssignmentPixel(cohort: NewTabPageSearchBoxExperiment.Cohort, onboardingCohort: PixelExperiment?) {
+        cohortAssignmentCalls.append(cohort)
+    }
+
     func fireNTPSearchBoxExperimentPixel(
         day: Int,
         count: Int,
@@ -90,6 +96,7 @@ final class NewTabPageSearchBoxExperimentTests: XCTestCase {
         XCTAssertTrue(experiment.isActive)
         XCTAssertGreaterThan(try XCTUnwrap(dataStore.enrollmentDate), date)
         XCTAssertEqual(experiment.cohort, cohortDecider.cohort)
+        XCTAssertEqual(pixelReporter.cohortAssignmentCalls, [cohortDecider.cohort])
     }
 
     func testWhenUserIsNotEnrolledAndIsNotEligibleForExperimentThenCohortIsNil() {
@@ -101,6 +108,7 @@ final class NewTabPageSearchBoxExperimentTests: XCTestCase {
         XCTAssertTrue(dataStore.didRunEnrollment)
         XCTAssertFalse(experiment.isActive)
         XCTAssertNil(experiment.cohort)
+        XCTAssertTrue(pixelReporter.cohortAssignmentCalls.isEmpty)
     }
 
     func testWhenUserIsEnrolledThenSubsequentCohortAssignmentsHaveNoEffect() {
@@ -114,6 +122,7 @@ final class NewTabPageSearchBoxExperimentTests: XCTestCase {
         XCTAssertTrue(dataStore.didRunEnrollment)
         XCTAssertEqual(experiment.cohort, .control)
         XCTAssertEqual(dataStore.enrollmentDate, date)
+        XCTAssertTrue(pixelReporter.cohortAssignmentCalls.isEmpty)
     }
 
     func testWhenUserIsEnrolledThenIsActiveReturnsFalseWhenExperimentExpires() {

--- a/UnitTests/HomePage/NewTabPageSearchBoxExperimentTests.swift
+++ b/UnitTests/HomePage/NewTabPageSearchBoxExperimentTests.swift
@@ -87,6 +87,18 @@ final class NewTabPageSearchBoxExperimentTests: XCTestCase {
         super.tearDown()
     }
 
+    func testThatLegacyAndCurrentExperimentCohortsAreCorrectlyIdentified() {
+        XCTAssertTrue(NewTabPageSearchBoxExperiment.Cohort.experiment.isExperiment)
+        XCTAssertTrue(NewTabPageSearchBoxExperiment.Cohort.experimentExistingUser.isExperiment)
+        XCTAssertTrue(NewTabPageSearchBoxExperiment.Cohort.legacyExperiment.isExperiment)
+        XCTAssertTrue(NewTabPageSearchBoxExperiment.Cohort.legacyExperimentExistingUser.isExperiment)
+
+        XCTAssertFalse(NewTabPageSearchBoxExperiment.Cohort.control.isExperiment)
+        XCTAssertFalse(NewTabPageSearchBoxExperiment.Cohort.controlExistingUser.isExperiment)
+        XCTAssertFalse(NewTabPageSearchBoxExperiment.Cohort.legacyControl.isExperiment)
+        XCTAssertFalse(NewTabPageSearchBoxExperiment.Cohort.legacyControlExistingUser.isExperiment)
+    }
+
     func testWhenUserIsNotEnrolledAndIsEligibleForExperimentThenCohortIsSet() throws {
         cohortDecider.cohort = .experimentExistingUser
         let date = Date()

--- a/UnitTests/HomePage/NewTabPageSearchBoxExperimentTests.swift
+++ b/UnitTests/HomePage/NewTabPageSearchBoxExperimentTests.swift
@@ -25,6 +25,7 @@ class MockNewTabPageSearchBoxExperimentCohortDecider: NewTabPageSearchBoxExperim
 }
 
 class MockOnboardingExperimentCohortProvider: OnboardingExperimentCohortProviding {
+    var isOnboardingFinished: Bool = true
     var onboardingExperimentCohort: PixelExperiment?
 }
 
@@ -97,6 +98,19 @@ final class NewTabPageSearchBoxExperimentTests: XCTestCase {
         XCTAssertFalse(NewTabPageSearchBoxExperiment.Cohort.controlExistingUser.isExperiment)
         XCTAssertFalse(NewTabPageSearchBoxExperiment.Cohort.legacyControl.isExperiment)
         XCTAssertFalse(NewTabPageSearchBoxExperiment.Cohort.legacyControlExistingUser.isExperiment)
+    }
+
+    func testWhenUserIsNotEnrolledAndOnboardingIsNotFinishedThenCohortIsNotSet() {
+        onboardingExperimentCohortProvider.isOnboardingFinished = false
+        cohortDecider.cohort = .experimentExistingUser
+        let date = Date()
+        experiment.assignUserToCohort()
+
+        XCTAssertFalse(dataStore.didRunEnrollment)
+        XCTAssertFalse(experiment.isActive)
+        XCTAssertNil(dataStore.enrollmentDate)
+        XCTAssertNil(experiment.cohort)
+        XCTAssertTrue(pixelReporter.cohortAssignmentCalls.isEmpty)
     }
 
     func testWhenUserIsNotEnrolledAndIsEligibleForExperimentThenCohortIsSet() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201621853593513/1208742047745355/f

**Description**:
This change adds a pixel that's fired when a user is enrolled into the NTP search box experiment.

**Steps to test this PR**:
1. clear app data
2. run the app from Xcode
3. check console logs and verify that `m_mac_initial-search-day-1` has been sent with `count=0`
4. run the app again
5. check console logs and verify that the pixel isn't sent.
6. return nil in `DefaultNewTabPageSearchBoxExperimentCohortDecider.cohort`
7. clear app data
8. run the app again
9. check console logs and verify that the pixel isn't sent.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
