### PR TITLE
Add pixels for Privacy Stats on HTML NTP

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1294,6 +1294,8 @@
 		37E307AC2D0745DB00599500 /* PrivacyStatsErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */; };
 		37E307AE2D07483400599500 /* NewTabPagePixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307AD2D07482F00599500 /* NewTabPagePixel.swift */; };
 		37E307AF2D07483400599500 /* NewTabPagePixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307AD2D07482F00599500 /* NewTabPagePixel.swift */; };
+		37E307B22D075B6500599500 /* NewTabPagePrivacyStatsEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307B12D075B5E00599500 /* NewTabPagePrivacyStatsEventHandler.swift */; };
+		37E307B32D075B6500599500 /* NewTabPagePrivacyStatsEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307B12D075B5E00599500 /* NewTabPagePrivacyStatsEventHandler.swift */; };
 		37EE81412D00DBC40068034A /* WebKitExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 37EE81402D00DBC40068034A /* WebKitExtensions */; };
 		37EE81432D00DBCC0068034A /* WebKitExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 37EE81422D00DBCC0068034A /* WebKitExtensions */; };
 		37F19A6528E1B3FB00740DC6 /* PreferencesDuckPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F19A6428E1B3FB00740DC6 /* PreferencesDuckPlayerView.swift */; };
@@ -3772,6 +3774,7 @@
 		37E260912C8A3EB4006EE07F /* MockHomePageSettingsModelNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHomePageSettingsModelNavigator.swift; sourceTree = "<group>"; };
 		37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyStatsErrorHandler.swift; sourceTree = "<group>"; };
 		37E307AD2D07482F00599500 /* NewTabPagePixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPagePixel.swift; sourceTree = "<group>"; };
+		37E307B12D075B5E00599500 /* NewTabPagePrivacyStatsEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPagePrivacyStatsEventHandler.swift; sourceTree = "<group>"; };
 		37E75733296F4F0500E1C162 /* UnitTestsAppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UnitTestsAppStore.xcconfig; sourceTree = "<group>"; };
 		37E75734296F4F0500E1C162 /* IntegrationTestsAppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = IntegrationTestsAppStore.xcconfig; sourceTree = "<group>"; };
 		37F19A6428E1B3FB00740DC6 /* PreferencesDuckPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesDuckPlayerView.swift; sourceTree = "<group>"; };
@@ -5827,6 +5830,7 @@
 		376788092CECCAD900F59D83 /* NewTabPage */ = {
 			isa = PBXGroup;
 			children = (
+				37E307B12D075B5E00599500 /* NewTabPagePrivacyStatsEventHandler.swift */,
 				374EFDF22D01C99700B30939 /* ActiveRemoteMessageModel+NewTabPage.swift */,
 				372D15EB2D00FA1400A11576 /* AppearancePreferences+NewTabPage.swift */,
 				372D15E82D00F18E00A11576 /* ContinueSetUpModel+NewTabPage.swift */,
@@ -11954,6 +11958,7 @@
 				3706FC23293F65D500E42796 /* StatisticsStore.swift in Sources */,
 				1DDD3EBD2B84DCB9004CBF2B /* WebTrackingProtectionPreferences.swift in Sources */,
 				3706FC25293F65D500E42796 /* ColorView.swift in Sources */,
+				37E307B32D075B6500599500 /* NewTabPagePrivacyStatsEventHandler.swift in Sources */,
 				3706FC26293F65D500E42796 /* RecentlyClosedCacheItem.swift in Sources */,
 				3706FC27293F65D500E42796 /* PopupBlockedPopover.swift in Sources */,
 				F1476FC12C1359FB00EAE46A /* SubscriptionUIHandler.swift in Sources */,
@@ -13345,6 +13350,7 @@
 				7B22D86E2CCFD7B7006A76E1 /* TipKitController.swift in Sources */,
 				B68C2FB227706E6A00BF2C7D /* ProcessExtension.swift in Sources */,
 				CD2AB5CA2C8225E70019EB49 /* URLTokenValidator.swift in Sources */,
+				37E307B22D075B6500599500 /* NewTabPagePrivacyStatsEventHandler.swift in Sources */,
 				B6106BA726A7BECC0013B453 /* PermissionAuthorizationQuery.swift in Sources */,
 				CD2AB5C32C8222F70019EB49 /* MaliciousSiteProtectionState.swift in Sources */,
 				3171D6BA288984D00068632A /* BadgeAnimationView.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -5992,10 +5992,10 @@
 		37C9F78E2CF1C855004D73A1 /* PrivacyStats */ = {
 			isa = PBXGroup;
 			children = (
-				37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */,
 				37FC2A162CF903000048E226 /* Mocks */,
-				370245FC2CF7C64B00CD79A3 /* PrivacyStatsTrackerDataProvider.swift */,
 				37DF37082CF38CD3005ED34B /* PrivacyStatsDatabase.swift */,
+				37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */,
+				370245FC2CF7C64B00CD79A3 /* PrivacyStatsTrackerDataProvider.swift */,
 			);
 			path = PrivacyStats;
 			sourceTree = "<group>";

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1290,6 +1290,10 @@
 		37E260932C8A3EB4006EE07F /* MockHomePageSettingsModelNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E260912C8A3EB4006EE07F /* MockHomePageSettingsModelNavigator.swift */; };
 		37E307A72D072A1600599500 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 37E307A62D072A1600599500 /* Common */; };
 		37E307A92D072A1E00599500 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 37E307A82D072A1E00599500 /* Common */; };
+		37E307AB2D0745DB00599500 /* PrivacyStatsErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */; };
+		37E307AC2D0745DB00599500 /* PrivacyStatsErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */; };
+		37E307AE2D07483400599500 /* NewTabPagePixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307AD2D07482F00599500 /* NewTabPagePixel.swift */; };
+		37E307AF2D07483400599500 /* NewTabPagePixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307AD2D07482F00599500 /* NewTabPagePixel.swift */; };
 		37EE81412D00DBC40068034A /* WebKitExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 37EE81402D00DBC40068034A /* WebKitExtensions */; };
 		37EE81432D00DBCC0068034A /* WebKitExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 37EE81422D00DBCC0068034A /* WebKitExtensions */; };
 		37F19A6528E1B3FB00740DC6 /* PreferencesDuckPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F19A6428E1B3FB00740DC6 /* PreferencesDuckPlayerView.swift */; };
