### PR TITLE
Implement hiding toolbars on full screen

### DIFF
--- a/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/DuckDuckGo/Common/Localizables/UserText.swift
@@ -704,6 +704,7 @@ struct UserText {
     static let themeSystem = NSLocalizedString("preferences.appearance.theme.system", value: "System", comment: "In the preferences for themes, the option to select for use the change the mode based on the system preferences.")
     static let addressBar = NSLocalizedString("preferences.appearance.address-bar", value: "Address Bar", comment: "Theme preferences")
     static let showFullWebsiteAddress = NSLocalizedString("preferences.appearance.show-full-url", value: "Full website address", comment: "Option to show full URL in the address bar")
+    static let hideToolbarsOnFullScreen = NSLocalizedString("preferences.appearance.hide-toolbars-on-full-screen", value: "Remove Tabs and Bookmarks Bar toolbars on Full Screen", comment: "Option to hide tabs and bookmarks bar toolbars on full screen")
     static let showAutocompleteSuggestions = NSLocalizedString("preferences.appearance.show-autocomplete-suggestions", value: "Autocomplete suggestions", comment: "Option to show autocomplete suggestions in the address bar")
     static let customizeBackground = NSLocalizedString("preferences.appearance.customize-background", value: "Customize Background", comment: "Button to open home page background customization options")
     static let zoomPickerTitle = NSLocalizedString("preferences.appearance.zoom-picker", value: "Default page zoom", comment: "Default page zoom picker title")

--- a/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -155,6 +155,8 @@ public struct UserDefaultsWrapper<T> {
         case centerAlignedBookmarksBar = "bookmarks.bar.center.aligned"
         case lastBookmarksBarUsagePixelSendDate = "bookmarks.bar.last-usage-pixel-send-date"
 
+        case hideToolbarsOnFullScreen = "hide.toolbars.on.fullscren"
+
         case pinnedViews = "pinning.pinned-views"
         case manuallyToggledPinnedViews = "pinning.manually-toggled-pinned-views"
 

--- a/DuckDuckGo/Localizable.xcstrings
+++ b/DuckDuckGo/Localizable.xcstrings
@@ -52814,6 +52814,18 @@
         }
       }
     },
