### PR TITLE
Fixes tabs shifting in Fire Window fullscreen mode

### DIFF
--- a/DuckDuckGo/TabBar/View/Base.lproj/TabBar.storyboard
+++ b/DuckDuckGo/TabBar/View/Base.lproj/TabBar.storyboard
@@ -272,11 +272,11 @@
                             <constraint firstItem="8Av-Au-VBq" firstAttribute="top" secondItem="JQD-ov-FCr" secondAttribute="top" id="UNA-xd-vb7"/>
                             <constraint firstItem="G3c-kC-Gu9" firstAttribute="leading" secondItem="JQD-ov-FCr" secondAttribute="leading" constant="76" id="a7p-a2-dhE"/>
                             <constraint firstItem="O0X-yp-zLn" firstAttribute="leading" secondItem="zsA-or-9Xo" secondAttribute="leading" id="bIL-4K-ggG"/>
+                            <constraint firstItem="kOb-4q-pAe" firstAttribute="leading" secondItem="G3c-kC-Gu9" secondAttribute="leading" priority="600" id="cW3-iX-UYZ"/>
                             <constraint firstItem="8Av-Au-VBq" firstAttribute="leading" secondItem="JQD-ov-FCr" secondAttribute="leading" id="djE-ZR-Zcb"/>
                             <constraint firstAttribute="trailing" secondItem="efe-Pc-ueP" secondAttribute="trailing" id="etm-VT-0k2"/>
                             <constraint firstItem="1Zn-JZ-2g3" firstAttribute="bottom" secondItem="G3c-kC-Gu9" secondAttribute="bottom" id="hCx-vd-PYo"/>
                             <constraint firstItem="dN1-y1-5Xe" firstAttribute="leading" secondItem="efe-Pc-ueT" secondAttribute="trailing" id="hWs-AC-dwE"/>
-                            <constraint firstItem="kOb-4q-pAe" firstAttribute="leading" secondItem="JQD-ov-FCr" secondAttribute="leading" priority="600" constant="76" id="i6Z-BW-hhH"/>
                             <constraint firstAttribute="bottom" secondItem="efe-Pc-ueP" secondAttribute="bottom" id="iYT-Di-UlL"/>
                             <constraint firstAttribute="trailing" secondItem="8kJ-Ja-bmu" secondAttribute="trailing" id="jKc-Ox-sjo"/>
                             <constraint firstItem="1Zn-JZ-2g3" firstAttribute="leading" secondItem="G3c-kC-Gu9" secondAttribute="leading" id="kBj-jh-X0L"/>


### PR DESCRIPTION
Fixes #3696 

**Description**:

- Fixes an issue in Fire Window fullscreen mode where tabs always left space for the "traffic lights" (minimize/close/fullscreen buttons) by changing the lower priority leading constraint to ensure tabs dynamically adjust their position and size based on the visibility of the traffic lights.
- The issue was caused by a lower-priority constraint (`StackView.Leading = Superview.Leading + 76`) being applied in the Fire Window because the `PinnedTabsContainerView` was empty. In normal browsing mode, this constraint had no effect because the `PinnedTabsContainerView` contained the `pinnedTabsView`, and a higher-priority constraint (`StackView.Leading = PinnedTabsContainerView.Trailing`) took precedence.

_Note: It might be sufficient to remove the lower-priority constraint altogether, but the constraint may serve as a fallback in specific scenarios I don’t know about._

**Steps to test this PR**:

1. Open a Fire Window in fullscreen mode.
2. Verify that tabs no longer leave a fixed space for the traffic lights when they are hidden.
3. Move the cursor to the top of the screen to make the traffic lights appear.
4. Verify that tabs shift positions to make space for the traffic lights when they appear.
5. Compare with a regular browser window in fullscreen mode to ensure consistent behavior.

**Evidence:**

https://github.com/user-attachments/assets/775528b7-bc60-4221-af80-66cf73c3d358