### PR TITLE
Fix endless loop when editing nested bookmarks bar item

### DIFF
--- a/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuPopover.swift
+++ b/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuPopover.swift
@@ -150,10 +150,10 @@ extension BookmarksBarMenuPopover: BookmarksBarMenuViewControllerDelegate {
     }
 
     func popover(shouldPreventClosure: Bool) {
-        var popover: BookmarksBarMenuPopover! = self
-        while popover != nil {
+        var window = contentViewController?.view.window
+        while let popover = window?.contentViewController?.nextResponder as? Self {
             popover.behavior = shouldPreventClosure ? .applicationDefined : .transient
-            popover = mainWindow?.contentViewController?.nextResponder as? BookmarksBarMenuPopover
+            window = window?.parent
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1208882942353448/f

**Description**:
- fixes an endless loop

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Create Folder -> Folder 1 -> Folder 2  in the Bookmarks Bar
2. Right click Folder 2 and choose Edit
3. Validate edit works fine and popovers stays on screen while editing

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
