### PR TITLE
Stop assigning users to NTP Search Box Experiment cohorts

### DIFF
--- a/DuckDuckGo/HomePage/Model/HomePageAddressBarModel.swift
+++ b/DuckDuckGo/HomePage/Model/HomePageAddressBarModel.swift
@@ -101,7 +101,6 @@ extension HomePage.Models {
         func setUpExperimentIfNeeded() {
             if isExperimentActive {
                 let ntpExperiment = NewTabPageSearchBoxExperiment()
-                ntpExperiment.assignUserToCohort()
                 shouldShowAddressBar = ntpExperiment.cohort?.isExperiment == true
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208746673107049/f

**Description**:
This change stops assigning new users to experiment, while keeping Search Box visible for users that have previously been enrolled.

**Steps to test this PR**:
Run the following commands to make yourself enrolled into the Search Box experiment:
```
defaults write com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.cohort ntp_search_box_existing_user
defaults write com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.enrollment-date -date "2024-11-10 16:22:28 +0000"
defaults write com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.did-run-enrollment 1
```
Run the app and confirm that you see the search box.

Then call the following to reset the experiment:
```
defaults delete com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.did-run-enrollment
defaults delete com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.cohort
defaults delete com.duckduckgo.macos.browser.debug homepage.searchbox.experiment.enrollment-date
```

Then run the app and confirm that you don't see the search box.
Then verify that this command in terminal doesn't show any output:
```
defaults read com.duckduckgo.macos.browser.debug | grep homepage
```

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
