### PR TITLE
Receive privacy config updates in AddressBarModel on main thread

### DIFF
--- a/DuckDuckGo/HomePage/Model/HomePageAddressBarModel.swift
+++ b/DuckDuckGo/HomePage/Model/HomePageAddressBarModel.swift
@@ -121,9 +121,11 @@ extension HomePage.Models {
             isExperimentActive = privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .newTabSearchField)
             setUpExperimentIfNeeded()
 
-            privacyConfigCancellable = privacyConfigurationManager.updatesPublisher.sink { [weak self, weak privacyConfigurationManager] in
-                self?.isExperimentActive = privacyConfigurationManager?.privacyConfig.isEnabled(featureKey: .newTabSearchField) == true
-            }
+            privacyConfigCancellable = privacyConfigurationManager.updatesPublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self, weak privacyConfigurationManager] in
+                    self?.isExperimentActive = privacyConfigurationManager?.privacyConfig.isEnabled(featureKey: .newTabSearchField) == true
+                }
         }
 
         private lazy var addressBarViewController: AddressBarViewController? = createAddressBarViewController()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208804405760977/f

**Description**:
This privacy config update may update a published value so must be received on main thread.

**Steps to test**:
I did the testing myself, but if you want to repeat my testing then use this config: https://www.jsonblob.com/1305205607014195200 where `ntpSearchField` is disabled and load it in the app (using `https://www.jsonblob.com/api/1305205607014195200` as custom config URL). Then update the config to say `enabled` for `ntpSearchField` and reload the configuration. Verify that you're not getting a Main Thread Checker warning.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
