### PR TITLE
Fix updating profile not triggering UI updates

### DIFF
--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/MapperToUITests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/MapperToUITests.swift
@@ -52,11 +52,16 @@ final class MapperToUITests: XCTestCase {
             .mock(dataBrokerName: "Broker #2")
         ]
 
+        let expected: [DBPUIScanProgress.ScannedBroker] = [
+            .mock("Broker #1", status: .completed),
+        ]
+
         let result = sut.initialScanState(brokerProfileQueryData)
 
-        XCTAssertEqual(result.scanProgress.currentScans, 1)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.count, result.scanProgress.currentScans)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.first!.name, "Broker #1")
+        XCTAssertEqual(result.scanProgress.currentScans, brokerProfileQueryData.legacyCurrentScans)
+        XCTAssertEqual(result.scanProgress.currentScans, expected.currentScans)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.count, expected.count)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.first!.name, expected.first!.name)
         XCTAssertTrue(result.resultsFound.isEmpty)
     }
 
@@ -67,11 +72,16 @@ final class MapperToUITests: XCTestCase {
             .mock(dataBrokerName: "Broker #2")
         ]
 
+        let expected: [DBPUIScanProgress.ScannedBroker] = [
+            .mock("Broker #1", status: .inProgress),
+        ]
+
         let result = sut.initialScanState(brokerProfileQueryData)
 
-        XCTAssertEqual(result.scanProgress.currentScans, 1)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.count, result.scanProgress.currentScans)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.first!.name, "Broker #1")
+        XCTAssertEqual(result.scanProgress.currentScans, brokerProfileQueryData.legacyCurrentScans)
+        XCTAssertEqual(result.scanProgress.currentScans, expected.currentScans)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.count, expected.count)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.first!.name, expected.first!.name)
         XCTAssertTrue(result.resultsFound.isEmpty)
     }
 
@@ -102,12 +112,18 @@ final class MapperToUITests: XCTestCase {
             .mock(dataBrokerName: "Broker #2", lastRunDate: Date())
         ]
 
+        let expected: [DBPUIScanProgress.ScannedBroker] = [
+            .mock("Broker #1", status: .completed),
+            .mock("Broker #2", status: .completed),
+        ]
+
         let result = sut.initialScanState(brokerProfileQueryData)
 
         XCTAssertEqual(result.scanProgress.totalScans, result.scanProgress.currentScans)
-        XCTAssertEqual(result.scanProgress.currentScans, 2)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.count, result.scanProgress.currentScans)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.map{ $0.name }.sorted(), ["Broker #1", "Broker #2"])
+        XCTAssertEqual(result.scanProgress.currentScans, brokerProfileQueryData.legacyCurrentScans)
+        XCTAssertEqual(result.scanProgress.currentScans, expected.currentScans)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.count, expected.count)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.map{ $0.name }.sorted(), expected.map(\.name))
     }
 
     func testWhenScansHaveDeprecatedProfileQueries_thenThoseAreNotTakenIntoAccount() {
@@ -118,12 +134,18 @@ final class MapperToUITests: XCTestCase {
             .mock(dataBrokerName: "Broker #3", lastRunDate: Date(), extractedProfile: .mockWithRemovedDate, deprecated: true)
         ]
 
+        let expected: [DBPUIScanProgress.ScannedBroker] = [
+            .mock("Broker #1", status: .completed),
+            .mock("Broker #2", status: .completed),
+        ]
+
         let result = sut.initialScanState(brokerProfileQueryData)
 
         XCTAssertEqual(result.scanProgress.totalScans, 2)
-        XCTAssertEqual(result.scanProgress.currentScans, 2)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.count, result.scanProgress.currentScans)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.map{ $0.name }.sorted(), ["Broker #1", "Broker #2"])
+        XCTAssertEqual(result.scanProgress.currentScans, brokerProfileQueryData.legacyCurrentScans)
+        XCTAssertEqual(result.scanProgress.currentScans, expected.currentScans)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.count, expected.count)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.map{ $0.name }.sorted(), expected.map(\.name))
         XCTAssertEqual(result.resultsFound.count, 1)
     }
 
@@ -136,12 +158,18 @@ final class MapperToUITests: XCTestCase {
             .mock(dataBrokerName: "Broker #3", lastRunDate: Date(), extractedProfile: .mockWithRemovedDate, deprecated: true)
         ]
 
+        let expected: [DBPUIScanProgress.ScannedBroker] = [
+            .mock("Broker #1", status: .completed),
+            .mock("Broker #2", status: .completed),
+        ]
+
         let result = sut.initialScanState(brokerProfileQueryData)
 
         XCTAssertEqual(result.scanProgress.totalScans, 2)
-        XCTAssertEqual(result.scanProgress.currentScans, 2)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.count, result.scanProgress.currentScans)
-        XCTAssertEqual(result.scanProgress.scannedBrokers.map{ $0.name }.sorted(), ["Broker #1", "Broker #2"])
+        XCTAssertEqual(result.scanProgress.currentScans, brokerProfileQueryData.legacyCurrentScans)
+        XCTAssertEqual(result.scanProgress.currentScans, expected.currentScans)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.count, expected.count)
+        XCTAssertEqual(result.scanProgress.scannedBrokers.map{ $0.name }.sorted(), expected.map(\.name))
         XCTAssertEqual(result.resultsFound.count, 1)
     }
 
@@ -390,7 +418,7 @@ final class MapperToUITests: XCTestCase {
 
         let result = sut.initialScanState(brokerProfileQueryData)
 
-        XCTAssertEqual(result.scanProgress.currentScans, 5)
+        XCTAssertEqual(result.scanProgress.currentScans, 3)
         XCTAssertEqual(result.scanProgress.scannedBrokers, expected)
     }
 
@@ -466,6 +494,34 @@ final class MapperToUITests: XCTestCase {
 extension DBPUIScanProgress.ScannedBroker {
     static func mock(_ name: String, status: Self.Status) -> DBPUIScanProgress.ScannedBroker {
         .init(name: name, url: "test.com", status: status)
+    }
+}
+
+extension Array where Element == BrokerProfileQueryData {
+    /// Number of completed broker scans, the way it was calculated prior to the introduction of scannedBrokers (1.94.0)
+    fileprivate var legacyCurrentScans: Int {
+        filteredProfileQueriesGroupedByBroker.reduce(0) { accumulator, element in
+            return accumulator + element.value.currentScans
+        }
+    }
+
+    private var filteredProfileQueriesGroupedByBroker: [String: [BrokerProfileQueryData]] {
+        let profileQueriesGroupedByBroker = Dictionary(grouping: self, by: { $0.dataBroker.name })
+        return profileQueriesGroupedByBroker.mapValues { queries in
+            queries.filter { !$0.profileQuery.deprecated }
+        }
+    }
+
+    private var currentScans: Int {
+        guard let broker = self.first?.dataBroker else { return 0 }
+
+        let didAllQueriesFinished = allSatisfy { $0.scanJobData.lastRunDate != nil }
+
+        if !didAllQueriesFinished {
+            return 0
+        } else {
+            return 1 + broker.mirrorSites.filter { $0.shouldWeIncludeMirrorSite() }.count
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203581873609357/1209044506846805/f
Tech Design URL:
CC:

**Description**:

UI doesn't update (stuck at Next scan: XXX). Scans still run behind the scene but the UI doesn't reflect that status. This seems to be related to the way `currentScans` is calculated. The logic was updated when we introduced `scannedBrokers`

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Run a PIR scan
2. Once it finishes, update the profile by either adding/removing name or changing the DoB
3. UI should show Scan in progress

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
