### PR TITLE
include config dir clearance in clean-app script

### DIFF
--- a/clean-app.sh
+++ b/clean-app.sh
@@ -1,44 +1,49 @@
 #!/bin/bash
 
 delete_data() {
-	bundle_id="$1"
+    bundle_id="$1"
 
-	printf '%s' "Deleting data for ${bundle_id}..."
+    printf '%s' "Deleting data for ${bundle_id}..."
 
-	if defaults read "${bundle_id}" &>/dev/null; then
-		defaults delete "${bundle_id}"
-	fi
-	rm -r "${HOME}/Library/Containers/${bundle_id}/Data"
+    if defaults read "${bundle_id}" &>/dev/null; then
+        defaults delete "${bundle_id}"
+    fi
 
-	echo " Done."
+    data_path="${HOME}/Library/Containers/${bundle_id}/Data"
+    if [ -d "${data_path}" ]; then
+        rm -r "${data_path}" || { echo "Failed to delete ${data_path}"; exit 1; }
+        echo " Done."
+    else
+        printf '\nnothing to do for %s\n' "${data_path}"
+    fi
 }
 
 bundle_id=
 config_id=
 
 case "$1" in
-	debug)
-		bundle_id="com.duckduckgo.macos.browser.debug"
+    debug)
+        bundle_id="com.duckduckgo.macos.browser.debug"
         config_ids="*com.duckduckgo.macos.browser.app-configuration.debug"
-		netp_bundle_ids_glob="*com.duckduckgo.macos.browser.network-protection*debug"
-		;;
-	review)
-		bundle_id="com.duckduckgo.macos.browser.review"
+        netp_bundle_ids_glob="*com.duckduckgo.macos.browser.network-protection*debug"
+        ;;
+    review)
+        bundle_id="com.duckduckgo.macos.browser.review"
         config_ids="*com.duckduckgo.macos.browser.app-configuration.review"
-		netp_bundle_ids_glob="*com.duckduckgo.macos.browser.network-protection*review"
-		;;
-	debug-appstore)
-		bundle_id="com.duckduckgo.mobile.ios.debug"
+        netp_bundle_ids_glob="*com.duckduckgo.macos.browser.network-protection*review"
+        ;;
+    debug-appstore)
+        bundle_id="com.duckduckgo.mobile.ios.debug"
         config_ids="*com.duckduckgo.mobile.ios.app-configuration.debug"
-		;;
-	review-appstore)
-		bundle_id="com.duckduckgo.mobile.ios.review"
+        ;;
+    review-appstore)
+        bundle_id="com.duckduckgo.mobile.ios.review"
         config_ids="*com.duckduckgo.mobile.ios.app-configuration.review"
-		;;
-	*)
-		echo "usage: clean-app debug|review|debug-appstore|review-appstore"
-		exit 1
-		;;
+        ;;
+    *)
+        echo "usage: clean-app debug|review|debug-appstore|review-appstore"
+        exit 1
+        ;;
 esac
 
 delete_data "${bundle_id}"
@@ -54,20 +59,25 @@ read -r -a config_bundle_ids <<< $(
 for config_id in "${config_bundle_ids[@]}"; do
     path="${HOME}/Library/Group Containers/${config_id}"
     printf '%s' "Deleting data at ${path}... "
-    rm -r "${path}"
-    echo "Done."
+    if [ -d "${path}" ]; then
+        rm -r "${path}" || { echo "Failed to delete ${path}"; exit 1; }
+        echo "Done."
+    else
+        printf '\nnothing to do for %s\n' "${path}"
+    fi
+
 done
 
 if [[ -n "${netp_bundle_ids_glob}" ]]; then
-	# shellcheck disable=SC2046
-	read -r -a netp_bundle_ids <<< $(
-		find "${HOME}/Library/Containers/" \
-			-type d \
-			-maxdepth 1 \
-			-name "${netp_bundle_ids_glob}" \
-			-exec basename {} \;
-	)
-	for netp_bundle_id in "${netp_bundle_ids[@]}"; do
-		delete_data "${netp_bundle_id}"
-	done
+    # shellcheck disable=SC2046
+    read -r -a netp_bundle_ids <<< $(
+        find "${HOME}/Library/Containers/" \
+            -type d \
+            -maxdepth 1 \
+            -name "${netp_bundle_ids_glob}" \
+            -exec basename {} \;
+    )
+    for netp_bundle_id in "${netp_bundle_ids[@]}"; do
+        delete_data "${netp_bundle_id}"
+    done
 fi

--- a/clean-app.sh
+++ b/clean-app.sh
@@ -14,7 +14,7 @@ delete_data() {
         rm -r "${data_path}" || { echo "Failed to delete ${data_path}"; exit 1; }
         echo " Done."
     else
-        printf '\nnothing to do for %s\n' "${data_path}"
+        printf '\nNothing to do for %s\n' "${data_path}"
     fi
 }
 
@@ -63,7 +63,7 @@ for config_id in "${config_bundle_ids[@]}"; do
         rm -r "${path}" || { echo "Failed to delete ${path}"; exit 1; }
         echo "Done."
     else
-        printf '\nnothing to do for %s\n' "${path}"
+        printf '\nNothing to do for %s\n' "${path}"
     fi
 
 done


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208943073994046/f

**Description**:
- Include `~/Library/Group\ Containers/*.com.duckduckgo.macos.browser.app-configuration.debug/*` path to clear by the `./clean-app.sh` script

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Validate downloaded configs directory is cleared by the script for both DMG and AppStore builds

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
