### PR TITLE
Do not refresh cookie on config update

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -394,10 +394,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                 let isEnabled = privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(PrivacyProSubfeature.setAccessTokenCookieForSubscriptionDomains)
 
-                Task { [weak self] in
+                Task { @MainActor [weak self] in
                     if isEnabled {
                         self?.subscriptionCookieManager.enableSettingSubscriptionCookie()
-                        await self?.subscriptionCookieManager.refreshSubscriptionCookie()
                     } else {
                         await self?.subscriptionCookieManager.disableSettingSubscriptionCookie()
                     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208835217248246/f

**Description**:
Do not refresh cookie on config update

**Steps to test this PR**:
Fix for crash when `subscriptionCookieManager` accessed WebKit datastore not on the main thread when the privacy config had update with enabled `setAccessTokenCookieForSubscriptionDomains` feature flag.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
