### PR TITLE
Add expectation when checking email text field value

### DIFF
--- a/UITests/FireWindowTests.swift
+++ b/UITests/FireWindowTests.swift
@@ -148,7 +148,15 @@ class FireWindowTests: XCTestCase {
             let coordinate = autoFillPopup.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
             coordinate.tap()
 
-            XCTAssertEqual(emailTextFieldFire.value as? String, "test@duck.com")
+            // Use an expectation to wait for the value to update
+            let expectedValue = "test@duck.com"
+            let valuePredicate = NSPredicate(format: "value == %@", expectedValue)
+
+            let expectation = XCTNSPredicateExpectation(predicate: valuePredicate, object: emailTextFieldFire)
+
+            let result = XCTWaiter().wait(for: [expectation], timeout: UITests.Timeouts.elementExistence)
+            XCTAssertEqual(result, .completed, "The email text field value did not update as expected.")
+            XCTAssertEqual(emailTextFieldFire.value as? String, expectedValue)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208793837278290/f
Tech Design URL:
CC:

**Description**:
The `testCrendentialsAreAutoFilledInFireWindows` failed on [macOS 15](https://github.com/duckduckgo/macos-browser/actions/runs/11905477557/job/33176330383).

Checking the logs, the problem was that there was a slight delay when the autofill credentials email is tapped and when it is loaded into the web view text field; given that we do not wait and check immediately, it could sometimes fail. 

I’ve added an expectation, so we will now wait for the email to appear.


**Steps to test this PR**:
1. Select the UI test target
2. Run the `testCrendentialsAreAutoFilledInFireWindows` test

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
