### PR TITLE
Improve tab lazy loading test reliability

### DIFF
--- a/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/UnitTests/Sync/SyncPreferencesTests.swift
@@ -144,9 +144,10 @@ final class SyncPreferencesTests: XCTestCase {
 
     @MainActor func testOnTurnOffSyncThenSyncServiceIsDisconnected() async {
         let expectation = XCTestExpectation(description: "Disconnect completed")
-        Task {
+        Task { @MainActor in
             syncPreferences.turnOffSync()
             XCTAssertNil(managementDialogModel.currentDialog)
+            await Task.yield()
             expectation.fulfill()
         }
         await fulfillment(of: [expectation], timeout: 5.0)

--- a/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
+++ b/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
@@ -243,7 +243,7 @@ class TabLazyLoaderTests: XCTestCase {
         lazyLoader?.scheduleLazyLoading()
 
         // Then
-        waitForExpectations(timeout: 0.3)
+        waitForExpectations(timeout: 3.0)
         XCTAssertEqual(didFinishEvents.count, 1)
         XCTAssertEqual(try XCTUnwrap(didFinishEvents.first), true)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1208926119997580/f
Tech Design URL:
CC:

**Description**:

This is an experimental change to improve some CI reliability, after successfully reproducing failures locally and then applying this fix to resolve them. So far, I haven't seen another failure locally after a half dozen runs, whereas before I could reproduce this almost every time.

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Check that CI is green

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
