### PR TITLE
Add privacyFeedHistoryLinkOpened pixel

### DIFF
--- a/DuckDuckGo/HomePage/View/HomePageViewController.swift
+++ b/DuckDuckGo/HomePage/View/HomePageViewController.swift
@@ -162,6 +162,7 @@ final class HomePageViewController: NSViewController {
 
     func createRecentlyVisitedModel() -> HomePage.Models.RecentlyVisitedModel {
         return .init { [weak self] url in
+            PixelKit.fire(GeneralPixel.privacyFeedHistoryLinkOpened, frequency: .dailyAndCount)
             self?.openUrl(url)
         }
     }

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -146,6 +146,9 @@ enum GeneralPixel: PixelKitEventV2 {
     case duckPlayerYouTubeOverlayNavigationClosed
     case duckPlayerYouTubeNavigationIdle30
 
+    // Temporary Home Page Pixels
+    case privacyFeedHistoryLinkOpened
+
     // Dashboard
     case dashboardProtectionAllowlistAdd(triggerOrigin: String?)
     case dashboardProtectionAllowlistRemove(triggerOrigin: String?)
@@ -694,6 +697,9 @@ enum GeneralPixel: PixelKitEventV2 {
             return "duckplayer_youtube_overlay_navigation_closed"
         case .duckPlayerYouTubeNavigationIdle30:
             return "duckplayer_youtube_overlay_idle-30"
+
+        case .privacyFeedHistoryLinkOpened:
+            return "privacy_feed_history_link_opened"
 
         case .dashboardProtectionAllowlistAdd:
             return "mp_wla"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209119352060519/f

**Description**:
This change adds a pixel that is fired whenever a user activates any history link in the Privacy Feed.

**Steps to test this PR**:
1. Run the app from Xcode and make sure you're using the native NTP
2. Accrue some browsing history
3. Click links in Privacy Feed and verify that `m_mac_privacy_feed_history_link_opened_daily` and `m_mac_privacy_feed_history_link_opened_count` are being fired.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
