### PR TITLE
[macos] adding support for message bridge

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -15097,7 +15097,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 210.0.3;
+				version = 211.0.0;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "a296f015a572fdfe53a81de653efb9a6d7fc3eba",
-        "version" : "210.0.3"
+        "revision" : "7033b0d6f166ac8152cff602f1a1301641f4da60",
+        "version" : "211.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "adca39c379b1a124f9990e9d0308c374f32f5018",
-        "version" : "6.32.0"
+        "revision" : "f2caf4ff814f4714d07d6fc2cf02498cb54a1389",
+        "version" : "6.36.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "53fd1a0f8d91fcf475d9220f810141007300dffd",
-        "version" : "7.1.1"
+        "revision" : "757bbbae1e2afbb421caee9bfca04ee5c56c3af8",
+        "version" : "7.2.0"
       }
     },
     {

--- a/DuckDuckGo/Autofill/ContentOverlayViewController.swift
+++ b/DuckDuckGo/Autofill/ContentOverlayViewController.swift
@@ -366,6 +366,7 @@ extension ContentOverlayViewController: SecureVaultManagerDelegate {
         let isGPCEnabled = WebTrackingProtectionPreferences.shared.isGPCEnabled
         let properties = ContentScopeProperties(gpcEnabled: isGPCEnabled,
                                                 sessionKey: topAutofillUserScript?.sessionKey ?? "",
+                                                messageSecret: topAutofillUserScript?.messageSecret ?? "",
                                                 featureToggles: ContentScopeFeatureToggles.supportedFeaturesOnMacOS(privacyConfigurationManager.privacyConfig))
 
         let runtimeConfiguration = DefaultAutofillSourceProvider.Builder(privacyConfigurationManager: privacyConfigurationManager,

--- a/DuckDuckGo/ContentBlocker/ScriptSourceProviding.swift
+++ b/DuckDuckGo/ContentBlocker/ScriptSourceProviding.swift
@@ -30,6 +30,7 @@ protocol ScriptSourceProviding {
     var privacyConfigurationManager: PrivacyConfigurationManaging { get }
     var autofillSourceProvider: AutofillUserScriptSourceProvider? { get }
     var sessionKey: String? { get }
+    var messageSecret: String? { get }
     var onboardingActionsManager: OnboardingActionsManaging? { get }
     func buildAutofillSource() -> AutofillUserScriptSourceProvider
 
@@ -47,6 +48,7 @@ struct ScriptSourceProvider: ScriptSourceProviding {
     private(set) var onboardingActionsManager: OnboardingActionsManaging?
     private(set) var autofillSourceProvider: AutofillUserScriptSourceProvider?
     private(set) var sessionKey: String?
+    private(set) var messageSecret: String?
 
     let configStorage: ConfigurationStoring
     let privacyConfigurationManager: PrivacyConfigurationManaging
@@ -73,6 +75,7 @@ struct ScriptSourceProvider: ScriptSourceProviding {
         self.contentBlockerRulesConfig = buildContentBlockerRulesConfig()
         self.surrogatesConfig = buildSurrogatesConfig()
         self.sessionKey = generateSessionKey()
+        self.messageSecret = generateSessionKey()
         self.autofillSourceProvider = buildAutofillSource()
         self.onboardingActionsManager = buildOnboardingActionsManager()
     }
@@ -86,6 +89,7 @@ struct ScriptSourceProvider: ScriptSourceProviding {
         return DefaultAutofillSourceProvider.Builder(privacyConfigurationManager: privacyConfigurationManager,
                                                      properties: ContentScopeProperties(gpcEnabled: webTrakcingProtectionPreferences.isGPCEnabled,
                                                                                         sessionKey: self.sessionKey ?? "",
+                                                                                        messageSecret: self.messageSecret ?? "",
                                                                                         featureToggles: ContentScopeFeatureToggles.supportedFeaturesOnMacOS(privacyConfig)),
                                                      isDebug: AutofillPreferences().debugScriptEnabled)
                 .withJSLoading()

--- a/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -56,8 +56,10 @@ final class DBPHomeViewController: NSViewController {
 
         let isGPCEnabled = WebTrackingProtectionPreferences.shared.isGPCEnabled
         let sessionKey = UUID().uuidString
+        let messageSecret = UUID().uuidString
         let prefs = ContentScopeProperties(gpcEnabled: isGPCEnabled,
                                            sessionKey: sessionKey,
+                                           messageSecret: messageSecret,
                                            featureToggles: features)
 
         return DataBrokerProtectionViewController(

--- a/DuckDuckGo/Tab/TabExtensions/AutofillTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/AutofillTabExtension.swift
@@ -209,6 +209,7 @@ extension AutofillTabExtension: SecureVaultManagerDelegate {
 
         return ContentScopeProperties(gpcEnabled: WebTrackingProtectionPreferences.shared.isGPCEnabled,
                                       sessionKey: autofillScript?.sessionKey ?? "",
+                                      messageSecret: autofillScript?.messageSecret ?? "",
                                       featureToggles: supportedFeatures)
     }
 }

--- a/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -62,8 +62,10 @@ final class UserScripts: UserScriptsProvider {
         let isGPCEnabled = WebTrackingProtectionPreferences.shared.isGPCEnabled
         let privacyConfig = sourceProvider.privacyConfigurationManager.privacyConfig
         let sessionKey = sourceProvider.sessionKey ?? ""
+        let messageSecret = sourceProvider.messageSecret ?? ""
         let prefs = ContentScopeProperties(gpcEnabled: isGPCEnabled,
                                                 sessionKey: sessionKey,
+                                                messageSecret: messageSecret,
                                                 featureToggles: ContentScopeFeatureToggles.supportedFeaturesOnMacOS(privacyConfig))
         contentScopeUserScript = ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs)
         contentScopeUserScriptIsolated = ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs, isIsolated: true)

--- a/DuckDuckGoDBPBackgroundAgent/DataBrokerProtectionBackgroundManager.swift
+++ b/DuckDuckGoDBPBackgroundAgent/DataBrokerProtectionBackgroundManager.swift
@@ -51,8 +51,10 @@ public final class DataBrokerProtectionBackgroundManager {
                                                   thirdPartyCredentialsProvider: false)
 
         let sessionKey = UUID().uuidString
+        let messageSecret = UUID().uuidString
         let prefs = ContentScopeProperties(gpcEnabled: false,
                                                 sessionKey: sessionKey,
+                                                messageSecret: messageSecret,
                                                 featureToggles: features)
 
         let pixelHandler = DataBrokerProtectionPixelsHandler()

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "210.0.3"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "211.0.0"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../AppKitExtensions"),
         .package(path: "../XPCHelper"),

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONViewModel.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/DebugUI/DataBrokerRunCustomJSONViewModel.swift
@@ -168,9 +168,11 @@ final class DataBrokerRunCustomJSONViewModel: ObservableObject {
                                                   unknownUsernameCategorization: false)
 
         let sessionKey = UUID().uuidString
+        let messageSecret = UUID().uuidString
         self.authenticationManager = authenticationManager
         let contentScopeProperties = ContentScopeProperties(gpcEnabled: false,
                                                             sessionKey: sessionKey,
+                                                            messageSecret: messageSecret,
                                                             featureToggles: features)
 
         self.runnerProvider = DataBrokerJobRunnerProvider(

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionAgentManager.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Scheduler/DataBrokerProtectionAgentManager.swift
@@ -61,6 +61,7 @@ public class DataBrokerProtectionAgentManagerProvider {
                                                   unknownUsernameCategorization: false)
         let contentScopeProperties = ContentScopeProperties(gpcEnabled: false,
                                                             sessionKey: UUID().uuidString,
+                                                            messageSecret: UUID().uuidString,
                                                             featureToggles: features)
 
         let fakeBroker = DataBrokerDebugFlagFakeBroker()

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/Mocks.swift
@@ -242,6 +242,7 @@ extension ContentScopeProperties {
         ContentScopeProperties(
             gpcEnabled: false,
             sessionKey: "sessionKey",
+            messageSecret: "messageSecret",
             featureToggles: ContentScopeFeatureToggles.mock
         )
     }

--- a/LocalPackages/FeatureFlags/Package.swift
+++ b/LocalPackages/FeatureFlags/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["FeatureFlags"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "210.0.3"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "211.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "210.0.3"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "211.0.0"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.3"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "210.0.3"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "211.0.0"),
         .package(path: "../SwiftUIExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208773745506350/f
Tech Design URL:
CC:

**Description**:

See the Asana task for more details - but a short version is that a recent change in C-S-S requires another UUID - I deliberately DO NOT want to re-use `sessionKey`, since that's used in other places already and it would be unclear when/where we could change this.

- name: `messageSecret` was chosen to match what android already use
- where: I placed this on ContentScopePreferences because it gets serialized as JSON into our scripts and is already used for such things
  - Again, it also matches Android

**Steps to test this PR**: (👀 VIDEO below)
1. Use the debug menu to set the AI Chat -> Web Communication -> Set Custom URL
    - set it to `https://bridge-example.netlify.app/ai-chat.html`
3. Now override remote config to use:
    - `https://bridge-example.netlify.app/ai-chat.json`
4. visit https://bridge-example.netlify.app/ai-chat.html
5. verify settings are opened
6. verify the data is fetched


---

AI Chat -> Web Communication -> Set Custom URL

<img width="868" alt="Screenshot 2024-11-15 at 10 42 17 AM" src="https://github.com/user-attachments/assets/65565ae3-19a0-40cf-aafc-fb746ddd0786">


https://github.com/user-attachments/assets/9b197aca-965d-4541-9d4b-70b066fc352e




**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)

3.   -  
8. change the message or4. change the message or

**Definition of Done**:**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

------
###### Internal references:###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
