### PR TITLE
Fix fetching variants list

### DIFF
--- a/.github/actions/asana-get-build-variants-list/get_build_variants_list.sh
+++ b/.github/actions/asana-get-build-variants-list/get_build_variants_list.sh
@@ -56,7 +56,7 @@ _fetch_origin_tasks() {
 		fi
 	done
 
-	echo "${origin_variants}"
+	echo "${origin_variants[*]}" | tr ' ' ','
 }
 
 # Create a JSON string from the list of ATB items passed.
@@ -92,14 +92,16 @@ _fetch_atb_variants() {
 
 	variants_list=("$(_create_atb_variant_pairs "$atb_variants")")
 
-	echo "${variants_list}"
+	echo "${variants_list[*]}" | tr ' ' ','
 }
 
 main() {
+	local atb_variants
+	local origin_variants
 	# fetch ATB variants
-	local atb_variants=$(_fetch_atb_variants)
+	atb_variants="$(_fetch_atb_variants)"
 	# fetch Origin variants
-	local origin_variants=$(_fetch_origin_tasks)
+	origin_variants="$(_fetch_origin_tasks)"
 	# merges the two list together. Use `include` keyword for later usage in matrix. 
 	# for more info see https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-adding-configurations.
 	local merged_variants="{\"include\": [${atb_variants},${origin_variants}]}"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1208823340768320/f
CC: @alessandroboron 

**Description**:
This change updates get_build_variants_list.sh to report all variants.
`origin_variants` and `variants_list` are both bash arrays and when outputting them
they need to be treated in a special way to avoid outputting only the first item.

**Steps to test this PR**:
See the linked task for steps to test.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
