### PR TITLE
Add 'locale' to report broken site params

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -15225,7 +15225,7 @@
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 219.0.0;
+				version = "219.0.0-1";
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "20df9e22d5a69acfc25204fb0228a9d6f79b721f",
-        "version" : "219.0.0"
+        "revision" : "155b47e287dfc9d5edb25b10da0bac8e638d08b7",
+        "version" : "219.0.0-1"
       }
     },
     {
@@ -75,7 +75,7 @@
     {
       "identity" : "lottie-spm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-spm",
+      "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
         "revision" : "1d29eccc24cc8b75bff9f6804155112c0ffc9605",
         "version" : "4.4.3"

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0-1"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../AppKitExtensions"),
         .package(path: "../XPCHelper"),

--- a/LocalPackages/FeatureFlags/Package.swift
+++ b/LocalPackages/FeatureFlags/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["FeatureFlags"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0-1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0-1"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.3"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/NewTabPage/Package.swift
+++ b/LocalPackages/NewTabPage/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["NewTabPage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0-1"),
         .package(path: "../WebKitExtensions"),
         .package(path: "../Utilities"),
     ],

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0-1"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../FeatureFlags")
     ],

--- a/LocalPackages/WebKitExtensions/Package.swift
+++ b/LocalPackages/WebKitExtensions/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "219.0.0-1"),
         .package(path: "../AppKitExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208827075841585/f

**Description**:
Add the "locale" param ID to the list of properties submitted in the Privacy Dashboard site breakage form.

**Steps to test this PR**:
To force report broken site form to be shown every time you can change https://github.com/duckduckgo/BrowserServicesKit/blob/b7f7ba99f7c77b576679eee426ddd80320dc74d8/Sources/PrivacyDashboard/ToggleReportingManager.swift#L104 to always return `true`
1. Open some website.
2. Wait until it completes loading.
3. Open Privacy Dashboard
4. Disable the protections
5. When the report broken site prompt is shown select "See what's sent"
6. Ensure the "Primary language and country of your device" string is shown


**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
