### PR TITLE
Only fire Duck Player navigational pixel for main frame navigations

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -246,7 +246,7 @@ extension DuckPlayerTabExtension: NavigationResponder {
         }
 
         // Fire DuckPlayer temporary pixels on navigating outside Youtube
-        if let url = navigationAction.request.url, !url.isYoutube {
+        if let url = navigationAction.request.url, !url.isYoutube, navigationAction.isForMainFrame {
             duckPlayerOverlayUsagePixels.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayer.mode)
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203249713006009/1208836976436118/f

**Description**:
This change limits Duck Player navigational pixels to be sent only on main frame navigations

**Steps to test this PR**:
See [this Asana comment](https://app.asana.com/0/0/1208674332470432/1208840180285935/f) for more context of the breakage.
1. Run the app from Xcode
2. Filter logs by "PixelKit" category
3. Set DuckPlayer to "always ask" mode
4. Go to youtube.com, search for video, open video page
5. Verify that refreshing doesn't trigger `navigation_back` or `navigation_outside_youtube` pixels

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
