### PR TITLE
Allow duplicates in observer

### DIFF
--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -335,7 +335,6 @@ final class MainViewController: NSViewController {
     private func subscribeToBookmarkBarVisibility() {
         bookmarksBarVisibilityChangedCancellable = bookmarksBarVisibilityManager
             .$isBookmarksBarVisible
-            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isBookmarksBarVisible in
                 self?.updateBookmarksBarViewVisibility(visible: isBookmarksBarVisible)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208767244367092/f
Tech Design URL:
CC:

**Description**:
We currently have a bug when the ’Show Bookmarks Bar` prompt is shown, if the user selects the hide option. The bar is visible.

The problem is that when showing the prompt, we update the visibility of the bookmarks bar but without updating its value, then when the user selects to hide or dismiss the prompt, given that the old value is false and the new values is false, the subscriber discards the new value and does not update the UI.

Removing the `removeDuplicates()` fixes the issue. I do not think there are problems removing that call, updating the visibility is something that happens on user interaction, we will have an ‘extra’ call if the user taps againg the same setting but I do not forsee a concern (open to opinions).

**Steps to test this PR**:
1. Start a fresh install (run `./clean-app.sh debug`)
2. Open a site, add a bookmark from the address bar button
3. Remove the bookmark from the address bar button
4. The prompt should appear, press hide
6. The bookmarks bar should hide

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
