### PR TITLE
Keep showing Search Box after experiment ends

### DIFF
--- a/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
+++ b/DuckDuckGo/HomePage/Model/NewTabPageSearchBoxExperiment.swift
@@ -210,7 +210,7 @@ final class NewTabPageSearchBoxExperiment {
     }
 
     var cohort: Cohort? {
-        isActive ? dataStore.experimentCohort : nil
+        dataStore.experimentCohort
     }
 
     var onboardingCohort: PixelExperiment? {

--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -326,6 +326,7 @@ final class AddressBarTextField: NSTextField {
 
     private func navigate(suggestion: Suggestion?) {
         let ntpExperiment = NewTabPageSearchBoxExperiment()
+        let ntpExperimentCohort: NewTabPageSearchBoxExperiment.Cohort? = ntpExperiment.isActive ? ntpExperiment.cohort : nil
         let source: NewTabPageSearchBoxExperiment.SearchSource? = {
             guard ntpExperiment.isActive else {
                 return nil
@@ -349,17 +350,17 @@ final class AddressBarTextField: NSTextField {
         let autocompletePixel: GeneralPixel? = {
             switch suggestion {
             case .phrase:
-                return .autocompleteClickPhrase(from: source, cohort: ntpExperiment.cohort, onboardingCohort: ntpExperiment.onboardingCohort)
+                return .autocompleteClickPhrase(from: source, cohort: ntpExperimentCohort, onboardingCohort: ntpExperiment.onboardingCohort)
             case .website:
-                return .autocompleteClickWebsite(from: source, cohort: ntpExperiment.cohort, onboardingCohort: ntpExperiment.onboardingCohort)
+                return .autocompleteClickWebsite(from: source, cohort: ntpExperimentCohort, onboardingCohort: ntpExperiment.onboardingCohort)
             case .bookmark(_, _, let isFavorite, _):
                 if isFavorite {
-                    return .autocompleteClickFavorite(from: source, cohort: ntpExperiment.cohort, onboardingCohort: ntpExperiment.onboardingCohort)
+                    return .autocompleteClickFavorite(from: source, cohort: ntpExperimentCohort, onboardingCohort: ntpExperiment.onboardingCohort)
                 } else {
-                    return .autocompleteClickBookmark(from: source, cohort: ntpExperiment.cohort, onboardingCohort: ntpExperiment.onboardingCohort)
+                    return .autocompleteClickBookmark(from: source, cohort: ntpExperimentCohort, onboardingCohort: ntpExperiment.onboardingCohort)
                 }
             case .historyEntry:
-                return .autocompleteClickHistory(from: source, cohort: ntpExperiment.cohort, onboardingCohort: ntpExperiment.onboardingCohort)
+                return .autocompleteClickHistory(from: source, cohort: ntpExperimentCohort, onboardingCohort: ntpExperiment.onboardingCohort)
             default:
                 return nil
             }

--- a/UnitTests/HomePage/NewTabPageSearchBoxExperimentTests.swift
+++ b/UnitTests/HomePage/NewTabPageSearchBoxExperimentTests.swift
@@ -162,12 +162,12 @@ final class NewTabPageSearchBoxExperimentTests: XCTestCase {
         XCTAssertFalse(experiment.isActive)
     }
 
-    func testWhenExperimentIsInactiveThenCohortIsNil() {
+    func testWhenExperimentIsInactiveThenCohortStays() {
         dataStore.didRunEnrollment = true
         dataStore.experimentCohort = .experiment
         dataStore.enrollmentDate = Date.daysAgo(NewTabPageSearchBoxExperiment.Const.experimentDurationInDays)
 
-        XCTAssertNil(experiment.cohort)
+        XCTAssertEqual(experiment.cohort, .experiment)
     }
 
     func testWhenExperimentIsInactiveThenOnboardingExperimentCohortIsNil() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208836242994116/f

**Description**:
If the experiment is not reporting pixels anymore (past 7-day deadline), we want to keep showing
search box to the users.

**Steps to test this PR**:
Run the following commands in the command line to make yourself enrolled in the experiment 2 weeks ago:
```
defaults write com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.cohort ntp_search_box_existing_user
defaults write com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.enrollment-date -date "2024-11-10 16:22:28 +0000"
defaults write com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.did-run-enrollment 1
```
Then run the app from Xcode and verify that the search box is present on NTP.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
