### PR TITLE
Disable reordering when sort by name is enabled

### DIFF
--- a/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
@@ -48,6 +48,7 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
     private var outlineView: BookmarksOutlineView?
 
     private let contentMode: ContentMode
+    private var sortMode: BookmarksSortMode
     private(set) var expandedNodesIDs = Set<String>()
     @Published private(set) var isSearching = false
 
@@ -95,6 +96,7 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
         self.dragDropManager = dragDropManager
         self.treeController = treeController
         self.presentFaviconsFetcherOnboarding = presentFaviconsFetcherOnboarding
+        self.sortMode = sortMode
 
         super.init()
     }
@@ -102,11 +104,13 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
     func reloadData(with sortMode: BookmarksSortMode, withRootFolder rootFolder: BookmarkFolder? = nil) {
         isSearching = false
         dragDestinationFolder = nil
+        self.sortMode = sortMode
         treeController.rebuild(for: sortMode, withRootFolder: rootFolder)
     }
 
     func reloadData(forSearchQuery searchQuery: String, sortMode: BookmarksSortMode) {
         isSearching = true
+        self.sortMode = sortMode
         treeController.rebuild(forSearchQuery: searchQuery, sortMode: sortMode)
     }
 
@@ -260,6 +264,8 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
     }
 
     func outlineView(_ outlineView: NSOutlineView, validateDrop info: NSDraggingInfo, proposedItem item: Any?, proposedChildIndex index: Int) -> NSDragOperation {
+        if !sortMode.isReorderingEnabled { return .none }
+
         let destinationNode = nodeForItem(item)
 
         if contentMode == .foldersOnly, destinationNode.isRoot {

--- a/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
+++ b/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
@@ -555,6 +555,7 @@ extension BookmarkManagementDetailViewController: NSTableViewDelegate, NSTableVi
                    validateDrop info: NSDraggingInfo,
                    proposedRow row: Int,
                    proposedDropOperation dropOperation: NSTableView.DropOperation) -> NSDragOperation {
+        if !sortBookmarksViewModel.selectedSortMode.isReorderingEnabled { return .none }
         let destination = destination(for: dropOperation, at: row)
 
         guard !isSearching || destination is BookmarkFolder else { return .none }

--- a/DuckDuckGo/Bookmarks/ViewModel/SortBookmarksViewModel.swift
+++ b/DuckDuckGo/Bookmarks/ViewModel/SortBookmarksViewModel.swift
@@ -55,6 +55,10 @@ enum BookmarksSortMode: Codable {
         return self == .nameAscending || self == .nameDescending
     }
 
+    var isReorderingEnabled: Bool{
+        return self == .manual
+    }
+
     func menu(target: AnyObject) -> NSMenu {
         switch self {
         case .manual:

--- a/UnitTests/Bookmarks/ViewModels/BookmarksSortModeTests.swift
+++ b/UnitTests/Bookmarks/ViewModels/BookmarksSortModeTests.swift
@@ -100,4 +100,10 @@ class BookmarksSortModeTests: XCTestCase {
         XCTAssertEqual(descendingMenu.items[4].title, UserText.bookmarksSortByNameDescending)
         XCTAssertEqual(descendingMenu.items[4].state, .on)
     }
+
+    func testReorderingValueIsCorrect() {
+        XCTAssertTrue(BookmarksSortMode.manual.isReorderingEnabled)
+        XCTAssertFalse(BookmarksSortMode.nameAscending.isReorderingEnabled)
+        XCTAssertFalse(BookmarksSortMode.nameDescending.isReorderingEnabled)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208661547711012/f
Tech Design URL:
CC:

**Description**:
This fixes a bug where we enabled reordering bookmarks in both the panel and the manager when sort by name was enabled.

**Steps to test this PR**:
1. Go to the bookmarks panel or manager
2. Sort by name descending or ascending
3. Try to re-order bookmarks
4. It shouldn’t let you drop bookmarks to re-order them

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
