### PR TITLE
Fix tabs width resizing glitch

### DIFF
--- a/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -529,7 +529,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             if dividedWidth < TabBarViewItem.Width.minimumSelected {
                 dividedWidth = (tabsWidth - TabBarViewItem.Width.minimumSelected) / (numberOfItems - 1)
             }
-            return min(TabBarViewItem.Width.maximum, max(minimumWidth, dividedWidth)).rounded()
+            return min(TabBarViewItem.Width.maximum, max(minimumWidth, dividedWidth))
         } else {
             return minimumWidth
         }


### PR DESCRIPTION
Fixes #3694

**Description:**

- Removes the rounding logic from the tab width calculation to fix the UI glitch that occurs during "traffic lights" (minimize/close/fullscreen buttons) visibility transitions in fullscreen mode.
- The rounding had no measurable performance benefit, and its removal ensures that tab widths resize smoothly and consistently during traffic lights visibility changes.

**Steps to test this PR:**

1. Open enough tabs to fill the screen width in fullscreen mode.
2. Move the cursor to the top of the screen to make the traffic lights appear.
3. Verify that tabs shift positions smoothly to make space for the traffic lights.

**Evidence:**

https://github.com/user-attachments/assets/f235f856-7fa6-42e9-8bee-d0597c43c66e