### PR TITLE
Look up lowercased URLs in lowercased items dict

### DIFF
--- a/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -187,7 +187,7 @@ final class LocalBookmarkManager: BookmarkManager {
         }
 
         for variant in url.bookmarkButtonUrlVariants() {
-            let variantString = variant.absoluteString
+            let variantString = variant.absoluteString.lowercased()
             if let bookmark = list.lowercasedItemsDict[variantString]?.first {
                 return bookmark
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1208943052282180/f

**Description**:
This change fixes looking up bookmarks in the lowercased items dictionary by also lowercasing
the URL in question.

**Steps to test this PR**:
1. Verify that UI tests pass.

You can test manually by opening a mixed case URL such as https://pl.wikipedia.org/w/index.php?title=The_Mandalorian_%28sezon_1%29&oldid=75295490&veaction=edit and trying to bookmark it via context menu -> Bookmark Page. The bookmark icon in the address bar should be filled, indicating that the URL is now bookmarked.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
