### PR TITLE
Update autoconsent to v11.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "macos-browser",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^11.1.0"
+        "@duckduckgo/autoconsent": "^11.4.0"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-11.1.0.tgz",
-      "integrity": "sha512-ZzccT+1Lf6GhoWmNENgKD0XIS9qsw1wRcSPzGR+WNYL1pRHCDGhdcNI2p5ih6DshodDlOEG0s2T4czM7i0e5UA==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-11.4.0.tgz",
+      "integrity": "sha512-2MjhDVwpMlyFae5Hsq5S4YL8WbHe+ctzau8QF2i5eAxkcIKTDVWS8yMuC0scr+XCSx7pk7mVuWHts3WHjNVhGw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^11.1.0"
+    "@duckduckgo/autoconsent": "^11.4.0"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208775332166220/1208775332166220
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v11.4.0


## Description
Updates Autoconsent to version [v11.4.0](https://github.com/duckduckgo/autoconsent/releases/tag/v11.4.0).

### Autoconsent v11.4.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v11.4.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI