### PR TITLE
addAttempt workaround

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDatabase.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Database/DataBrokerProtectionDatabase.swift
@@ -64,6 +64,7 @@ public protocol DataBrokerProtectionRepository {
     func fetchOptOutHistoryEvents(brokerId: Int64, profileQueryId: Int64, extractedProfileId: Int64) throws -> [HistoryEvent]
     func hasMatches() throws -> Bool
 
+    func fetchAllAttempts() throws -> [AttemptInformation]
     func fetchAttemptInformation(for extractedProfileId: Int64) throws -> AttemptInformation?
     func addAttempt(extractedProfileId: Int64, attemptUUID: UUID, dataBroker: String, lastStageDate: Date, startTime: Date) throws
 }
@@ -483,6 +484,17 @@ final class DataBrokerProtectionDatabase: DataBrokerProtectionRepository {
         } catch {
             Logger.dataBrokerProtection.error("Database error: fetchHistoryEvents, error: \(error.localizedDescription, privacy: .public)")
             pixelHandler.fire(.generalError(error: error, functionOccurredIn: "DataBrokerProtectionDatabase.fetchOptOutHistoryEvents brokerId profileQueryId extractedProfileId"))
+            throw error
+        }
+    }
+
+    func fetchAllAttempts() throws -> [AttemptInformation] {
+        do {
+            let vault = try self.vault ?? DataBrokerProtectionSecureVaultFactory.makeVault(reporter: secureVaultErrorReporter)
+            return try vault.fetchAllAttempts()
+        } catch {
+            Logger.dataBrokerProtection.error("Database error: fetchAllAttempts, error: \(error.localizedDescription, privacy: .public)")
+            pixelHandler.fire(.generalError(error: error, functionOccurredIn: "DataBrokerProtectionDatabase.fetchAllAttempts"))
             throw error
         }
     }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProfileQueryOperationManager.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Operations/DataBrokerProfileQueryOperationManager.swift
@@ -353,10 +353,10 @@ struct DataBrokerProfileQueryOperationManager: OperationsManager {
                                                         profileQueryId: profileQueryId)
 
             try database.addAttempt(extractedProfileId: extractedProfileId,
-                                attemptUUID: stageDurationCalculator.attemptId,
-                                dataBroker: stageDurationCalculator.dataBroker,
-                                lastStageDate: stageDurationCalculator.lastStateTime,
-                                startTime: stageDurationCalculator.startTime)
+                                    attemptUUID: stageDurationCalculator.attemptId,
+                                    dataBroker: stageDurationCalculator.dataBroker,
+                                    lastStageDate: stageDurationCalculator.lastStateTime,
+                                    startTime: stageDurationCalculator.startTime)
             try database.add(.init(extractedProfileId: extractedProfileId, brokerId: brokerId, profileQueryId: profileQueryId, type: .optOutRequested))
             try incrementAttemptCountIfNeeded(
                 database: database,

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
@@ -634,7 +634,14 @@ final class DefaultDataBrokerProtectionDatabaseProvider: GRDBSecureStorageDataba
 
     func save(_ optOutAttemptDB: OptOutAttemptDB) throws {
         try db.write { db in
-            try optOutAttemptDB.insert(db)
+            // We originally intended for ExtractedProfileDB to have a one-to-many relationship with OptOutAttemptDB,
+            // but it somehow ended up as a one-to-one relationship instead.
+            //
+            // This serves as a temporary workaround to keep the opt-out retry mechanism functioning.
+            // We'll need to address this issue properly in the future.
+            //
+            // https://app.asana.com/0/1205591970852438/1208761697124514/f
+            try optOutAttemptDB.upsert(db)
         }
     }
 }

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionDatabaseProvider.swift
@@ -100,6 +100,7 @@ protocol DataBrokerProtectionDatabaseProvider: SecureStorageDatabaseProvider {
 
     func hasMatches() throws -> Bool
 
+    func fetchAllAttempts() throws -> [OptOutAttemptDB]
     func fetchAttemptInformation(for extractedProfileId: Int64) throws -> OptOutAttemptDB?
     func save(_ optOutAttemptDB: OptOutAttemptDB) throws
  }
