### PR TITLE
Fix flaky TabLazyLoaderTests

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1288,6 +1288,8 @@
 		37E260902C8A3ABE006EE07F /* HomePageSettingsModelNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E2608E2C8A3ABE006EE07F /* HomePageSettingsModelNavigator.swift */; };
 		37E260922C8A3EB4006EE07F /* MockHomePageSettingsModelNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E260912C8A3EB4006EE07F /* MockHomePageSettingsModelNavigator.swift */; };
 		37E260932C8A3EB4006EE07F /* MockHomePageSettingsModelNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E260912C8A3EB4006EE07F /* MockHomePageSettingsModelNavigator.swift */; };
+		37E307A72D072A1600599500 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 37E307A62D072A1600599500 /* Common */; };
+		37E307A92D072A1E00599500 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 37E307A82D072A1E00599500 /* Common */; };
 		37EE81412D00DBC40068034A /* WebKitExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 37EE81402D00DBC40068034A /* WebKitExtensions */; };
 		37EE81432D00DBCC0068034A /* WebKitExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 37EE81422D00DBCC0068034A /* WebKitExtensions */; };
 		37F19A6528E1B3FB00740DC6 /* PreferencesDuckPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F19A6428E1B3FB00740DC6 /* PreferencesDuckPlayerView.swift */; };
@@ -5116,6 +5118,7 @@
 				4B41EDAB2B1544B2001EEDF4 /* LoginItems in Frameworks */,
 				7B00997D2B6508B700FE7C31 /* NetworkProtectionProxy in Frameworks */,
 				7BEEA5122AD1235B00A9E72B /* NetworkProtectionIPC in Frameworks */,
+				37E307A72D072A1600599500 /* Common in Frameworks */,
 				7B8FDD202CDD88C500720907 /* FeatureFlags in Frameworks */,
 				7BA7CC5F2AD1210C0042E5CE /* Networking in Frameworks */,
 				02A15D942C88D78F001A4237 /* Persistence in Frameworks */,
@@ -5139,6 +5142,7 @@
 				7BA7CC612AD1211C0042E5CE /* Networking in Frameworks */,
 				F198C71C2BD18A61000BF24D /* PixelKit in Frameworks */,
 				02A15D982C88D79D001A4237 /* Persistence in Frameworks */,
+				37E307A92D072A1E00599500 /* Common in Frameworks */,
 				7BEEA5142AD1236300A9E72B /* NetworkProtectionIPC in Frameworks */,
 				02A15D962C88D797001A4237 /* Configuration in Frameworks */,
 				BDADBDCB2BD2BC2800421B9B /* Lottie in Frameworks */,
@@ -10105,6 +10109,7 @@
 				02A15D912C88D789001A4237 /* Configuration */,
 				02A15D932C88D78F001A4237 /* Persistence */,
 				7B8FDD1F2CDD88C500720907 /* FeatureFlags */,
+				37E307A62D072A1600599500 /* Common */,
 			);
 			productName = DuckDuckGoAgent;
 			productReference = 4B2D06392A11CFBB00DE1F49 /* DuckDuckGo VPN.app */;
@@ -10142,6 +10147,7 @@
 				02A15D952C88D797001A4237 /* Configuration */,
 				02A15D972C88D79D001A4237 /* Persistence */,
 				7B8FDD212CDD88CB00720907 /* FeatureFlags */,
+				37E307A82D072A1E00599500 /* Common */,
 			);
 			productName = DuckDuckGoAgentAppStore;
 			productReference = 4B2D06692A13318400DE1F49 /* DuckDuckGo VPN App Store.app */;
@@ -15604,6 +15610,16 @@
 		37DF37062CF38B9F005ED34B /* PrivacyStats */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PrivacyStats;
+		};
+		37E307A62D072A1600599500 /* Common */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9807F643278CA16F00E1547B /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
+			productName = Common;
+		};
+		37E307A82D072A1E00599500 /* Common */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9807F643278CA16F00E1547B /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
+			productName = Common;
 		};
 		37EE81402D00DBC40068034A /* WebKitExtensions */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