@@ -3766,6 +3770,8 @@
 		37E2608B2C8A1F6D006EE07F /* UserColorProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserColorProviding.swift; sourceTree = "<group>"; };
 		37E2608E2C8A3ABE006EE07F /* HomePageSettingsModelNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageSettingsModelNavigator.swift; sourceTree = "<group>"; };
 		37E260912C8A3EB4006EE07F /* MockHomePageSettingsModelNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHomePageSettingsModelNavigator.swift; sourceTree = "<group>"; };
+		37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyStatsErrorHandler.swift; sourceTree = "<group>"; };
+		37E307AD2D07482F00599500 /* NewTabPagePixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPagePixel.swift; sourceTree = "<group>"; };
 		37E75733296F4F0500E1C162 /* UnitTestsAppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UnitTestsAppStore.xcconfig; sourceTree = "<group>"; };
 		37E75734296F4F0500E1C162 /* IntegrationTestsAppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = IntegrationTestsAppStore.xcconfig; sourceTree = "<group>"; };
 		37F19A6428E1B3FB00740DC6 /* PreferencesDuckPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesDuckPlayerView.swift; sourceTree = "<group>"; };
@@ -5982,6 +5988,7 @@
 		37C9F78E2CF1C855004D73A1 /* PrivacyStats */ = {
 			isa = PBXGroup;
 			children = (
+				37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */,
 				37FC2A162CF903000048E226 /* Mocks */,
 				370245FC2CF7C64B00CD79A3 /* PrivacyStatsTrackerDataProvider.swift */,
 				37DF37082CF38CD3005ED34B /* PrivacyStatsDatabase.swift */,
@@ -9303,6 +9310,7 @@
 				F18826832BBEE31700D9AC4F /* PixelKit+Assertion.swift */,
 				F188267F2BBEB58100D9AC4F /* PrivacyProPixel.swift */,
 				370270BB2C78AC6F002E44E4 /* NewTabBackgroundPixel.swift */,
+				37E307AD2D07482F00599500 /* NewTabPagePixel.swift */,
 				56DB9FE82CD24B47001BEC23 /* ContextualOnboardingPixel.swift */,
 				37219B362CBFBC8200C9D7A8 /* NewTabSearchBoxExperimentPixel.swift */,
 			);
@@ -11399,6 +11407,7 @@
 				3706FAF3293F65D500E42796 /* LocalAuthenticationService.swift in Sources */,
 				1D36E659298AA3BA00AA485D /* InternalUserDeciderStore.swift in Sources */,
 				B6BCC5242AFCDABB002C5499 /* DataImportSourceViewModel.swift in Sources */,
+				37E307AF2D07483400599500 /* NewTabPagePixel.swift in Sources */,
 				B6F1B02B2BCE675C005E863C /* NetworkProtectionControllerTabExtension.swift in Sources */,
 				3706FEBC293F6EFF00E42796 /* BWResponse.swift in Sources */,
 				B65C7DFC2B886CF0001E2D5C /* WKPDFHUDViewWrapper.swift in Sources */,
@@ -11984,6 +11993,7 @@
 				4B9DB04B2A983B24000927DB /* NotificationService.swift in Sources */,
 				3706FC3A293F65D500E42796 /* NSOpenPanelExtensions.swift in Sources */,
 				F118EA862BEACC7000F77634 /* NonStandardPixel.swift in Sources */,
+				37E307AC2D0745DB00599500 /* PrivacyStatsErrorHandler.swift in Sources */,
 				3706FC3B293F65D500E42796 /* FirePopover.swift in Sources */,
 				4B4D60C12A0C848E00BCD287 /* NetworkProtectionControllerErrorStore.swift in Sources */,
 				3706FC3E293F65D500E42796 /* VariantManager.swift in Sources */,
@@ -13347,6 +13357,7 @@
 				370C23092C76A39900A80A3E /* BackgroundCategoryView.swift in Sources */,
 				56D6A3D629DB2BAB0055215A /* ContinueSetUpView.swift in Sources */,
 				B6B5F5842B03580A008DB58A /* RequestFilePermissionView.swift in Sources */,
+				37E307AB2D0745DB00599500 /* PrivacyStatsErrorHandler.swift in Sources */,
 				4B1E6EEE27AB5E5100F51793 /* PasswordManagementListSection.swift in Sources */,
 				31C9ADE52AF0564500CEF57D /* WaitlistFeatureSetupHandler.swift in Sources */,
 				AA222CB92760F74E00321475 /* FaviconReferenceCache.swift in Sources */,
@@ -13616,6 +13627,7 @@
 				3712092A2C2333A0003ADF3D /* RemoteMessagingDatabase.swift in Sources */,
 				F1FDC9382BF51F41006B1435 /* VPNSettings+Environment.swift in Sources */,
 				3158B14A2B0BF74300AF130C /* DataBrokerProtectionDebugMenu.swift in Sources */,
+				37E307AE2D07483400599500 /* NewTabPagePixel.swift in Sources */,
 				4BBDEE9128FC14760092FAA6 /* BWInstallationService.swift in Sources */,
 				7B4D8A212BDA857300852966 /* VPNOperationErrorRecorder.swift in Sources */,
 				F17E7DDE2C7C83E500907A84 /* Logger+FileDownload.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1115,8 +1115,6 @@
 		372A0FED2B2379310033BF7F /* SyncMetricsEventsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372A0FEB2B2379310033BF7F /* SyncMetricsEventsHandler.swift */; };
 		372BC2A12A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372BC2A02A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift */; };
 		372BC2A22A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372BC2A02A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift */; };
-		372D15E92D00F19500A11576 /* ContinueSetUpModel+NewTabPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372D15E82D00F18E00A11576 /* ContinueSetUpModel+NewTabPage.swift */; };
-		372D15EA2D00F19500A11576 /* ContinueSetUpModel+NewTabPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372D15E82D00F18E00A11576 /* ContinueSetUpModel+NewTabPage.swift */; };
 		372D15EC2D00FA1A00A11576 /* AppearancePreferences+NewTabPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372D15EB2D00FA1400A11576 /* AppearancePreferences+NewTabPage.swift */; };
 		372D15ED2D00FA1A00A11576 /* AppearancePreferences+NewTabPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372D15EB2D00FA1400A11576 /* AppearancePreferences+NewTabPage.swift */; };
 		3739326529AE4B39009346AE /* DDGSync in Frameworks */ = {isa = PBXBuildFile; productRef = 3739326429AE4B39009346AE /* DDGSync */; };
@@ -1230,6 +1228,8 @@
 		37B11B3928095E6600CBB621 /* TabLazyLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B11B3828095E6600CBB621 /* TabLazyLoader.swift */; };
 		37BA812D29B3CD690053F1A3 /* SyncUI in Frameworks */ = {isa = PBXBuildFile; productRef = 37BA812C29B3CD690053F1A3 /* SyncUI */; };
 		37BA812F29B3CD6E0053F1A3 /* SyncUI in Frameworks */ = {isa = PBXBuildFile; productRef = 37BA812E29B3CD6E0053F1A3 /* SyncUI */; };
+		37BE087A2D09C0F200C77B8E /* NewTabPageNextStepsCardsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BE08792D09C0EA00C77B8E /* NewTabPageNextStepsCardsProvider.swift */; };
+		37BE087B2D09C0F200C77B8E /* NewTabPageNextStepsCardsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BE08792D09C0EA00C77B8E /* NewTabPageNextStepsCardsProvider.swift */; };
 		37BF3F14286D8A6500BD9014 /* PinnedTabsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BF3F13286D8A6500BD9014 /* PinnedTabsManager.swift */; };
 		37BF3F21286F0A7A00BD9014 /* PinnedTabsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BF3F1E286F0A7A00BD9014 /* PinnedTabsViewModel.swift */; };
 		37BF3F22286F0A7A00BD9014 /* PinnedTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BF3F1F286F0A7A00BD9014 /* PinnedTabsView.swift */; };