@@ -616,6 +617,12 @@ final class DefaultDataBrokerProtectionDatabaseProvider: GRDBSecureStorageDataba
     func hasMatches() throws -> Bool {
         try db.read { db in
             return try OptOutDB.fetchCount(db) > 0
+        }
+    }
+
+    func fetchAllAttempts() throws -> [OptOutAttemptDB] {
+        try db.read { db in
+            return try OptOutAttemptDB.fetchAll(db)
         }
     }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionSecureVault.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Storage/DataBrokerProtectionSecureVault.swift
@@ -107,6 +107,7 @@ protocol DataBrokerProtectionSecureVault: SecureVault {
 
     func hasMatches() throws -> Bool
 
+    func fetchAllAttempts() throws -> [AttemptInformation]
     func fetchAttemptInformation(for extractedProfileId: Int64) throws -> AttemptInformation?
     func save(extractedProfileId: Int64, attemptUUID: UUID, dataBroker: String, lastStageDate: Date, startTime: Date) throws
 }
@@ -443,6 +444,11 @@ final class DefaultDataBrokerProtectionSecureVault<T: DataBrokerProtectionDataba
 
     func hasMatches() throws -> Bool {
         try self.providers.database.hasMatches()
+    }
+
+    func fetchAllAttempts() throws -> [AttemptInformation] {
+        let mapper = MapperToModel(mechanism: l2Decrypt(data:))
+        return try self.providers.database.fetchAllAttempts().map(mapper.mapToModel(_:))
     }
 
     func fetchAttemptInformation(for extractedProfileId: Int64) throws -> AttemptInformation? {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -769,6 +769,10 @@ final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecureVault
         return 1
     }
 
+    func fetchAllAttempts() throws -> [AttemptInformation] {
+        []
+    }
+
     func fetchAttemptInformation(for extractedProfileId: Int64) throws -> AttemptInformation? {
         return nil
     }
@@ -988,6 +992,10 @@ final class MockDatabase: DataBrokerProtectionRepository {
 
     func fetchExtractedProfiles(for brokerId: Int64) -> [ExtractedProfile] {
         return extractedProfilesFromBroker
+    }
+
+    func fetchAllAttempts() throws -> [AttemptInformation] {
+        [attemptInformation].compactMap { $0 }
     }
 
     func fetchAttemptInformation(for extractedProfileId: Int64) -> AttemptInformation? {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -1211,8 +1211,9 @@ extension ScanJobData {
 
 extension OptOutJobData {
     static func mock(with extractedProfile: ExtractedProfile,
+                     preferredRunDate: Date? = nil,
                      historyEvents: [HistoryEvent] = [HistoryEvent]()) -> OptOutJobData {
-        .init(brokerId: 1, profileQueryId: 1, createdDate: Date(), historyEvents: historyEvents, attemptCount: 0, extractedProfile: extractedProfile)
+        .init(brokerId: 1, profileQueryId: 1, createdDate: Date(), preferredRunDate: preferredRunDate, historyEvents: historyEvents, attemptCount: 0, extractedProfile: extractedProfile)
     }
 
     static func mock(with createdDate: Date) -> OptOutJobData {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205591970852438/1208761697124514/f
Tech Design URL:
CC:

**Description**:

Workaround to deal with OptOutAttemptDB having one-to-one relationship with ExtractedProfileDB.

The idea is to let subsequent attempts overwrite the previous one. Associated pixels should've already been fired, so no data loss. This would allow the opt-out operation to finish cleanly, add the right history events, and fire the correct pixels.

**Steps to test this PR**:

This is quite time consuming to verify. You may use this branch for sped up process: https://github.com/duckduckgo/macos-browser/tree/anh/pir/resubmit-opt-outs-pr-review 

1. Go through the DBP flow
2. Move the system time forward so that DBP does another scan/opt-out passes
3. As opt-out retries are done, you should see attemptCount being incremented in the DB browser

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
