### PR TITLE
Add OS version to download fail pixel

### DIFF
--- a/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
+++ b/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
@@ -333,9 +333,10 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
             Logger.fileDownload.error("🛑 file presenters failure: \(self): \(error)")
 
             self.download.cancel()
+
             self.finish(with: .failure(.failedToCompleteDownloadTask(underlyingError: error, resumeData: nil, isRetryable: false)))
 
-            PixelKit.fire(DebugEvent(GeneralPixel.fileDownloadCreatePresentersFailed, error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.fileDownloadCreatePresentersFailed(OSVersion: "\(ProcessInfo.processInfo.operatingSystemVersion)"), error: error))
         }
     }
 

--- a/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
+++ b/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
@@ -336,7 +336,7 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
 
             self.finish(with: .failure(.failedToCompleteDownloadTask(underlyingError: error, resumeData: nil, isRetryable: false)))
 
-            PixelKit.fire(DebugEvent(GeneralPixel.fileDownloadCreatePresentersFailed(OSVersion: "\(ProcessInfo.processInfo.operatingSystemVersion)"), error: error))
+            PixelKit.fire(DebugEvent(GeneralPixel.fileDownloadCreatePresentersFailed(osVersion: "\(ProcessInfo.processInfo.operatingSystemVersion)"), error: error))
         }
     }
 

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -294,7 +294,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case fileMoveToDownloadsFailed
     case fileAccessRelatedItemFailed
     case fileGetDownloadLocationFailed
-    case fileDownloadCreatePresentersFailed
+    case fileDownloadCreatePresentersFailed(OSVersion: String)
     case downloadResumeDataCodingFailed
 
     case suggestionsFetchFailed
@@ -1297,6 +1297,8 @@ enum GeneralPixel: PixelKitEventV2 {
                 parameters[NewTabSearchBoxExperimentPixel.Parameters.onboardingCohort] = onboardingCohort.rawValue
             }
             return parameters
+        case .fileDownloadCreatePresentersFailed(let OSVersion):
+            return ["OSVersion": OSVersion]
         default: return nil
         }
     }

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -294,7 +294,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case fileMoveToDownloadsFailed
     case fileAccessRelatedItemFailed
     case fileGetDownloadLocationFailed
-    case fileDownloadCreatePresentersFailed(OSVersion: String)
+    case fileDownloadCreatePresentersFailed(osVersion: String)
     case downloadResumeDataCodingFailed
 
     case suggestionsFetchFailed
@@ -1297,8 +1297,8 @@ enum GeneralPixel: PixelKitEventV2 {
                 parameters[NewTabSearchBoxExperimentPixel.Parameters.onboardingCohort] = onboardingCohort.rawValue
             }
             return parameters
-        case .fileDownloadCreatePresentersFailed(let OSVersion):
-            return ["OSVersion": OSVersion]
+        case .fileDownloadCreatePresentersFailed(let osVersion):
+            return ["osVersion": osVersion]
         default: return nil
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208780258680355/f
Tech Design URL:
CC:

**Description**:
It adds the OS version to this pixel to show where we are experiencing the download issue.

**Steps to test this PR**:
1. You can add a throw in the 323 line
2. Check the `fileDownloadCreatePresentersFailed` pixel has the `OSVersion` (it should be in the logs)


**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
