### PR TITLE
Bump workflows to Xcode 16.2

### DIFF
--- a/.github/workflows/pir_end_to_end_tests.yml
+++ b/.github/workflows/pir_end_to_end_tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         runner: [macos-15-xlarge]
         include:
-          - xcode-version: "16.1"
+          - xcode-version: "16.2"
             runner: macos-15-xlarge
 
     if: |

--- a/.github/workflows/sync_end_to_end.yml
+++ b/.github/workflows/sync_end_to_end.yml
@@ -41,7 +41,7 @@ jobs:
             runner: macos-13-xlarge
           - xcode-version: "15.4"
             runner: macos-14-xlarge
-          - xcode-version: "16.1"
+          - xcode-version: "16.2"
             runner: macos-15-xlarge
 
     timeout-minutes: 60

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -45,7 +45,7 @@ jobs:
             runner: macos-13-xlarge
           - xcode-version: "15.4"
             runner: macos-14-xlarge
-          - xcode-version: "16.1"
+          - xcode-version: "16.2"
             runner: macos-15-xlarge
 
     concurrency:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1209021750286613/f

**Description**: We have bumped CI to Xcode 16.2 as per [here](https://github.com/duckduckgo/macos-browser/pull/3677). This PR bumps workflows to address failing PIR and UI tests.

**Optional E2E tests**:
- [X] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Green CI

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