@@ -3646,7 +3646,6 @@
 		37219B3C2CC27DB300C9D7A8 /* NewTabPageSearchBoxExperimentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSearchBoxExperimentTests.swift; sourceTree = "<group>"; };
 		372A0FEB2B2379310033BF7F /* SyncMetricsEventsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMetricsEventsHandler.swift; sourceTree = "<group>"; };
 		372BC2A02A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCredentialsAdapter.swift; sourceTree = "<group>"; };
-		372D15E82D00F18E00A11576 /* ContinueSetUpModel+NewTabPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContinueSetUpModel+NewTabPage.swift"; sourceTree = "<group>"; };
 		372D15EB2D00FA1400A11576 /* AppearancePreferences+NewTabPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppearancePreferences+NewTabPage.swift"; sourceTree = "<group>"; };
 		373A1AA7283ED1B900586521 /* BookmarkHTMLReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkHTMLReader.swift; sourceTree = "<group>"; };
 		373A1AA9283ED86C00586521 /* BookmarksHTMLReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksHTMLReaderTests.swift; sourceTree = "<group>"; };
@@ -3730,6 +3729,7 @@
 		37AFCE9127DB8CAD00471A10 /* PreferencesAboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesAboutView.swift; sourceTree = "<group>"; };
 		37B11B3828095E6600CBB621 /* TabLazyLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLazyLoader.swift; sourceTree = "<group>"; };
 		37BA812B29B3CB8A0053F1A3 /* SyncUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SyncUI; sourceTree = "<group>"; };
+		37BE08792D09C0EA00C77B8E /* NewTabPageNextStepsCardsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageNextStepsCardsProvider.swift; sourceTree = "<group>"; };
 		37BF3F13286D8A6500BD9014 /* PinnedTabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTabsManager.swift; sourceTree = "<group>"; };
 		37BF3F1E286F0A7A00BD9014 /* PinnedTabsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinnedTabsViewModel.swift; sourceTree = "<group>"; };
 		37BF3F1F286F0A7A00BD9014 /* PinnedTabsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinnedTabsView.swift; sourceTree = "<group>"; };
@@ -5830,10 +5830,10 @@
 		376788092CECCAD900F59D83 /* NewTabPage */ = {
 			isa = PBXGroup;
 			children = (
+				37BE08792D09C0EA00C77B8E /* NewTabPageNextStepsCardsProvider.swift */,
 				37E307B12D075B5E00599500 /* NewTabPagePrivacyStatsEventHandler.swift */,
 				374EFDF22D01C99700B30939 /* ActiveRemoteMessageModel+NewTabPage.swift */,
 				372D15EB2D00FA1400A11576 /* AppearancePreferences+NewTabPage.swift */,
-				372D15E82D00F18E00A11576 /* ContinueSetUpModel+NewTabPage.swift */,
 				3772BEDC2D019CDF0019B9EF /* DefaultsFavoritesActionHandler.swift */,
 				371BBC5D2D00CA3E008FA0C7 /* NewTabPageWebViewModel.swift */,
 				371BBC5A2D00C911008FA0C7 /* NewTabPageActionsManagerExtension.swift */,
@@ -11615,6 +11615,7 @@
 				1D4071AF2BD64267002D4537 /* DockCustomizer.swift in Sources */,
 				C153E7C32C8AD68D00B9BAD7 /* FreemiumDBPPromotionViewCoordinator.swift in Sources */,
 				4B41EDA42B1543B9001EEDF4 /* VPNPreferencesModel.swift in Sources */,
+				37BE087A2D09C0F200C77B8E /* NewTabPageNextStepsCardsProvider.swift in Sources */,
 				1E559BB22BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift in Sources */,
 				3706FB6C293F65D500E42796 /* FaviconStore.swift in Sources */,
 				3706FB6D293F65D500E42796 /* SuggestionListCharacteristics.swift in Sources */,
@@ -12092,7 +12093,6 @@
 				B6C0BB6829AEFF8100AE8E3C /* BookmarkExtension.swift in Sources */,
 				B69A14FB2B4D705D00B9417D /* BookmarkFolderPicker.swift in Sources */,
 				3706FC6C293F65D500E42796 /* BookmarkViewModel.swift in Sources */,
-				372D15EA2D00F19500A11576 /* ContinueSetUpModel+NewTabPage.swift in Sources */,
 				3706FC6D293F65D500E42796 /* DaxSpeech.swift in Sources */,
 				CB63DECC2CDC0BBE0097986A /* PageRefreshMonitor.swift in Sources */,
 				3706FC6E293F65D500E42796 /* DuckURLSchemeHandler.swift in Sources */,
@@ -12901,6 +12901,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAA0CC572539EBC90079BC96 /* FaviconUserScript.swift in Sources */,
+				37BE087B2D09C0F200C77B8E /* NewTabPageNextStepsCardsProvider.swift in Sources */,
 				3158B1532B0BF75700AF130C /* LoginItem+DataBrokerProtection.swift in Sources */,
 				1D2DC0082901679E008083A1 /* BWResponse.swift in Sources */,
 				AADCBF3A26F7C2CE00EF67A8 /* LottieAnimationCache.swift in Sources */,
@@ -13320,7 +13321,6 @@
 				3199AF792C80734A003AEBDC /* DuckPlayerOnboardingViewModel.swift in Sources */,
 				B6685E4229A61C470043D2EE /* DownloadsTabExtension.swift in Sources */,
 				4B8AC93B26B48ADF00879451 /* ASN1Parser.swift in Sources */,
-				372D15E92D00F19500A11576 /* ContinueSetUpModel+NewTabPage.swift in Sources */,
 				856C98DF257014BD00A22F1F /* FileDownloadManager.swift in Sources */,
 				4BB99CFF26FE191E001E4761 /* BookmarkImport.swift in Sources */,
 				B68503A7279141CD00893A05 /* KeySetDictionary.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -5000,6 +5000,10 @@
 		FD23FD2C2886A81D007F6985 /* AutoconsentManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoconsentManagement.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		3792D51A2D09C72200FC15D6 /* NewTabPage */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = NewTabPage; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		3706FCA6293F65D500E42796 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -8035,6 +8039,7 @@
 				1D3B1AB7293405F5006F4388 /* PasswordManagers */,
 				B6106BA126A7BE430013B453 /* Permissions */,
 				CD34F0BE2C886462006826BE /* MaliciousSiteProtection */,
+				3792D51A2D09C72200FC15D6 /* NewTabPage */,
 				37D2377E287EFECD00BCE03B /* PinnedTabs */,
 				4B0511EE262CAEB300F6079C /* Preferences */,
 				31E163BB293A577200963C10 /* PrivacyReferenceTests */,
@@ -9975,6 +9980,9 @@
 				B6AEB5552BA3042300781A09 /* PBXTargetDependency */,
 				37079A93294236F20031BB3C /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				3792D51A2D09C72200FC15D6 /* NewTabPage */,
+			);
 			name = "Unit Tests App Store";
 			packageProductDependencies = (
 				3706FDD6293F661700E42796 /* OHHTTPStubs */,
@@ -10461,6 +10469,9 @@
 			dependencies = (
 				B6E6BA1D2BA2E049008AA7E1 /* PBXTargetDependency */,
 				B6CAC23D2B8F0EC6006CD402 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				3792D51A2D09C72200FC15D6 /* NewTabPage */,
 			);
 			name = "Unit Tests";
 			packageProductDependencies = (

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -327,7 +327,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 #if DEBUG
         if NSApplication.runType.requiresEnvironment {
-            privacyStats = PrivacyStats(databaseProvider: PrivacyStatsDatabase())
+            privacyStats = PrivacyStats(databaseProvider: PrivacyStatsDatabase(), errorEvents: PrivacyStatsErrorHandler())
         } else {
             privacyStats = MockPrivacyStats()
         }

--- a/DuckDuckGo/NewTabPage/ContinueSetUpModel+NewTabPage.swift
+++ b/DuckDuckGo/NewTabPage/ContinueSetUpModel+NewTabPage.swift
@@ -62,6 +62,7 @@ extension HomePage.Models.ContinueSetUpModel: NewTabPageNextStepsCardsProviding 
         guard cards.contains(.addAppToDockMac) else {
             return
         }
+        continueSetUpCardsViewDidAppear()
         PixelKit.fire(GeneralPixel.addToDockNewTabPageCardPresented,
                       frequency: .uniqueByName,
                       includeAppVersionParameter: false)

--- a/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -44,7 +44,7 @@ extension NewTabPageActionsManager {
         self.init(scriptClients: [
             NewTabPageConfigurationClient(sectionsVisibilityProvider: appearancePreferences),
             NewTabPageRMFClient(remoteMessageProvider: activeRemoteMessageModel),
-            NewTabPageNextStepsCardsClient(model: HomePage.Models.ContinueSetUpModel(tabOpener: NewTabPageTabOpener())),
+            NewTabPageNextStepsCardsClient(model: NewTabPageNextStepsCardsProvider(continueSetUpModel: HomePage.Models.ContinueSetUpModel(tabOpener: NewTabPageTabOpener()))),
             NewTabPageFavoritesClient(favoritesModel: favoritesModel, preferredFaviconSize: Int(Favicon.SizeCategory.medium.rawValue)),
             NewTabPagePrivacyStatsClient(model: privacyStatsModel)
         ])

--- a/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -30,6 +30,7 @@ extension NewTabPageActionsManager {
         let privacyStatsModel = NewTabPagePrivacyStatsModel(
             privacyStats: privacyStats,
             trackerDataProvider: PrivacyStatsTrackerDataProvider(contentBlocking: ContentBlocking.shared),
+            eventMapping: NewTabPagePrivacyStatsEventHandler(),
             getLegacyIsViewExpandedSetting: UserDefaultsWrapper<Bool>(key: .homePageShowRecentlyVisited, defaultValue: false).wrappedValue
         )
 

--- a/DuckDuckGo/NewTabPage/NewTabPageNextStepsCardsProvider.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPageNextStepsCardsProvider.swift
@@ -53,7 +53,7 @@ final class NewTabPageNextStepsCardsProvider: NewTabPageNextStepsCardsProviding 
 
     var cardsPublisher: AnyPublisher<[NewTabPageNextStepsCardsClient.CardID], Never> {
         let features = continueSetUpModel.$featuresMatrix.dropFirst().removeDuplicates()
-        let cardsDidBecomeOutdated = appearancePreferences.$isContinueSetUpCardsViewOutdated.filter({ $0 })
+        let cardsDidBecomeOutdated = appearancePreferences.$isContinueSetUpCardsViewOutdated.dropFirst().removeDuplicates()
 
         return Publishers.CombineLatest(features, cardsDidBecomeOutdated)
             .map { features, isOutdated -> [NewTabPageNextStepsCardsClient.CardID] in

--- a/DuckDuckGo/NewTabPage/NewTabPageNextStepsCardsProvider.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPageNextStepsCardsProvider.swift
@@ -53,7 +53,7 @@ final class NewTabPageNextStepsCardsProvider: NewTabPageNextStepsCardsProviding 
 
     var cardsPublisher: AnyPublisher<[NewTabPageNextStepsCardsClient.CardID], Never> {
         let features = continueSetUpModel.$featuresMatrix.dropFirst().removeDuplicates()
-        let cardsDidBecomeOutdated = appearancePreferences.$isContinueSetUpCardsViewOutdated.dropFirst().removeDuplicates()
+        let cardsDidBecomeOutdated = appearancePreferences.$isContinueSetUpCardsViewOutdated.removeDuplicates()
 
         return Publishers.CombineLatest(features, cardsDidBecomeOutdated)
             .map { features, isOutdated -> [NewTabPageNextStepsCardsClient.CardID] in

--- a/DuckDuckGo/NewTabPage/NewTabPageNextStepsCardsProvider.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPageNextStepsCardsProvider.swift
@@ -1,5 +1,5 @@
 //
-//  ContinueSetUpModel+NewTabPage.swift
+//  NewTabPageNextStepsCardsProvider.swift
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //
@@ -22,26 +22,34 @@ import NewTabPage
 import PixelKit
 import UserScript
 
-extension HomePage.Models.ContinueSetUpModel: NewTabPageNextStepsCardsProviding {
+final class NewTabPageNextStepsCardsProvider: NewTabPageNextStepsCardsProviding {
+    let continueSetUpModel: HomePage.Models.ContinueSetUpModel
+    let appearancePreferences: AppearancePreferences
+
+    init(continueSetUpModel: HomePage.Models.ContinueSetUpModel, appearancePreferences: AppearancePreferences = .shared) {
+        self.continueSetUpModel = continueSetUpModel
+        self.appearancePreferences = appearancePreferences
+    }
+
     var isViewExpanded: Bool {
         get {
-            shouldShowAllFeatures
+            continueSetUpModel.shouldShowAllFeatures
         }
         set {
-            shouldShowAllFeatures = newValue
+            continueSetUpModel.shouldShowAllFeatures = newValue
         }
     }
 
     var isViewExpandedPublisher: AnyPublisher<Bool, Never> {
-        shouldShowAllFeaturesPublisher.eraseToAnyPublisher()
+        continueSetUpModel.shouldShowAllFeaturesPublisher.eraseToAnyPublisher()
     }
 
     var cards: [NewTabPageNextStepsCardsClient.CardID] {
-        featuresMatrix.flatMap { $0.map(NewTabPageNextStepsCardsClient.CardID.init) }
+        continueSetUpModel.featuresMatrix.flatMap { $0.map(NewTabPageNextStepsCardsClient.CardID.init) }
     }
 
     var cardsPublisher: AnyPublisher<[NewTabPageNextStepsCardsClient.CardID], Never> {
-        $featuresMatrix.dropFirst().removeDuplicates()
+        continueSetUpModel.$featuresMatrix.dropFirst().removeDuplicates()
             .map { matrix in
                 matrix.flatMap { $0.map(NewTabPageNextStepsCardsClient.CardID.init) }
             }
@@ -50,19 +58,24 @@ extension HomePage.Models.ContinueSetUpModel: NewTabPageNextStepsCardsProviding 
 
     @MainActor
     func handleAction(for card: NewTabPageNextStepsCardsClient.CardID) {
-        performAction(for: .init(card))
+        continueSetUpModel.performAction(for: .init(card))
     }
 
     @MainActor
     func dismiss(_ card: NewTabPageNextStepsCardsClient.CardID) {
-        removeItem(for: .init(card))
+        continueSetUpModel.removeItem(for: .init(card))
     }
 
+    @MainActor
     func willDisplayCards(_ cards: [NewTabPageNextStepsCardsClient.CardID]) {
+        appearancePreferences.continueSetUpCardsViewDidAppear()
+        fireAddToDockPixelIfNeeded(cards)
+    }
+
+    private func fireAddToDockPixelIfNeeded(_ cards: [NewTabPageNextStepsCardsClient.CardID]) {
         guard cards.contains(.addAppToDockMac) else {
             return
         }
-        continueSetUpCardsViewDidAppear()
         PixelKit.fire(GeneralPixel.addToDockNewTabPageCardPresented,
                       frequency: .uniqueByName,
                       includeAppVersionParameter: false)

--- a/DuckDuckGo/NewTabPage/NewTabPagePrivacyStatsEventHandler.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPagePrivacyStatsEventHandler.swift
@@ -1,0 +1,39 @@
+//
+//  NewTabPagePrivacyStatsEventHandler.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import PixelKit
+import NewTabPage
+
+final class NewTabPagePrivacyStatsEventHandler: EventMapping<NewTabPagePrivacyStatsEvent> {
+
+    init() {
+        super.init { event, _, _, _ in
+            switch event {
+            case .showLess:
+                PixelKit.fire(NewTabPagePixel.blockedTrackingAttemptsShowLess, frequency: .dailyAndCount)
+            case .showMore:
+                PixelKit.fire(NewTabPagePixel.blockedTrackingAttemptsShowMore, frequency: .dailyAndCount)
+            }
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<NewTabPagePrivacyStatsEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}

--- a/DuckDuckGo/PrivacyStats/PrivacyStatsDatabase.swift
+++ b/DuckDuckGo/PrivacyStats/PrivacyStatsDatabase.swift
@@ -43,9 +43,9 @@ public final class PrivacyStatsDatabase: PrivacyStatsDatabaseProviding {
             db.loadStore { context, error in
                 guard context != nil else {
                     if let error = error {
-                        PixelKit.fire(DebugEvent(GeneralPixel.privacyStatsCouldNotLoadDatabase, error: error))
+                        PixelKit.fire(DebugEvent(NewTabPagePixel.privacyStatsCouldNotLoadDatabase, error: error), frequency: .dailyAndCount)
                     } else {
-                        PixelKit.fire(DebugEvent(GeneralPixel.privacyStatsCouldNotLoadDatabase))
+                        PixelKit.fire(DebugEvent(NewTabPagePixel.privacyStatsCouldNotLoadDatabase), frequency: .dailyAndCount)
                     }
 
                     Thread.sleep(forTimeInterval: 1)

--- a/DuckDuckGo/PrivacyStats/PrivacyStatsErrorHandler.swift
+++ b/DuckDuckGo/PrivacyStats/PrivacyStatsErrorHandler.swift
@@ -32,4 +32,3 @@ final class PrivacyStatsErrorHandler: EventMapping<PrivacyStatsError> {
         fatalError("Use init()")
     }
 }
-

--- a/DuckDuckGo/PrivacyStats/PrivacyStatsErrorHandler.swift
+++ b/DuckDuckGo/PrivacyStats/PrivacyStatsErrorHandler.swift
@@ -24,7 +24,7 @@ final class PrivacyStatsErrorHandler: EventMapping<PrivacyStatsError> {
 
     init() {
         super.init { event, _, _, _ in
-            PixelKit.fire(DebugEvent(NewTabPagePixel.privacyStatsDatabaseError, error: event.underlyingError), frequency: .dailyAndCount)
+            PixelKit.fire(DebugEvent(NewTabPagePixel.privacyStatsDatabaseError, error: event), frequency: .dailyAndCount)
         }
     }
 

--- a/DuckDuckGo/PrivacyStats/PrivacyStatsErrorHandler.swift
+++ b/DuckDuckGo/PrivacyStats/PrivacyStatsErrorHandler.swift
@@ -1,0 +1,35 @@
+//
+//  PrivacyStatsErrorHandler.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import PixelKit
+import PrivacyStats
+
+final class PrivacyStatsErrorHandler: EventMapping<PrivacyStatsError> {
+
+    init() {
+        super.init { event, _, _, _ in
+            PixelKit.fire(DebugEvent(NewTabPagePixel.privacyStatsDatabaseError, error: event.underlyingError), frequency: .dailyAndCount)
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<PrivacyStatsError>.Mapping) {
+        fatalError("Use init()")
+    }
+}
+

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -464,9 +464,6 @@ enum GeneralPixel: PixelKitEventV2 {
     case siteNotWorkingShown
     case siteNotWorkingWebsiteIsBroken
 
-    // Privacy Stats
-    case privacyStatsCouldNotLoadDatabase
-
     var name: String {
         switch self {
 
@@ -1144,9 +1141,6 @@ enum GeneralPixel: PixelKitEventV2 {
         case .pageRefreshThreeTimesWithin20Seconds: return "m_mac_reload-three-times-within-20-seconds"
         case .siteNotWorkingShown: return "m_mac_site-not-working_shown"
         case .siteNotWorkingWebsiteIsBroken: return "m_mac_site-not-working_website-is-broken"
-
-            // Privacy Stats
-        case .privacyStatsCouldNotLoadDatabase: return "privacy_stats_could_not_load_database"
         }
     }
 

--- a/DuckDuckGo/Statistics/NewTabPagePixel.swift
+++ b/DuckDuckGo/Statistics/NewTabPagePixel.swift
@@ -57,7 +57,20 @@ enum NewTabPagePixel: PixelKitEventV2 {
     // MARK: - Debug
 
     /**
-     * Event Trigger: Privacy Stats reports a database error, as outlined by `PrivacyStatsError`. This is a debug (health) pixel.
+     * Event Trigger: Privacy Stats database fails to be initialized. Firing this pixel is followed by an app crash with a `fatalError`.
+     * This pixel can be fired when there's no space on disk, when database migration fails or when database was tampered with.
+     * This is a debug (health) pixel.
+     *
+     * Anomaly Investigation:
+     * - If this spikes in production it may mean we've released a new PriacyStats database model version
+     *   and didn't handle migration correctly in which case we need a hotfix.
+     * - Otherwise it may happen occasionally for users with not space left on device.
+     */
+    case privacyStatsCouldNotLoadDatabase
+
+    /**
+     * Event Trigger: Privacy Stats reports a database error when fetching, storing or clearing data,
+     * as outlined by `PrivacyStatsError`. This is a debug (health) pixel.
      *
      * Anomaly Investigation:
      * - The errors here are all Core Data errors. The error code identifies the specific enum case of `PrivacyStatsError`.
@@ -69,7 +82,8 @@ enum NewTabPagePixel: PixelKitEventV2 {
         switch self {
         case .blockedTrackingAttemptsShowLess: return "m_mac_new-tab-page_blocked-tracking-attempts_show-less"
         case .blockedTrackingAttemptsShowMore: return "m_mac_new-tab-page_blocked-tracking-attempts_show-more"
-        case .privacyStatsDatabaseError: return "m_mac_new-tab-page_privacy-stats_database_error"
+        case .privacyStatsCouldNotLoadDatabase: return "new-tab-page_privacy-stats_could-not-load-database"
+        case .privacyStatsDatabaseError: return "new-tab-page_privacy-stats_database_error"
         }
     }
 

--- a/DuckDuckGo/Statistics/NewTabPagePixel.swift
+++ b/DuckDuckGo/Statistics/NewTabPagePixel.swift
@@ -28,6 +28,32 @@ import PixelKit
  */
 enum NewTabPagePixel: PixelKitEventV2 {
 
+    /**
+     * Event Trigger: "Show Less" button is clicked in Privacy Stats table on the New Tab Page, to collapse the table.
+     *
+     * > Note: This isn't the section collapse setting (like for Favorites or Next Steps), but the sub-setting
+     *   to control whether the view should contain 5 most frequently blocked top companies or all top companies.
+     *
+     * Anomaly Investigation:
+     * - This pixel is fired from `NewTabPagePrivacyStatsModel` in response to a message sent by the user script.
+     * - In case of anomalies, check if the subscription between the user script and the model isn't causing the pixel
+     *   to be fired more than once per interaction.
+     */
+    case blockedTrackingAttemptsShowLess
+
+    /**
+     * Event Trigger: "Show More" button is clicked in Privacy Stats table on the New Tab Page, to expand the table.
+     *
+     * > Note: This isn't the section collapse setting (like for Favorites or Next Steps), but the sub-setting
+     *   to control whether the view should contain 5 most frequently blocked top companies or all top companies.
+     *
+     * Anomaly Investigation:
+     * - This pixel is fired from `NewTabPagePrivacyStatsModel` in response to a message sent by the user script.
+     * - In case of anomalies, check if the subscription between the user script and the model isn't causing the pixel
+     *   to be fired more than once per interaction.
+     */
+    case blockedTrackingAttemptsShowMore
+
     // MARK: - Debug
 
     /**
@@ -41,7 +67,9 @@ enum NewTabPagePixel: PixelKitEventV2 {
 
     var name: String {
         switch self {
-        case .privacyStatsDatabaseError: return "m_mac_new-tab-page.privacy-stats.database.error"
+        case .blockedTrackingAttemptsShowLess: return "m_mac_new-tab-page_blocked-tracking-attempts_show-less"
+        case .blockedTrackingAttemptsShowMore: return "m_mac_new-tab-page_blocked-tracking-attempts_show-more"
+        case .privacyStatsDatabaseError: return "m_mac_new-tab-page_privacy-stats_database_error"
         }
     }
 

--- a/DuckDuckGo/Statistics/NewTabPagePixel.swift
+++ b/DuckDuckGo/Statistics/NewTabPagePixel.swift
@@ -1,0 +1,55 @@
+//
+//  NewTabPagePixel.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PixelKit
+
+/**
+ * This enum keeps pixels related to HTML New Tab Page.
+ *
+ * > Related links:
+ * [Privacy Triage](https://app.asana.com/0/69071770703008/1208146890364172/f)
+ * [Detailed Pixels description](https://app.asana.com/0/1201621708115095/1207983904350396/f)
+ */
+enum NewTabPagePixel: PixelKitEventV2 {
+
+    // MARK: - Debug
+
+    /**
+     * Event Trigger: Privacy Stats reports a database error, as outlined by `PrivacyStatsError`. This is a debug (health) pixel.
+     *
+     * Anomaly Investigation:
+     * - The errors here are all Core Data errors. The error code identifies the specific enum case of `PrivacyStatsError`.
+     * - Check `PrivacyStats` for places where the error is thrown.
+     */
+    case privacyStatsDatabaseError
+
+    var name: String {
+        switch self {
+        case .privacyStatsDatabaseError: return "m_mac_new-tab-page.privacy-stats.database.error"
+        }
+    }
+
+    var parameters: [String: String]? {
+        nil
+    }
+
+    var error: (any Error)? {
+        nil
+    }
+}

--- a/LocalPackages/NewTabPage/Sources/NewTabPage/NextStepsCards/NewTabPageNextStepsCardsClient.swift
+++ b/LocalPackages/NewTabPage/Sources/NewTabPage/NextStepsCards/NewTabPageNextStepsCardsClient.swift
@@ -57,7 +57,9 @@ public final class NewTabPageNextStepsCardsClient: NewTabPageScriptClient {
 
         willDisplayCardsPublisher
             .sink { cards in
-                model.willDisplayCards(cards)
+                Task { @MainActor in
+                    model.willDisplayCards(cards)
+                }
             }
             .store(in: &cancellables)
     }

--- a/LocalPackages/NewTabPage/Sources/NewTabPage/NextStepsCards/NewTabPageNextStepsCardsProviding.swift
+++ b/LocalPackages/NewTabPage/Sources/NewTabPage/NextStepsCards/NewTabPageNextStepsCardsProviding.swift
@@ -34,5 +34,6 @@ public protocol NewTabPageNextStepsCardsProviding: AnyObject {
     @MainActor
     func dismiss(_ card: NewTabPageNextStepsCardsClient.CardID)
 
+    @MainActor
     func willDisplayCards(_ cards: [NewTabPageNextStepsCardsClient.CardID])
 }

--- a/LocalPackages/NewTabPage/Sources/NewTabPage/PrivacyStats/NewTabPagePrivacyStatsClient.swift
+++ b/LocalPackages/NewTabPage/Sources/NewTabPage/PrivacyStats/NewTabPagePrivacyStatsClient.swift
@@ -34,6 +34,8 @@ public final class NewTabPagePrivacyStatsClient: NewTabPageScriptClient {
         case onConfigUpdate = "stats_onConfigUpdate"
         case onDataUpdate = "stats_onDataUpdate"
         case setConfig = "stats_setConfig"
+        case showLess = "stats_showLess"
+        case showMore = "stats_showMore"
     }
 
     public init(model: NewTabPagePrivacyStatsModel) {
@@ -60,7 +62,9 @@ public final class NewTabPagePrivacyStatsClient: NewTabPageScriptClient {
         userScript.registerMessageHandlers([
             MessageName.getConfig.rawValue: { [weak self] in try await self?.getConfig(params: $0, original: $1) },
             MessageName.getData.rawValue: { [weak self] in try await self?.getData(params: $0, original: $1) },
-            MessageName.setConfig.rawValue: { [weak self] in try await self?.setConfig(params: $0, original: $1) }
+            MessageName.setConfig.rawValue: { [weak self] in try await self?.setConfig(params: $0, original: $1) },
+            MessageName.showLess.rawValue: { [weak self] in try await self?.showLess(params: $0, original: $1) },
+            MessageName.showMore.rawValue: { [weak self] in try await self?.showMore(params: $0, original: $1) }
         ])
     }
 
@@ -93,6 +97,18 @@ public final class NewTabPagePrivacyStatsClient: NewTabPageScriptClient {
     @MainActor
     private func getData(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         return await model.calculatePrivacyStats()
+    }
+
+    @MainActor
+    private func showLess(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        model.showLess()
+        return nil
+    }
+
+    @MainActor
+    private func showMore(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        model.showMore()
+        return nil
     }
 }
 

--- a/LocalPackages/NewTabPage/Sources/NewTabPage/PrivacyStats/NewTabPagePrivacyStatsModel.swift
+++ b/LocalPackages/NewTabPage/Sources/NewTabPage/PrivacyStats/NewTabPagePrivacyStatsModel.swift
@@ -17,6 +17,7 @@
 //
 
 import Combine
+import Common
 import Foundation
 import os.log
 import Persistence
@@ -51,6 +52,10 @@ final class UserDefaultsNewTabPagePrivacyStatsSettingsPersistor: NewTabPagePriva
     }
 }
 
+public enum NewTabPagePrivacyStatsEvent: Equatable {
+    case showLess, showMore
+}
+
 public final class NewTabPagePrivacyStatsModel {
 
     let privacyStats: PrivacyStatsCollecting
@@ -65,6 +70,7 @@ public final class NewTabPagePrivacyStatsModel {
     private let settingsPersistor: NewTabPagePrivacyStatsSettingsPersistor
     private var topCompanies: Set<String> = []
     private let trackerDataProvider: PrivacyStatsTrackerDataProviding
+    private let eventMapping: EventMapping<NewTabPagePrivacyStatsEvent>?
 
     private let statsUpdateSubject = PassthroughSubject<Void, Never>()
     private var cancellables: Set<AnyCancellable> = []
@@ -72,12 +78,14 @@ public final class NewTabPagePrivacyStatsModel {
     public convenience init(
         privacyStats: PrivacyStatsCollecting,
         trackerDataProvider: PrivacyStatsTrackerDataProviding,
+        eventMapping: EventMapping<NewTabPagePrivacyStatsEvent>? = nil,
         keyValueStore: KeyValueStoring = UserDefaults.standard,
         getLegacyIsViewExpandedSetting: @autoclosure () -> Bool?
     ) {
         self.init(
             privacyStats: privacyStats,
             trackerDataProvider: trackerDataProvider,
+            eventMapping: eventMapping,
             settingsPersistor: UserDefaultsNewTabPagePrivacyStatsSettingsPersistor(keyValueStore, getLegacySetting: getLegacyIsViewExpandedSetting())
         )
     }
@@ -85,10 +93,12 @@ public final class NewTabPagePrivacyStatsModel {
     init(
         privacyStats: PrivacyStatsCollecting,
         trackerDataProvider: PrivacyStatsTrackerDataProviding,
+        eventMapping: EventMapping<NewTabPagePrivacyStatsEvent>?,
         settingsPersistor: NewTabPagePrivacyStatsSettingsPersistor
     ) {
         self.privacyStats = privacyStats
         self.trackerDataProvider = trackerDataProvider
+        self.eventMapping = eventMapping
         self.settingsPersistor = settingsPersistor
 
         isViewExpanded = settingsPersistor.isViewExpanded
@@ -109,6 +119,14 @@ public final class NewTabPagePrivacyStatsModel {
             .store(in: &cancellables)
 
         refreshTopCompanies()
+    }
+
+    func showLess() {
+        eventMapping?.fire(.showLess)
+    }
+
+    func showMore() {
+        eventMapping?.fire(.showMore)
     }
 
     func calculatePrivacyStats() async -> NewTabPagePrivacyStatsClient.PrivacyStatsData {

--- a/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/CapturingNewTabPagePrivacyStatsEventHandler.swift
+++ b/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/CapturingNewTabPagePrivacyStatsEventHandler.swift
@@ -1,0 +1,43 @@
+//
+//  CapturingNewTabPagePrivacyStatsEventHandler.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Common
+import NewTabPage
+
+final class CapturingNewTabPagePrivacyStatsEventHandler: EventMapping<NewTabPagePrivacyStatsEvent> {
+    var events: [NewTabPagePrivacyStatsEvent] = []
+
+    init() {
+        var localEvents = PassthroughSubject<NewTabPagePrivacyStatsEvent, Never>()
+        super.init { event, _, _, _ in
+            localEvents.send(event)
+        }
+
+        cancellable = localEvents
+            .sink { [weak self] value in
+                self?.events.append(value)
+            }
+    }
+
+    override init(mapping: @escaping EventMapping<NewTabPagePrivacyStatsEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+
+    private var cancellable: AnyCancellable?
+}

--- a/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageNextStepsCardsClientTests.swift
+++ b/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageNextStepsCardsClientTests.swift
@@ -134,7 +134,7 @@ final class NewTabPageNextStepsCardsClientTests: XCTestCase {
 
         XCTAssertEqual(model.willDisplayCardsCalls, [])
 
-        try await performAndWaitForWillDisplayCards() {
+        try await performAndWaitForWillDisplayCards {
             try await handleMessageIgnoringResponse(named: .getConfig)
         }
 

--- a/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageNextStepsCardsClientTests.swift
+++ b/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageNextStepsCardsClientTests.swift
@@ -112,38 +112,51 @@ final class NewTabPageNextStepsCardsClientTests: XCTestCase {
 
     func testThatWillDisplayCardsPublisherIsSentAfterGetDataAndGetConfigAreCalled() async throws {
         model.cards = [.addAppToDockMac, .duckplayer]
-        try await handleMessageIgnoringResponse(named: .getData)
-        try await handleMessageIgnoringResponse(named: .getConfig)
+
+        try await performAndWaitForWillDisplayCards {
+            try await handleMessageIgnoringResponse(named: .getData)
+            try await handleMessageIgnoringResponse(named: .getConfig)
+        }
 
         XCTAssertEqual(model.willDisplayCardsCalls, [[.addAppToDockMac, .duckplayer]])
     }
 
     func testThatWillDisplayCardsPublisherIsNotSentBeforeGetConfigIsCalled() async throws {
         model.cards = [.addAppToDockMac, .duckplayer]
-        try await handleMessageIgnoringResponse(named: .getData)
-        try await handleMessageIgnoringResponse(named: .getData)
-        try await handleMessageIgnoringResponse(named: .getData)
-        try await handleMessageIgnoringResponse(named: .getData)
-        try await handleMessageIgnoringResponse(named: .getData)
+
+        try await performAndWaitForWillDisplayCards(count: 0, timeout: 0.1) {
+            try await handleMessageIgnoringResponse(named: .getData)
+            try await handleMessageIgnoringResponse(named: .getData)
+            try await handleMessageIgnoringResponse(named: .getData)
+            try await handleMessageIgnoringResponse(named: .getData)
+            try await handleMessageIgnoringResponse(named: .getData)
+        }
 
         XCTAssertEqual(model.willDisplayCardsCalls, [])
 
-        try await handleMessageIgnoringResponse(named: .getConfig)
+        try await performAndWaitForWillDisplayCards() {
+            try await handleMessageIgnoringResponse(named: .getConfig)
+        }
 
         XCTAssertEqual(model.willDisplayCardsCalls, [[.addAppToDockMac, .duckplayer]])
     }
 
     func testThatWillDisplayCardsPublisherIsNotSentBeforeGetDataIsCalled() async throws {
         model.cards = [.addAppToDockMac, .duckplayer]
-        try await handleMessageIgnoringResponse(named: .getConfig)
-        try await handleMessageIgnoringResponse(named: .getConfig)
-        try await handleMessageIgnoringResponse(named: .getConfig)
-        try await handleMessageIgnoringResponse(named: .getConfig)
-        try await handleMessageIgnoringResponse(named: .getConfig)
+
+        try await performAndWaitForWillDisplayCards(count: 0, timeout: 0.1) {
+            try await handleMessageIgnoringResponse(named: .getConfig)
+            try await handleMessageIgnoringResponse(named: .getConfig)
+            try await handleMessageIgnoringResponse(named: .getConfig)
+            try await handleMessageIgnoringResponse(named: .getConfig)
+            try await handleMessageIgnoringResponse(named: .getConfig)
+        }
 
         XCTAssertEqual(model.willDisplayCardsCalls, [])
 
-        try await handleMessageIgnoringResponse(named: .getData)
+        try await performAndWaitForWillDisplayCards {
+            try await handleMessageIgnoringResponse(named: .getData)
+        }
 
         XCTAssertEqual(model.willDisplayCardsCalls, [[.addAppToDockMac, .duckplayer]])
     }
@@ -153,11 +166,10 @@ final class NewTabPageNextStepsCardsClientTests: XCTestCase {
         model.isViewExpanded = true
         try await triggerInitialCardsEventAndResetMockState()
 
-        let expectation = self.expectation(description: "willDisplayCards")
-        model.willDisplayCardsImpl = { _ in expectation.fulfill() }
+        try await performAndWaitForWillDisplayCards {
+            model.cards = [.addAppToDockMac, .duckplayer, .bringStuff]
+        }
 
-        model.cards = [.addAppToDockMac, .duckplayer, .bringStuff]
-        await fulfillment(of: [expectation], timeout: 0.1)
         XCTAssertEqual(model.willDisplayCardsCalls, [[.addAppToDockMac, .duckplayer, .bringStuff]])
     }
 
@@ -166,14 +178,12 @@ final class NewTabPageNextStepsCardsClientTests: XCTestCase {
         model.isViewExpanded = false
         try await triggerInitialCardsEventAndResetMockState()
 
-        let expectation = self.expectation(description: "willDisplayCards")
-        expectation.expectedFulfillmentCount = 3
-        model.willDisplayCardsImpl = { _ in expectation.fulfill() }
+        try await performAndWaitForWillDisplayCards(count: 3) {
+            model.cards = [.addAppToDockMac, .duckplayer, .bringStuff]
+            model.cards = [.duckplayer, .addAppToDockMac, .bringStuff]
+            model.cards = [.addAppToDockMac, .emailProtection, .duckplayer]
+        }
 
-        model.cards = [.addAppToDockMac, .duckplayer, .bringStuff]
-        model.cards = [.duckplayer, .addAppToDockMac, .bringStuff]
-        model.cards = [.addAppToDockMac, .emailProtection, .duckplayer]
-        await fulfillment(of: [expectation], timeout: 0.1)
         XCTAssertEqual(model.willDisplayCardsCalls, [
             [.addAppToDockMac, .duckplayer],
             [.duckplayer, .addAppToDockMac],
@@ -186,14 +196,12 @@ final class NewTabPageNextStepsCardsClientTests: XCTestCase {
         model.isViewExpanded = false
         try await triggerInitialCardsEventAndResetMockState()
 
-        let expectation = self.expectation(description: "willDisplayCards")
-        expectation.expectedFulfillmentCount = 2
-        model.willDisplayCardsImpl = { _ in expectation.fulfill() }
+        try await performAndWaitForWillDisplayCards(count: 2) {
+            model.cards = [.addAppToDockMac, .duckplayer, .bringStuff]
+            model.cards = []
+            model.cards = [.addAppToDockMac, .emailProtection, .duckplayer]
+        }
 
-        model.cards = [.addAppToDockMac, .duckplayer, .bringStuff]
-        model.cards = []
-        model.cards = [.addAppToDockMac, .emailProtection, .duckplayer]
-        await fulfillment(of: [expectation], timeout: 0.1)
         XCTAssertEqual(model.willDisplayCardsCalls, [
             [.addAppToDockMac, .duckplayer],
             [.addAppToDockMac, .emailProtection]
@@ -205,11 +213,10 @@ final class NewTabPageNextStepsCardsClientTests: XCTestCase {
         model.isViewExpanded = false
         try await triggerInitialCardsEventAndResetMockState()
 
-        let expectation = self.expectation(description: "willDisplayCards")
-        model.willDisplayCardsImpl = { _ in expectation.fulfill() }
+        try await performAndWaitForWillDisplayCards {
+            model.isViewExpanded = true
+        }
 
-        model.isViewExpanded = true
-        await fulfillment(of: [expectation], timeout: 0.1)
         XCTAssertEqual(model.willDisplayCardsCalls, [[.emailProtection, .bringStuff, .defaultApp]])
     }
 
@@ -218,12 +225,10 @@ final class NewTabPageNextStepsCardsClientTests: XCTestCase {
         model.isViewExpanded = false
         try await triggerInitialCardsEventAndResetMockState()
 
-        let expectation = self.expectation(description: "willDisplayCards")
-        expectation.isInverted = true
-        model.willDisplayCardsImpl = { _ in expectation.fulfill() }
+        try await performAndWaitForWillDisplayCards(count: 0, timeout: 0.5) {
+            model.isViewExpanded = true
+        }
 
-        model.isViewExpanded = true
-        await fulfillment(of: [expectation], timeout: 0.1)
         XCTAssertEqual(model.willDisplayCardsCalls, [])
     }
 
@@ -232,21 +237,39 @@ final class NewTabPageNextStepsCardsClientTests: XCTestCase {
         model.isViewExpanded = true
         try await triggerInitialCardsEventAndResetMockState()
 
-        let expectation = self.expectation(description: "willDisplayCards")
-        expectation.isInverted = true
-        model.willDisplayCardsImpl = { _ in expectation.fulfill() }
+        try await performAndWaitForWillDisplayCards(count: 0, timeout: 0.5) {
+            model.isViewExpanded = false
+        }
 
-        model.isViewExpanded = false
-        await fulfillment(of: [expectation], timeout: 0.1)
         XCTAssertEqual(model.willDisplayCardsCalls, [])
     }
 
     // MARK: - Helper functions
 
     func triggerInitialCardsEventAndResetMockState() async throws {
-        try await handleMessageIgnoringResponse(named: .getConfig)
-        try await handleMessageIgnoringResponse(named: .getData)
+        try await performAndWaitForWillDisplayCards {
+            try await handleMessageIgnoringResponse(named: .getConfig)
+            try await handleMessageIgnoringResponse(named: .getData)
+        }
         model.willDisplayCardsCalls = []
+    }
+
+    func performAndWaitForWillDisplayCards(count expectedCount: Int = 1, timeout: TimeInterval = 0.1, _ block: () async throws -> Void) async throws {
+        let originalImpl = model.willDisplayCardsImpl
+
+        let expectation = self.expectation(description: "willDisplayCards_waitForWillDisplayCards")
+        if expectedCount == 0 {
+            expectation.isInverted = true
+        } else {
+            expectation.expectedFulfillmentCount = expectedCount
+        }
+        model.willDisplayCardsImpl = { _ in expectation.fulfill() }
+
+        try await block()
+
+        await fulfillment(of: [expectation], timeout: timeout)
+
+        model.willDisplayCardsImpl = originalImpl
     }
 
     func handleMessage<Response: Encodable>(named methodName: NewTabPageNextStepsCardsClient.MessageName, parameters: Any = [], file: StaticString = #file, line: UInt = #line) async throws -> Response {

--- a/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPagePrivacyStatsClientTests.swift
+++ b/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPagePrivacyStatsClientTests.swift
@@ -29,6 +29,7 @@ final class NewTabPagePrivacyStatsClientTests: XCTestCase {
 
     var privacyStats: CapturingPrivacyStats!
     var trackerDataProvider: MockPrivacyStatsTrackerDataProvider!
+    var eventMapping: CapturingNewTabPagePrivacyStatsEventHandler!
     var settingsPersistor: UserDefaultsNewTabPagePrivacyStatsSettingsPersistor!
 
     var userScript: NewTabPageUserScript!
@@ -38,11 +39,13 @@ final class NewTabPagePrivacyStatsClientTests: XCTestCase {
 
         privacyStats = CapturingPrivacyStats()
         trackerDataProvider = MockPrivacyStatsTrackerDataProvider()
+        eventMapping = CapturingNewTabPagePrivacyStatsEventHandler()
         settingsPersistor = UserDefaultsNewTabPagePrivacyStatsSettingsPersistor(MockKeyValueStore(), getLegacySetting: nil)
 
         model = NewTabPagePrivacyStatsModel(
             privacyStats: privacyStats,
             trackerDataProvider: trackerDataProvider,
+            eventMapping: eventMapping,
             settingsPersistor: settingsPersistor
         )
 
@@ -99,6 +102,7 @@ final class NewTabPagePrivacyStatsClientTests: XCTestCase {
         model = NewTabPagePrivacyStatsModel(
             privacyStats: privacyStats,
             trackerDataProvider: trackerDataProvider,
+            eventMapping: eventMapping,
             settingsPersistor: settingsPersistor
         )
         privacyStats.privacyStats = ["A": 1, "B": 2, "C": 3, "D": 4, "E": 1500, "F": 100, "G": 900]
@@ -121,6 +125,20 @@ final class NewTabPagePrivacyStatsClientTests: XCTestCase {
     func testWhenPrivacyStatsAreEmptyThenGetDataReturnsEmptyArray() async throws {
         let data: NewTabPagePrivacyStatsClient.PrivacyStatsData = try await handleMessage(named: .getData)
         XCTAssertEqual(data, .init(totalCount: 0, trackerCompanies: []))
+    }
+
+    // MARK: - showLess
+
+    func testThatShowLessIsPassedToTheModelAndToTheEventMapping() async throws {
+        try await handleMessageExpectingNilResponse(named: .showLess)
+        XCTAssertEqual(eventMapping.events, [.showLess])
+    }
+
+    // MARK: - showMore
+
+    func testThatShowMoreIsPassedToTheModelAndToTheEventMapping() async throws {
+        try await handleMessageExpectingNilResponse(named: .showMore)
+        XCTAssertEqual(eventMapping.events, [.showMore])
     }
 
     // MARK: - Helper functions

--- a/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPagePrivacyStatsModelTests.swift
+++ b/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPagePrivacyStatsModelTests.swift
@@ -81,6 +81,7 @@ final class NewTabPagePrivacyStatsModelTests: XCTestCase {
         model = NewTabPagePrivacyStatsModel(
             privacyStats: privacyStats,
             trackerDataProvider: trackerDataProvider,
+            eventMapping: nil,
             settingsPersistor: settingsPersistor
         )
     }
@@ -106,6 +107,7 @@ final class NewTabPagePrivacyStatsModelTests: XCTestCase {
         model = NewTabPagePrivacyStatsModel(
             privacyStats: privacyStats,
             trackerDataProvider: trackerDataProvider,
+            eventMapping: nil,
             settingsPersistor: settingsPersistor
         )
 
@@ -135,6 +137,7 @@ final class NewTabPagePrivacyStatsModelTests: XCTestCase {
         model = NewTabPagePrivacyStatsModel(
             privacyStats: privacyStats,
             trackerDataProvider: trackerDataProvider,
+            eventMapping: nil,
             settingsPersistor: settingsPersistor
         )
 

--- a/UnitTests/NewTabPage/NewTabPageNextStepsCardsProviderTests.swift
+++ b/UnitTests/NewTabPage/NewTabPageNextStepsCardsProviderTests.swift
@@ -1,0 +1,121 @@
+//
+//  NewTabPageNextStepsCardsProviderTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Combine
+import NewTabPage
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+final class NewTabPageNextStepsCardsProviderTests: XCTestCase {
+    var provider: NewTabPageNextStepsCardsProvider!
+
+    @MainActor
+    override func setUp() async throws {
+        let privacyConfigManager = MockPrivacyConfigurationManager()
+        let config = MockPrivacyConfiguration()
+        privacyConfigManager.privacyConfig = config
+
+        let continueSetUpModel = HomePage.Models.ContinueSetUpModel(
+            defaultBrowserProvider: CapturingDefaultBrowserProvider(),
+            dockCustomizer: DockCustomizerMock(),
+            dataImportProvider: CapturingDataImportProvider(),
+            tabOpener: TabCollectionViewModelTabOpener(tabCollectionViewModel: TabCollectionViewModel()),
+            emailManager: EmailManager(storage: MockEmailStorage()),
+            duckPlayerPreferences: DuckPlayerPreferencesPersistorMock(),
+            privacyConfigurationManager: privacyConfigManager
+        )
+
+        provider = NewTabPageNextStepsCardsProvider(
+            continueSetUpModel: continueSetUpModel,
+            appearancePreferences: AppearancePreferences(persistor: MockAppearancePreferencesPersistor())
+        )
+    }
+
+    func testWhenCardsViewIsNotOutdatedThenCardsAreReportedByModel() {
+        provider.appearancePreferences.isContinueSetUpCardsViewOutdated = false
+        provider.continueSetUpModel.featuresMatrix = [[.defaultBrowser, .dock, .emailProtection]]
+
+        XCTAssertEqual(provider.cards, [.defaultApp, .addAppToDockMac, .emailProtection])
+    }
+
+    func testWhenCardsViewIsOutdatedThenCardsAreEmpty() {
+        provider.appearancePreferences.isContinueSetUpCardsViewOutdated = true
+        provider.continueSetUpModel.featuresMatrix = [[.defaultBrowser, .dock, .emailProtection]]
+
+        XCTAssertEqual(provider.cards, [])
+    }
+
+    func testWhenCardsViewIsNotOutdatedThenCardsAreEmitted() {
+        provider.appearancePreferences.isContinueSetUpCardsViewOutdated = false
+        provider.continueSetUpModel.featuresMatrix = [[.defaultBrowser]]
+
+        var cardsEvents = [[NewTabPageNextStepsCardsClient.CardID]]()
+
+        let cancellable = provider.cardsPublisher
+            .sink { cards in
+                cardsEvents.append(cards)
+            }
+
+        provider.continueSetUpModel.featuresMatrix = [[.dock]]
+        provider.continueSetUpModel.featuresMatrix = [[.dock, .duckplayer]]
+        provider.continueSetUpModel.featuresMatrix = [[.defaultBrowser]]
+
+        cancellable.cancel()
+        XCTAssertEqual(cardsEvents, [[.addAppToDockMac], [.addAppToDockMac, .duckplayer], [.defaultApp]])
+    }
+
+    func testWhenCardsViewIsOutdatedThenEmptyCardsAreEmitted() {
+        provider.appearancePreferences.isContinueSetUpCardsViewOutdated = true
+        provider.continueSetUpModel.featuresMatrix = [[.defaultBrowser]]
+
+        var cardsEvents = [[NewTabPageNextStepsCardsClient.CardID]]()
+
+        let cancellable = provider.cardsPublisher
+            .sink { cards in
+                cardsEvents.append(cards)
+            }
+
+        provider.continueSetUpModel.featuresMatrix = [[.dock]]
+        provider.continueSetUpModel.featuresMatrix = [[.duckplayer]]
+        provider.continueSetUpModel.featuresMatrix = [[.defaultBrowser]]
+
+        cancellable.cancel()
+        XCTAssertEqual(cardsEvents, [[], [], []])
+    }
+
+    func testWhenCardsViewBecomesOutdatedThenCardsStopBeingEmitted() {
+        provider.appearancePreferences.isContinueSetUpCardsViewOutdated = false
+        provider.continueSetUpModel.featuresMatrix = [[.defaultBrowser]]
+
+        var cardsEvents = [[NewTabPageNextStepsCardsClient.CardID]]()
+
+        let cancellable = provider.cardsPublisher
+            .sink { cards in
+                cardsEvents.append(cards)
+            }
+
+        provider.continueSetUpModel.featuresMatrix = [[.dock]]
+        provider.continueSetUpModel.featuresMatrix = [[.dock, .duckplayer]]
+        provider.appearancePreferences.isContinueSetUpCardsViewOutdated = true
+        provider.continueSetUpModel.featuresMatrix = [[.defaultBrowser]]
+
+        cancellable.cancel()
+        XCTAssertEqual(cardsEvents, [[.addAppToDockMac], [.addAppToDockMac, .duckplayer], [], []])
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/69071770703008/1208936504720914/f

**Description:**
This change adds 2 new messages to track actions in the Privacy Stats widget
and implements usage and debug pixels for Privacy Stats.

**Steps to test this PR**:
1. Run the app from Xcode, set internal user state and set htmlNewTabPage feature flag.
2. Filter Xcode console by "PixelKit" subsystem.
3. Visit some websites to have Privacy Stats widget populated.
4. Click "Show More" and then "Show Less" and verify the following output in the console:
```
👾[Daily and Count-Fired] m_mac_new-tab-page_blocked-tracking-attempts_show-more_daily ["appVersion": "1.118.0", "pixelSource": "browser-dmg"]
👾[Daily and Count-Fired] m_mac_new-tab-page_blocked-tracking-attempts_show-more_count ["appVersion": "1.118.0", "pixelSource": "browser-dmg"]
👾[Daily and Count-Fired] m_mac_new-tab-page_blocked-tracking-attempts_show-less_daily ["pixelSource": "browser-dmg", "appVersion": "1.118.0"]
👾[Daily and Count-Fired] m_mac_new-tab-page_blocked-tracking-attempts_show-less_count ["pixelSource": "browser-dmg", "appVersion": "1.118.0"]
```
5. Repeat previous step and verify the following output in the console:
```
👾[Daily and Count-Skipped] m_mac_new-tab-page_blocked-tracking-attempts_show-more_daily ["pixelSource": "browser-dmg", "appVersion": "1.118.0"]
👾[Daily and Count-Fired] m_mac_new-tab-page_blocked-tracking-attempts_show-more_count ["pixelSource": "browser-dmg", "appVersion": "1.118.0"]
👾[Daily and Count-Skipped] m_mac_new-tab-page_blocked-tracking-attempts_show-less_daily ["pixelSource": "browser-dmg", "appVersion": "1.118.0"]
👾[Daily and Count-Fired] m_mac_new-tab-page_blocked-tracking-attempts_show-less_count ["pixelSource": "browser-dmg", "appVersion": "1.118.0"]
```
6. Without closing the app, call the following in terminal:
```
sqlite3 ~/Library/Containers/com.duckduckgo.macos.browser.debug/Data/Library/Application\ Support/PrivacyStats.sqlite 'drop table ZDAILYBLOCKEDTRACKERSENTITY'
```
7. Visit a website, verify the following output in the console:
```
👾[Daily and Count-Fired] m_mac_debug_new-tab-page_privacy-stats_database_error_daily ["e": "2", "d": "PrivacyStatsError", "appVersion": "1.118.0", "ud": "NSCocoaErrorDomain", "ue": "256", "pixelSource": "browser-dmg"]
👾[Daily and Count-Fired] m_mac_debug_new-tab-page_privacy-stats_database_error_count ["pixelSource": "browser-dmg", "appVersion": "1.118.0", "d": "PrivacyStatsError", "ud": "NSCocoaErrorDomain", "e": "2", "ue": "256"]
```
8. Quit the app and call the following in terminal:
```
echo "hello" > ~/Library/Containers/com.duckduckgo.macos.browser.debug/Data/Library/Application\ Support/PrivacyStats.sqlite
```
8. Launch the app, verify the following output in the console:
```
👾[Daily and Count-Fired] m_mac_debug_new-tab-page_privacy-stats_could-not-load-database_daily ["pixelSource": "browser-dmg", "appVersion": "1.118.0", "e": "26", "d": "NSSQLiteErrorDomain"]
👾[Daily and Count-Fired] m_mac_debug_new-tab-page_privacy-stats_could-not-load-database_count ["d": "NSSQLiteErrorDomain", "appVersion": "1.118.0", "e": "26", "pixelSource": "browser-dmg"]
```
9. Clean up after testing so that your debug build works:
```
rm -f ~/Library/Containers/com.duckduckgo.macos.browser.debug/Data/Library/Application\ Support/PrivacyStats.sqlite
```

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
