### PR TITLE
Update autoconsent to v12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "macos-browser",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^11.5.0"
+        "@duckduckgo/autoconsent": "^12.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-11.5.0.tgz",
-      "integrity": "sha512-mjMVTtJuHKPnX+poz5ZOPpUCPtoVh7nQeO7oXtsYEXZNSEIO/UIK9ozEWUI3Ta1utzQm4pN5wJwmsgmxNUXi/w==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-12.0.0.tgz",
+      "integrity": "sha512-ObPv0pE1d8G1Nnj9NtTxvu04mNRnJ8o8cpU1G0YJk1kP2ykipGnlp9wrn9Tkn2fDy5zT8HQqDsOYWEyk3ES1kg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^11.5.0"
+    "@duckduckgo/autoconsent": "^12.0.0"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208828457680750/1208828457680750
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v12.0.0


## Description
Updates Autoconsent to version [v12.0.0](https://github.com/duckduckgo/autoconsent/releases/tag/v12.0.0).

### Autoconsent v12.0.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v12.0.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI