### PR TITLE
Enforce stricter hasPendingUpdate check

### DIFF
--- a/DuckDuckGo/Updates/UpdateController.swift
+++ b/DuckDuckGo/Updates/UpdateController.swift
@@ -71,7 +71,7 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
         didSet {
             if let cachedUpdateResult {
                 latestUpdate = Update(appcastItem: cachedUpdateResult.item, isInstalled: cachedUpdateResult.isInstalled)
-                hasPendingUpdate = latestUpdate?.isInstalled == false && updateProgress.isIdle
+                hasPendingUpdate = latestUpdate?.isInstalled == false && updateProgress.isDone && userDriver?.isResumable == true
                 needsNotificationDot = hasPendingUpdate
             }
             showUpdateNotificationIfNeeded()

--- a/DuckDuckGo/Updates/UpdateUserDriver.swift
+++ b/DuckDuckGo/Updates/UpdateUserDriver.swift
@@ -86,15 +86,18 @@ final class UpdateUserDriver: NSObject, SPUUserDriver {
     private var internalUserDecider: InternalUserDecider
 
     private var checkpoint: Checkpoint
-    private var onResuming: () -> Void = {}
-
+    private var onResuming: (() -> Void)?
     private var onSkipping: () -> Void = {}
+
+    var isResumable: Bool {
+        onResuming != nil
+    }
 
     private var bytesToDownload: UInt64 = 0
     private var bytesDownloaded: UInt64 = 0
 
     @Published var updateProgress = UpdateCycleProgress.default
-    public var updateProgressPublisher: Published<UpdateCycleProgress>.Publisher { $updateProgress }
+    var updateProgressPublisher: Published<UpdateCycleProgress>.Publisher { $updateProgress }
 
     init(internalUserDecider: InternalUserDecider,
          areAutomaticUpdatesEnabled: Bool) {
@@ -103,7 +106,7 @@ final class UpdateUserDriver: NSObject, SPUUserDriver {
     }
 
     func resume() {
-        onResuming()
+        onResuming?()
     }
 
     func cancelAndDismissCurrentUpdate() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208746324713624/f
Tech Design URL:
CC:

**Description**:

Fixes Install Now menu item does nothing by making sure we can resume the update process. As a bonus, this fixes an edge case where the user toggles back and forth between automatic & manual update checkboxes and that causes the upgrade process to go weird. 

**Steps to test this PR**:
1. Use this build: https://staticcdn.duckduckgo.com/macos-desktop-browser/a81f9679-e41d-404d-81a6-fd4a461d82f7/testbuilds/3447618/duckduckgo-1.114.0.305.dmg
1. Test different scenarios (automatic/manual update, trigger the update from different entry points, etc)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