+    "preferences.appearance.hide-toolbars-on-full-screen" : {
+      "comment" : "Option to hide tabs and bookmarks bar toolbars on full screen",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove Tabs and Bookmarks Bar toolbars on Full Screen"
+          }
+        }
+      }
+    },
     "preferences.appearance.show-autocomplete-suggestions" : {
       "comment" : "Option to show autocomplete suggestions in the address bar",
       "extractionState" : "extracted_with_value",

--- a/DuckDuckGo/MainWindow/MainView.swift
+++ b/DuckDuckGo/MainWindow/MainView.swift
@@ -31,6 +31,9 @@ final class MainView: NSView {
 
     private(set) var navigationBarTopConstraint: NSLayoutConstraint!
     private(set) var bookmarksBarHeightConstraint: NSLayoutConstraint!
+    private(set) var webContainerTopConstraint: NSLayoutConstraint!
+    private(set) var webContainerTopConstraintToNavigation: NSLayoutConstraint!
+    private(set) var tabBarHeightConstraint: NSLayoutConstraint!
 
     @Published var isMouseAboveWebView: Bool = false
 
@@ -59,14 +62,19 @@ final class MainView: NSView {
 
     private func addConstraints() {
         bookmarksBarHeightConstraint = bookmarksBarContainerView.heightAnchor.constraint(equalToConstant: 34)
-
+        tabBarHeightConstraint = tabBarContainerView.heightAnchor.constraint(equalToConstant: 38)
         navigationBarTopConstraint = navigationBarContainerView.topAnchor.constraint(equalTo: topAnchor, constant: 38)
+        webContainerTopConstraint = webContainerView.topAnchor.constraint(equalTo: bookmarksBarContainerView.bottomAnchor)
+        webContainerTopConstraintToNavigation = webContainerView.topAnchor.constraint(equalTo: navigationBarContainerView.bottomAnchor)
+
+        webContainerTopConstraint.priority = .defaultHigh
+        webContainerTopConstraintToNavigation.priority = .defaultLow
 
         NSLayoutConstraint.activate([
             tabBarContainerView.topAnchor.constraint(equalTo: topAnchor),
             tabBarContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
             tabBarContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            tabBarContainerView.heightAnchor.constraint(equalToConstant: 38),
+            tabBarHeightConstraint,
 
             divider.topAnchor.constraint(equalTo: navigationBarContainerView.bottomAnchor),
             divider.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -82,7 +90,8 @@ final class MainView: NSView {
             navigationBarContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
             navigationBarContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
-            webContainerView.topAnchor.constraint(equalTo: bookmarksBarContainerView.bottomAnchor),
+            webContainerTopConstraint,
+            webContainerTopConstraintToNavigation,
             webContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
             webContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
             webContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),

--- a/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/DuckDuckGo/MainWindow/MainViewController.swift
@@ -27,7 +27,7 @@ import os.log
 import BrokenSitePrompt
 
 final class MainViewController: NSViewController {
-    private lazy var mainView = MainView(frame: NSRect(x: 0, y: 0, width: 600, height: 660))
+    private(set) lazy var mainView = MainView(frame: NSRect(x: 0, y: 0, width: 600, height: 660))
 
     let tabBarViewController: TabBarViewController
     let navigationBarViewController: NavigationBarViewController

--- a/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
+++ b/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
@@ -39,6 +39,7 @@ protocol AppearancePreferencesPersistor {
     var homeButtonPosition: HomeButtonPosition { get set }
     var homePageCustomBackground: String? { get set }
     var centerAlignedBookmarksBar: Bool { get set }
+    var hideToolbarsOnFullScreen: Bool { get set }
 }
 
 struct AppearancePreferencesUserDefaultsPersistor: AppearancePreferencesPersistor {
@@ -101,6 +102,9 @@ struct AppearancePreferencesUserDefaultsPersistor: AppearancePreferencesPersisto
 
     @UserDefaultsWrapper(key: .centerAlignedBookmarksBar, defaultValue: true)
     var centerAlignedBookmarksBar: Bool
+
+    @UserDefaultsWrapper(key: .hideToolbarsOnFullScreen, defaultValue: false)
+    var hideToolbarsOnFullScreen: Bool
 }
 
 protocol HomePageNavigator {
@@ -205,6 +209,12 @@ final class AppearancePreferences: ObservableObject {
     @Published var showFullURL: Bool {
         didSet {
             persistor.showFullURL = showFullURL
+        }
+    }
+
+    @Published var hideToolbarsOnFullScreen: Bool {
+        didSet {
+            persistor.hideToolbarsOnFullScreen = hideToolbarsOnFullScreen
         }
     }
 
@@ -355,6 +365,7 @@ final class AppearancePreferences: ObservableObject {
         homeButtonPosition = persistor.homeButtonPosition
         homePageCustomBackground = persistor.homePageCustomBackground.flatMap(CustomBackground.init)
         centerAlignedBookmarksBarBool = persistor.centerAlignedBookmarksBar
+        hideToolbarsOnFullScreen = persistor.hideToolbarsOnFullScreen
     }
 
     private var persistor: AppearancePreferencesPersistor

--- a/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -99,6 +99,8 @@ extension Preferences {
                 // SECTION 2: Address Bar
                 PreferencePaneSection(UserText.addressBar) {
                     ToggleMenuItem(UserText.showFullWebsiteAddress, isOn: $model.showFullURL)
+
+                    ToggleMenuItem(UserText.hideToolbarsOnFullScreen, isOn: $model.hideToolbarsOnFullScreen)
                 }
 
                 // SECTION 3: New Tab Page

--- a/UnitTests/Preferences/AppearancePreferencesTests.swift
+++ b/UnitTests/Preferences/AppearancePreferencesTests.swift
@@ -38,6 +38,7 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
     var homePageCustomBackground: String?
     var centerAlignedBookmarksBar: Bool
     var didDismissHomePagePromotion: Bool
+    var hideToolbarsOnFullScreen: Bool
 
     init(
         showFullURL: Bool = false,
@@ -55,7 +56,8 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
         homeButtonPosition: HomeButtonPosition = .right,
         homePageCustomBackground: String? = nil,
         centerAlignedBookmarksBar: Bool = true,
-        didDismissHomePagePromotion: Bool = true
+        didDismissHomePagePromotion: Bool = true,
+        hideToolbarsOnFullScreen: Bool = false
     ) {
         self.showFullURL = showFullURL
         self.currentThemeName = currentThemeName
@@ -73,6 +75,7 @@ struct AppearancePreferencesPersistorMock: AppearancePreferencesPersistor {
         self.homePageCustomBackground = homePageCustomBackground
         self.centerAlignedBookmarksBar = centerAlignedBookmarksBar
         self.didDismissHomePagePromotion = didDismissHomePagePromotion
+        self.hideToolbarsOnFullScreen = hideToolbarsOnFullScreen
     }
 }
 
@@ -103,6 +106,7 @@ final class AppearancePreferencesTests: XCTestCase {
         XCTAssertEqual(model.homeButtonPosition, .left)
         XCTAssertEqual(model.homePageCustomBackground, .gradient(.gradient01))
         XCTAssertTrue(model.centerAlignedBookmarksBarBool)
+        XCTAssertFalse(model.hideToolbarsOnFullScreen)
 
         model = AppearancePreferences(
             persistor: AppearancePreferencesPersistorMock(
@@ -115,7 +119,8 @@ final class AppearancePreferencesTests: XCTestCase {
                 isSearchBarVisible: false,
                 homeButtonPosition: .left,
                 homePageCustomBackground: CustomBackground.gradient(.gradient05).description,
-                centerAlignedBookmarksBar: false
+                centerAlignedBookmarksBar: false,
+                hideToolbarsOnFullScreen: true
             )
         )
         XCTAssertEqual(model.showFullURL, true)
@@ -128,6 +133,7 @@ final class AppearancePreferencesTests: XCTestCase {
         XCTAssertEqual(model.homeButtonPosition, .left)
         XCTAssertEqual(model.homePageCustomBackground, .gradient(.gradient05))
         XCTAssertFalse(model.centerAlignedBookmarksBarBool)
+        XCTAssertTrue(model.hideToolbarsOnFullScreen)
     }
 
     func testWhenInitializedWithGarbageThenThemeIsSetToSystemDefault() throws {

--- a/UnitTests/Sync/Mocks/MockAppearancePreferencesPersistor.swift
+++ b/UnitTests/Sync/Mocks/MockAppearancePreferencesPersistor.swift
@@ -56,4 +56,6 @@ class MockAppearancePreferencesPersistor: AppearancePreferencesPersistor {
     var centerAlignedBookmarksBar: Bool = false
 
     var didDismissHomePagePromotion = true
+
+    var hideToolbarsOnFullScreen: Bool = false
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208939873445197/f
Tech Design URL:
CC:

**Description**:
Adds a setting that hides the tabs and bookmarks bar toolbars when on full-screen mode.

**Steps to test this PR**:
1. Go to Settings → Appearance → Check 'Remove Tabs and Bookmarks Bar toolbars on Full Screen'
2. Open a site
3. Enter full screen mode
4. The tabs toolbar and the bookmarks bar should be hidden automatically
5. When the user exits full screen mode, it should restore both toolbars
6. Disable the feature, both the bookmarks bar and the tabs toolbar should be visible on full screen

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