+++ b/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
@@ -59,7 +59,7 @@ private final class TabMock: LazyLoadable {
 
         reloadClosure = { tab in
             // instantly notify that loading has finished (or failed)
-            Task {
+            Task { @MainActor in
                 reloadExpectation?.fulfill()
                 tab.loadingFinishedSubject.send(tab)
             }
@@ -267,7 +267,7 @@ class TabLazyLoaderTests: XCTestCase {
         for i in 0..<(2 * maxNumberOfLazyLoadedTabs) {
             let tab = TabMock(isUrl: true, url: "http://\(i).com".url!, selectedTimestamp: Date(timeIntervalSince1970: .init(i)))
             tab.reloadClosure = { tab in
-                Task {
+                Task { @MainActor in
                     reloadedTabsIndices.append(i)
                     tab.loadingFinishedSubject.send(tab)
                     reloadExpectation.fulfill()

--- a/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
+++ b/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
@@ -59,7 +59,7 @@ private final class TabMock: LazyLoadable {
 
         reloadClosure = { tab in
             // instantly notify that loading has finished (or failed)
-            DispatchQueue.main.async {
+            Task {
                 reloadExpectation?.fulfill()
                 tab.loadingFinishedSubject.send(tab)
             }
@@ -146,7 +146,7 @@ class TabLazyLoaderTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(didFinishEvents.first), false)
     }
 
-    func testWhenSelectedTabIsNotUrlThenLazyLoadingStartsImmediately() throws {
+    func testWhenSelectedTabIsNotUrlThenLazyLoadingStartsImmediately() async throws {
         let reloadExpectation = expectation(description: "TabMock.reload() called")
         reloadExpectation.expectedFulfillmentCount = 2
 
@@ -157,21 +157,14 @@ class TabLazyLoaderTests: XCTestCase {
         ]
         dataSource.selectedTab = dataSource.tabs.first
 
-        let lazyLoader = TabLazyLoader(dataSource: dataSource)
+        let lazyLoader = try XCTUnwrap(TabLazyLoader(dataSource: dataSource))
 
-        var didFinishEvents: [Bool] = []
-        lazyLoader?.lazyLoadingDidFinishPublisher.sink(receiveValue: { didFinishEvents.append($0) }).store(in: &cancellables)
-
-        // When
-        lazyLoader?.scheduleLazyLoading()
-
-        // Then
-        waitForExpectations(timeout: 0.3)
-        XCTAssertEqual(didFinishEvents.count, 1)
-        XCTAssertEqual(try XCTUnwrap(didFinishEvents.first), true)
+        await waitForLoadingDidFinishEvent(lazyLoader, and: [reloadExpectation]) {
+            lazyLoader.scheduleLazyLoading()
+        }
     }
 
-    func testThatLazyLoadingStartsAfterCurrentUrlTabFinishesLoading() throws {
+    func testThatLazyLoadingStartsAfterCurrentUrlTabFinishesLoading() async throws {
         let reloadExpectation = expectation(description: "TabMock.reload() called")
         reloadExpectation.expectedFulfillmentCount = 2
 
@@ -184,19 +177,12 @@ class TabLazyLoaderTests: XCTestCase {
         ]
         dataSource.selectedTab = dataSource.tabs.first
 
-        let lazyLoader = TabLazyLoader(dataSource: dataSource)
+        let lazyLoader = try XCTUnwrap(TabLazyLoader(dataSource: dataSource))
 
-        var didFinishEvents: [Bool] = []
-        lazyLoader?.lazyLoadingDidFinishPublisher.sink(receiveValue: { didFinishEvents.append($0) }).store(in: &cancellables)
-
-        // When
-        lazyLoader?.scheduleLazyLoading()
-        selectedUrlTab.reload()
-
-        // Then
-        waitForExpectations(timeout: 0.3)
-        XCTAssertEqual(didFinishEvents.count, 1)
-        XCTAssertEqual(try XCTUnwrap(didFinishEvents.first), true)
+        await waitForLoadingDidFinishEvent(lazyLoader, and: [reloadExpectation]) {
+            lazyLoader.scheduleLazyLoading()
+            selectedUrlTab.reload()
+        }
     }
 
     func testThatLazyLoadingDoesNotStartIfCurrentUrlTabDoesNotFinishLoading() async throws {
@@ -223,7 +209,7 @@ class TabLazyLoaderTests: XCTestCase {
         await fulfillment(of: [reloadExpectation], timeout: 0.1)
     }
 
-    func testThatLazyLoadingStopsAfterLoadingMaximumNumberOfTabs() throws {
+    func testThatLazyLoadingStopsAfterLoadingMaximumNumberOfTabs() async throws {
         let maxNumberOfLazyLoadedTabs = TabLazyLoader<TabLazyLoaderDataSourceMock>.Const.maxNumberOfLazyLoadedTabs
         let reloadExpectation = expectation(description: "TabMock.reload() called")
         reloadExpectation.expectedFulfillmentCount = maxNumberOfLazyLoadedTabs
@@ -234,21 +220,14 @@ class TabLazyLoaderTests: XCTestCase {
         }
         dataSource.selectedTab = dataSource.tabs.first
 
-        let lazyLoader = TabLazyLoader(dataSource: dataSource)
+        let lazyLoader = try XCTUnwrap(TabLazyLoader(dataSource: dataSource))
 
-        var didFinishEvents: [Bool] = []
-        lazyLoader?.lazyLoadingDidFinishPublisher.sink(receiveValue: { didFinishEvents.append($0) }).store(in: &cancellables)
-
-        // When
-        lazyLoader?.scheduleLazyLoading()
-
-        // Then
-        waitForExpectations(timeout: 3.0)
-        XCTAssertEqual(didFinishEvents.count, 1)
-        XCTAssertEqual(try XCTUnwrap(didFinishEvents.first), true)
+        await waitForLoadingDidFinishEvent(lazyLoader, and: [reloadExpectation]) {
+            lazyLoader.scheduleLazyLoading()
+        }
     }
 
-    func testThatLazyLoadingSkipsTabsSelectedInCurrentSession() throws {
+    func testThatLazyLoadingSkipsTabsSelectedInCurrentSession() async throws {
         let reloadExpectation = expectation(description: "TabMock.reload() called")
         reloadExpectation.expectedFulfillmentCount = 2
 
@@ -257,34 +236,27 @@ class TabLazyLoaderTests: XCTestCase {
         dataSource.tabs = [
             selectedUrlTab,
             TabMock(isUrl: true, reloadExpectation: reloadExpectation),
-            TabMock(isUrl: true, reloadExpectation: reloadExpectation),
-            TabMock(isUrl: true, reloadExpectation: reloadExpectation),
+            TabMock(isUrl: true, reloadExpectation: reloadExpectation), // we expect this to be lazy loaded
+            TabMock(isUrl: true, reloadExpectation: reloadExpectation), // we expect this to be lazy loaded
             TabMock(isUrl: true, reloadExpectation: reloadExpectation),
             TabMock(isUrl: true, reloadExpectation: reloadExpectation)
         ]
         dataSource.selectedTab = selectedUrlTab
 
-        let lazyLoader = TabLazyLoader(dataSource: dataSource)
+        let lazyLoader = try XCTUnwrap(TabLazyLoader(dataSource: dataSource))
 
-        var didFinishEvents: [Bool] = []
-        lazyLoader?.lazyLoadingDidFinishPublisher.sink(receiveValue: { didFinishEvents.append($0) }).store(in: &cancellables)
+        await waitForLoadingDidFinishEvent(lazyLoader, and: [reloadExpectation]) {
+            lazyLoader.scheduleLazyLoading()
 
-        // When
-        lazyLoader?.scheduleLazyLoading()
+            dataSource.selectedTabSubject.send(dataSource.tabs[1])
+            dataSource.selectedTabSubject.send(dataSource.tabs[4])
+            dataSource.selectedTabSubject.send(dataSource.tabs[5])
 
-        dataSource.selectedTabSubject.send(dataSource.tabs[1])
-        dataSource.selectedTabSubject.send(dataSource.tabs[4])
-        dataSource.selectedTabSubject.send(dataSource.tabs[5])
-
-        selectedUrlTab.reload()
-
-        // Then
-        waitForExpectations(timeout: 1)
-        XCTAssertEqual(didFinishEvents.count, 1)
-        XCTAssertEqual(try XCTUnwrap(didFinishEvents.first), true)
+            selectedUrlTab.reload()
+        }
     }
 
-    func testWhenTabNumberExceedsMaximumForLazyLoadingThenAdjacentTabsAreLoadedFirst() throws {
+    func testWhenTabNumberExceedsMaximumForLazyLoadingThenAdjacentTabsAreLoadedFirst() async throws {
         let maxNumberOfLazyLoadedTabs = TabLazyLoader<TabLazyLoaderDataSourceMock>.Const.maxNumberOfLazyLoadedTabs
         let reloadExpectation = expectation(description: "TabMock.reload() called")
         reloadExpectation.expectedFulfillmentCount = maxNumberOfLazyLoadedTabs + 1
@@ -295,7 +267,7 @@ class TabLazyLoaderTests: XCTestCase {
         for i in 0..<(2 * maxNumberOfLazyLoadedTabs) {
             let tab = TabMock(isUrl: true, url: "http://\(i).com".url!, selectedTimestamp: Date(timeIntervalSince1970: .init(i)))
             tab.reloadClosure = { tab in
-                DispatchQueue.main.async {
+                Task {
                     reloadedTabsIndices.append(i)
                     tab.loadingFinishedSubject.send(tab)
                     reloadExpectation.fulfill()
@@ -308,28 +280,23 @@ class TabLazyLoaderTests: XCTestCase {
         dataSource.selectedTab = dataSource.tabs[3]
         dataSource.selectedTabIndex = .unpinned(3)
 
-        let lazyLoader = TabLazyLoader(dataSource: dataSource)
+        let lazyLoader = try XCTUnwrap(TabLazyLoader(dataSource: dataSource))
 
-        var didFinishEvents: [Bool] = []
-        lazyLoader?.lazyLoadingDidFinishPublisher.sink(receiveValue: { didFinishEvents.append($0) }).store(in: &cancellables)
+        await waitForLoadingDidFinishEvent(lazyLoader, and: [reloadExpectation]) {
+            lazyLoader.scheduleLazyLoading()
+            dataSource.selectedTab?.reload()
+        }
 
-        // When
-        lazyLoader?.scheduleLazyLoading()
-        dataSource.selectedTab?.reload()
-
-        // Then
-        waitForExpectations(timeout: 0.3)
-        XCTAssertEqual(didFinishEvents.count, 1)
         XCTAssertEqual(reloadedTabsIndices, [3, 4, 2, 5, 1, 6, 0, 7, 8, 9, 10, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30])
     }
 
     /**
      * This test sets up 2 tabs suitable for lazy loading.
-     * When the first one is reloaded, it artificially triggers currently selected tab reload.
+     * When the first one is lazy loaded, it artificially triggers currently selected tab reload.
      * This effectively pauses lazy loading and prevents the other tab from being reloaded
      * until currently selected tab is marked as done loading.
      */
-    func testWhenSelectedTabIsLoadingThenLazyLoadingIsPaused() throws {
+    func testWhenSelectedTabIsLoadingThenLazyLoadingIsPaused() async throws {
         var reloadedTabsUrls = [URL?]()
 
         let tabReloadClosure: (TabMock) -> Void = { tab in
@@ -351,28 +318,44 @@ class TabLazyLoaderTests: XCTestCase {
         dataSource.tabs = [.mockNotUrl, newTab, oldTab]
         dataSource.selectedTab = dataSource.tabs.first
 
-        let lazyLoader = TabLazyLoader(dataSource: dataSource)
+        let lazyLoader = try XCTUnwrap(TabLazyLoader(dataSource: dataSource))
 
-        var didFinishEvents: [Bool] = []
         var isLazyLoadingPausedEvents: [Bool] = []
+        lazyLoader.isLazyLoadingPausedPublisher.sink(receiveValue: { isLazyLoadingPausedEvents.append($0) }).store(in: &cancellables)
 
-        lazyLoader?.lazyLoadingDidFinishPublisher.sink(receiveValue: { didFinishEvents.append($0) }).store(in: &cancellables)
-        lazyLoader?.isLazyLoadingPausedPublisher.sink(receiveValue: { isLazyLoadingPausedEvents.append($0) }).store(in: &cancellables)
+        await waitForLoadingDidFinishEvent(lazyLoader) {
+            lazyLoader.scheduleLazyLoading()
+            XCTAssertEqual(reloadedTabsUrls, [newTab.url])
 
-        // When
-        lazyLoader?.scheduleLazyLoading()
+            // unpause lazy loading here
+            dataSource.isSelectedTabLoading = false
+            dataSource.isSelectedTabLoadingSubject.send(false)
+        }
 
-        XCTAssertEqual(reloadedTabsUrls, [newTab.url])
-
-        // unpause lazy loading here
-        dataSource.isSelectedTabLoading = false
-        dataSource.isSelectedTabLoadingSubject.send(false)
-
-        // Then
         XCTAssertEqual(reloadedTabsUrls, [newTab.url, oldTab.url])
-        XCTAssertEqual(didFinishEvents.count, 1)
         XCTAssertEqual(isLazyLoadingPausedEvents, [false, true, false])
-        XCTAssertEqual(try XCTUnwrap(didFinishEvents.first), true)
     }
 
+    func waitForLoadingDidFinishEvent<DataSource>(
+        _ lazyLoader: TabLazyLoader<DataSource>,
+        and otherExpectations: [XCTestExpectation] = [],
+        expectedDidFinishValue expectedValue: Bool = true,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ block: () async -> Void
+    ) async {
+
+        let expectation = self.expectation(description: "loadingDidFinish")
+        var result = false
+        let cancellable = lazyLoader.lazyLoadingDidFinishPublisher.sink { didLoadAnyTabs in
+            result = didLoadAnyTabs
+            expectation.fulfill()
+        }
+
+        await block()
+
+        await fulfillment(of: otherExpectations + [expectation], timeout: 2)
+        cancellable.cancel()
+        XCTAssertEqual(result, expectedValue, file: file, line: line)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208934054688674/f

**Description**:
This change updates TabLazyLoaderTests to use structured concurrency in place of DispatchQueue.main.async calls.

**Steps to test this PR**:
1. Verify that CI doesn't fail on "Build and run unit tests" step.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
