### PR TITLE
disable contextual onboarding

### DIFF
--- a/DuckDuckGo/Statistics/Experiment/PixelExperiment.swift
+++ b/DuckDuckGo/Statistics/Experiment/PixelExperiment.swift
@@ -60,8 +60,8 @@ enum PixelExperiment: String, CaseIterable {
 
     // These are the variants. Rename or add/remove them as needed.  If you change the string value
     //  remember to keep it clear for privacy triage.
-    case control = "oc"
-    case newOnboarding = "od"
+    case control = "oe"
+    case newOnboarding = "of"
 }
 
 // These functions contain the business logic for determining if the pixel should be fired or not.

--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -793,7 +793,6 @@ protocol NewWindowPolicyDecisionMaker {
 #endif
 
         if PixelExperiment.cohort == .newOnboarding {
-            Application.appDelegate.onboardingStateMachine.state = .notStarted
             setContent(.onboarding)
         } else {
             setContent(.onboardingDeprecated)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208965309086157/f

**Description**: We want to disable the contextual onboarding while leaving the rest of the treatment variant

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Run ./clean-app.sh debug
2. In MainWindowController in shouldShowOnboarding leave only line 87 and 88
3. Run the app (repeat the above steps until you get the new onboarding)
4. go through the onboarding and at the end check that no contextual dialog is present.

<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
