### PR TITLE
Ignore timeouts in the malicious site test suite

### DIFF
--- a/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/UnitTests/Sync/SyncPreferencesTests.swift
@@ -222,8 +222,9 @@ final class SyncPreferencesTests: XCTestCase {
     func test_WhenSyncIsTurnedOff_ErrorHandlerSyncDidTurnOffCalled() async {
         let expectation = XCTestExpectation(description: "Sync Turned off")
 
-        Task {
+        Task { @MainActor in
             syncPreferences.turnOffSync()
+            await Task.yield()
             expectation.fulfill()
         }
 


### PR DESCRIPTION
This allows us to still detect failures when the suite doesn't time out.

Task/Issue URL: https://app.asana.com/0/1199230911884351/1208926848453614/f
Tech Design URL:
CC:

**Description**:

This PR updates the malicious site tests to ignore time outs. These tests rely on an outside dependency which is not reliably loading; rather than disable them entirely, let's run them as expected in cases where the timeout doesn't occur.

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Check that the CI runs do not show any failures related to this test suite

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
