### PR TITLE
Simplify User Agent logic and update unit tests

### DIFF
--- a/DuckDuckGo/UserAgent/Model/UserAgent.swift
+++ b/DuckDuckGo/UserAgent/Model/UserAgent.swift
@@ -61,11 +61,9 @@ extension UserAgent {
 
     static func `for`(_ url: URL?,
                       privacyConfig: PrivacyConfiguration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig) -> String {
-        guard let absoluteString = url?.absoluteString else {
+        guard let url, privacyConfig.isEnabled(featureKey: .customUserAgent) else {
             return Self.default
         }
-
-        guard privacyConfig.isEnabled(featureKey: .customUserAgent) else { return Self.default }
 
         if isURLPartOfWebviewDefaultList(url: url, privacyConfig: privacyConfig) {
             return Self.webViewDefault
@@ -83,25 +81,25 @@ extension UserAgent {
     static let webviewDefaultKey = "webViewDefault"
     static let domainKey = "domain"
 
-    private static func isURLPartOfWebviewDefaultList(url: URL?,
+    private static func isURLPartOfWebviewDefaultList(url: URL,
                                                       privacyConfig: PrivacyConfiguration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig) -> Bool {
         let settings = privacyConfig.settings(for: .customUserAgent)
         let webViewDefaultList = settings[webviewDefaultKey] as? [[String: String]] ?? []
         let domains = webViewDefaultList.map { $0[domainKey] ?? "" }
 
         return domains.contains(where: { domain in
-            url?.isPart(ofDomain: domain) ?? false
+            url.isPart(ofDomain: domain)
         })
     }
 
-    private static func isURLPartOfDefaultSitesList(url: URL?, privacyConfig: PrivacyConfiguration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig) -> Bool {
+    private static func isURLPartOfDefaultSitesList(url: URL, privacyConfig: PrivacyConfiguration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig) -> Bool {
 
         let uaSettings = privacyConfig.settings(for: .customUserAgent)
         let defaultSitesObjs = uaSettings[defaultSitesKey] as? [[String: String]] ?? []
         let domains = defaultSitesObjs.map { $0[domainKey] ?? "" }
 
         return domains.contains(where: { domain in
-            url?.isPart(ofDomain: domain) ?? false
+            url.isPart(ofDomain: domain)
         })
     }
 }

--- a/UnitTests/UserAgent/Model/UserAgentTests.swift
+++ b/UnitTests/UserAgent/Model/UserAgentTests.swift
@@ -35,7 +35,7 @@ final class UserAgentTests: XCTestCase {
         XCTAssertEqual(UserAgent.brandedDefault, UserAgent.for(URL(string: "https://a.docs.google.com")!))
     }
 
-    func testWhenDomainIsDuckDuckGo_ThenUserAgentDoesNotIncludeSafari() {
+    func testWhenDomainIsDuckDuckGo_ThenUserAgentDoesNotIncludeChrome() {
         XCTAssertFalse(UserAgent.for(URL.duckDuckGo).contains("Chrome"))
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208568177174606/f
CC: @jonathanKingston 

**Description**:
This change updates User Agent rules as follows:
* The default UA is now DDG-branded and it's applied to all web, including duckduckgo.com.
* `defaultPolicy` privacy config item is no longer supported.
* 2 types of privacy-config-provided exceptions are supported: `webViewDefault` (using WebKit default UA) and `defaultSites` (using Safari UA).

**Steps to test this PR**:
1. Open https://duckduckgo.com and verify that you see a minimal homepage (without macOS browser download CTA as seen in Safari)
2. Open [this Kibana view](https://kibana.duckduckgo.com/app/r/s/vC4ya) and [this Kibana view](https://kibana.duckduckgo.com/app/r/s/9T8ml).
3. Search on SERP for `samplesearchformacosbrowseruapullrequesttesting`
4. Refresh Kibana and verify that agent reported for nginx access and pixels is `ddg_mac_desktop` (the same searches on a macOS browser release app would show empty user agent).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
