### PR TITLE
Fix displaying multi-line custom background category names

### DIFF
--- a/DuckDuckGo/HomePage/View/HomePageSettings/BackgroundCategoryView.swift
+++ b/DuckDuckGo/HomePage/View/HomePageSettings/BackgroundCategoryView.swift
@@ -40,25 +40,28 @@ extension HomePage.Views {
 
         var body: some View {
             Button(action: action) {
-                VStack(alignment: .leading, spacing: Const.titleSpacing) {
-                    ZStack {
-                        if modeModel.contentType == .customImagePicker && !model.hasUserImages {
-                            BackgroundThumbnailView(displayMode: .addBackground)
-                        } else if modeModel.contentType == .defaultBackground {
-                            BackgroundThumbnailView(displayMode: .categoryView) {
-                                Color.newTabPageBackground
+                VStack(alignment: .leading, spacing: 0) {
+                    VStack(alignment: .leading, spacing: Const.titleSpacing) {
+                        ZStack {
+                            if modeModel.contentType == .customImagePicker && !model.hasUserImages {
+                                BackgroundThumbnailView(displayMode: .addBackground)
+                            } else if modeModel.contentType == .defaultBackground {
+                                BackgroundThumbnailView(displayMode: .categoryView) {
+                                    Color.newTabPageBackground
+                                }
+                            } else {
+                                BackgroundThumbnailView(
+                                    displayMode: .categoryView,
+                                    customBackground: modeModel.customBackgroundThumbnail ?? .solidColor(.color01)
+                                )
                             }
-                        } else {
-                            BackgroundThumbnailView(
-                                displayMode: .categoryView,
-                                customBackground: modeModel.customBackgroundThumbnail ?? .solidColor(.color01)
-                            )
+                        }
+                        if showTitle {
+                            Text(modeModel.title)
+                                .font(.system(size: 11))
                         }
                     }
-                    if showTitle {
-                        Text(modeModel.title)
-                            .font(.system(size: 11))
-                    }
+                    Spacer(minLength: 0)
                 }
             }
             .buttonStyle(.plain)

--- a/DuckDuckGo/HomePage/View/HomePageSettings/BackgroundThumbnailView.swift
+++ b/DuckDuckGo/HomePage/View/HomePageSettings/BackgroundThumbnailView.swift
@@ -98,14 +98,17 @@ extension HomePage.Views {
 
         var body: some View {
             ZStack {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(.clear)
-                    .background(thumbnailContent)
-                    .cornerRadius(4)
-                RoundedRectangle(cornerRadius: 4)
-                    .stroke(Color.homeSettingsBackgroundPreviewStroke)
-                    .frame(height: SettingsView.Const.gridItemHeight)
-                    .background(selectionBackground)
+                Group {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(.clear)
+                        .background(thumbnailContent)
+                        .cornerRadius(4)
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color.homeSettingsBackgroundPreviewStroke)
+                        .background(selectionBackground)
+                }
+                .frame(height: SettingsView.Const.gridItemHeight)
+
                 if displayMode.allowsDeletingCustomBackgrounds, case .userImage(let image) = customBackground {
                     HStack {
                         Spacer()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201621708115095/1208921971523524/f

**Description**:
This change fixes layout of BackgroundCategoryView to correctly align multi-line title labels with other grid items.

**Steps to test this PR**:
1. Set app language to Italian
2. Run the app from Xcode
3. Open Customize panel in NTP
4. Verify that background categories grid is aligned correctly.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
