### PR TITLE
Move FE Overlay Pixel to the Native layer

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -214,9 +214,11 @@ extension DuckPlayerTabExtension: NavigationResponder {
         guard duckPlayer.isAvailable, duckPlayer.mode != .disabled else {
             return decidePolicyWithDisabledDuckPlayer(for: navigationAction)
         }
-        
-        // Fires the Overlay Shown Pixel
-        fireOverlayShownPixelIfNeeded(url: navigationAction.url)
+ 
+        // Fires the Overlay Shown Pixel if not coming from DuckPlayer's Watch in Youtube
+        if !navigationAction.sourceFrame.url.isDuckPlayer {
+            fireOverlayShownPixelIfNeeded(url: navigationAction.url)
+        }
 
         // session restoration will try to load real www.youtube-nocookie.com url
         // we need to redirect it to custom duck:// scheme handler which will load

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -214,7 +214,7 @@ extension DuckPlayerTabExtension: NavigationResponder {
         guard duckPlayer.isAvailable, duckPlayer.mode != .disabled else {
             return decidePolicyWithDisabledDuckPlayer(for: navigationAction)
         }
- 
+
         // Fires the Overlay Shown Pixel if not coming from DuckPlayer's Watch in Youtube
         if !navigationAction.sourceFrame.url.isDuckPlayer {
             fireOverlayShownPixelIfNeeded(url: navigationAction.url)
@@ -316,10 +316,10 @@ extension DuckPlayerTabExtension: NavigationResponder {
             webView.goBack()
             webView.load(URLRequest(url: .duckPlayer(videoID, timestamp: timestamp)))
         }
-        
+
         // Fire Overlay Shown Pixels
         fireOverlayShownPixelIfNeeded(url: navigation.url)
-        
+
         // Fire DuckPlayer Overlay Temporary Pixels
         if let url = navigation.request.url {
             duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -129,11 +129,27 @@ final class DuckPlayerTabExtension {
     }
 
     private func fireOverlayShownPixelIfNeeded(url: URL) {
+
         guard duckPlayer.isAvailable,
-                duckPlayer.mode == .alwaysAsk,
-                url.isYoutubeWatch else {
+              duckPlayer.mode == .alwaysAsk,
+              url.isYoutubeWatch else {
             return
         }
+
+        // Static variable for debounce logic
+        let debounceInterval: TimeInterval = 1.0
+        let now = Date()
+
+        struct Debounce {
+            static var lastFireTime: Date?
+        }
+
+        // Check debounce condition and update timestamp if firing
+        guard Debounce.lastFireTime == nil || now.timeIntervalSince(Debounce.lastFireTime!) >= debounceInterval else {
+            return
+        }
+
+        Debounce.lastFireTime = now
         PixelKit.fire(GeneralPixel.duckPlayerOverlayYoutubeImpressions)
     }
 }

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -128,6 +128,14 @@ final class DuckPlayerTabExtension {
         }
     }
 
+    private func fireOverlayShownPixelIfNeeded(url: URL) {
+        guard duckPlayer.isAvailable,
+                duckPlayer.mode == .alwaysAsk,
+                url.isYoutubeWatch else {
+            return
+        }
+        PixelKit.fire(GeneralPixel.duckPlayerOverlayYoutubeImpressions)
+    }
 }
 
 extension DuckPlayerTabExtension: YoutubeOverlayUserScriptDelegate {
@@ -190,6 +198,9 @@ extension DuckPlayerTabExtension: NavigationResponder {
         guard duckPlayer.isAvailable, duckPlayer.mode != .disabled else {
             return decidePolicyWithDisabledDuckPlayer(for: navigationAction)
         }
+        
+        // Fires the Overlay Shown Pixel
+        fireOverlayShownPixelIfNeeded(url: navigationAction.url)
 
         // session restoration will try to load real www.youtube-nocookie.com url
         // we need to redirect it to custom duck:// scheme handler which will load
@@ -287,7 +298,10 @@ extension DuckPlayerTabExtension: NavigationResponder {
             webView.goBack()
             webView.load(URLRequest(url: .duckPlayer(videoID, timestamp: timestamp)))
         }
-
+        
+        // Fire Overlay Shown Pixels
+        fireOverlayShownPixelIfNeeded(url: navigation.url)
+        
         // Fire DuckPlayer Overlay Temporary Pixels
         if let url = navigation.request.url {
             duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)

--- a/DuckDuckGo/YoutubePlayer/YoutubeOverlayUserScript.swift
+++ b/DuckDuckGo/YoutubePlayer/YoutubeOverlayUserScript.swift
@@ -161,8 +161,11 @@ extension YoutubeOverlayUserScript {
         case "play.do_not_use":
             duckPlayerPreferences.youtubeOverlayAnyButtonPressed = true
             PixelKit.fire(GeneralPixel.duckPlayerOverlayYoutubeWatchHere)
-        case "overlay":
-            PixelKit.fire(GeneralPixel.duckPlayerOverlayYoutubeImpressions)
+
+        // Moved to DuckPlayerTabExtension
+        // See :https://app.asana.com/0/1203249713006009/1208754606104659/f
+            // case "overlay":
+            // PixelKit.fire(GeneralPixel.duckPlayerOverlayYoutubeImpressions)
         default:
             break
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204099484721401/1208754606104631/f
Tech Design URL:
CC:

**Description**:
- Move the `m_mac_duck-player_overlay_youtube_impressions` pixel to the native layer

**Steps to test this PR**:
-  Filter console logs with `m_mac_duck-player_overlay_youtube_impressions`
- Set DuckPlayer to Ask Mode

**Confirm the pixel is fired 'once' in the following scenarios when the overlay is shown.**
- [x] Visit https://www.youtube.com/watch?v=Of5lcc54qRY 
- [x] Open any other video from the Youtube Recommendations in the page.

**Confirm Pixel is NOT fired when**
- [x] Visiting duck://player/tAGnKpE4NCI
- [x] Visiting https://www.youtube-nocookie.com/embed/tAGnKpE4NCI
- [x] Opening a video via "Watch in Youtube" from DuckPlayer


<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->


---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
