### PR TITLE
Password manager: Fix tabbing between text fields

### DIFF
--- a/DuckDuckGo/SecureVault/View/AutoRecalculatingKeyViewHostingView.swift
+++ b/DuckDuckGo/SecureVault/View/AutoRecalculatingKeyViewHostingView.swift
@@ -1,0 +1,28 @@
+//
+//  AutoRecalculatingKeyViewHostingView.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+final class AutoRecalculatingKeyViewHostingView<Content: View>: NSHostingView<Content> {
+    override func layout() {
+        super.layout()
+
+        // Fix not being able to tab between TextFields by manually updating key view loop after SwiftUI has finished layout. This doesn't happen automatically because MainWindow sets autorecalculatesKeyViewLoop to false.
+        self.window?.recalculateKeyViewLoop()
+    }
+}

--- a/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -531,6 +531,11 @@ final class PasswordManagementViewController: NSViewController {
         itemContainer.addSubview(view)
         itemContainer.wantsLayer = true
         itemContainer.layer?.masksToBounds = false
+
+        // MainWindow sets autorecalculatesKeyViewLoop to false, so need to call recalculateKeyViewLoop() when view changes.
+        DispatchQueue.main.async {
+            view.window?.recalculateKeyViewLoop()
+        }
     }
 
     private func doSaveCredentials(_ credentials: SecureVaultModels.WebsiteCredentials) {

--- a/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -462,7 +462,7 @@ final class PasswordManagementViewController: NSViewController {
 
         self.itemModel = itemModel
 
-        let view = NSHostingView(rootView: PasswordManagementLoginItemView().environmentObject(itemModel))
+        let view = AutoRecalculatingKeyViewHostingView(rootView: PasswordManagementLoginItemView().environmentObject(itemModel))
         replaceItemContainerChildView(with: view)
     }
 
@@ -478,7 +478,7 @@ final class PasswordManagementViewController: NSViewController {
 
         self.itemModel = itemModel
 
-        let view = NSHostingView(rootView: PasswordManagementIdentityItemView().environmentObject(itemModel))
+        let view = AutoRecalculatingKeyViewHostingView(rootView: PasswordManagementIdentityItemView().environmentObject(itemModel))
         replaceItemContainerChildView(with: view)
     }
 
@@ -494,7 +494,7 @@ final class PasswordManagementViewController: NSViewController {
 
         self.itemModel = itemModel
 
-        let view = NSHostingView(rootView: PasswordManagementNoteItemView().environmentObject(itemModel))
+        let view = AutoRecalculatingKeyViewHostingView(rootView: PasswordManagementNoteItemView().environmentObject(itemModel))
         replaceItemContainerChildView(with: view)
     }
 
@@ -510,7 +510,7 @@ final class PasswordManagementViewController: NSViewController {
 
         self.itemModel = itemModel
 
-        let view = NSHostingView(rootView: PasswordManagementCreditCardItemView().environmentObject(itemModel))
+        let view = AutoRecalculatingKeyViewHostingView(rootView: PasswordManagementCreditCardItemView().environmentObject(itemModel))
         replaceItemContainerChildView(with: view)
     }
 
@@ -531,11 +531,6 @@ final class PasswordManagementViewController: NSViewController {
         itemContainer.addSubview(view)
         itemContainer.wantsLayer = true
         itemContainer.layer?.masksToBounds = false
-
-        // MainWindow sets autorecalculatesKeyViewLoop to false, so need to call recalculateKeyViewLoop() when view changes.
-        DispatchQueue.main.async {
-            view.window?.recalculateKeyViewLoop()
-        }
     }
 
     private func doSaveCredentials(_ credentials: SecureVaultModels.WebsiteCredentials) {


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/macos-browser/issues/3723

**Description**:

Fix tabbing between text fields in the password manager by manually recalculating key view loop in `PasswordManagementViewController`. This isn't done automatically [as `MainWindow` disables `autorecalculatesKeyViewLoop`](https://github.com/duckduckgo/macos-browser/blob/ef70ecc9ed957efeefe2d12870f1ad2b4a903a60/DuckDuckGo/MainWindow/MainWindow.swift#L61).

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Click  _Open application menu_ (⋯)
2. Click _Passwords & Autofill_
3. Click  _Add item_ (+)
4. Select any type of item, e.g. _Password_
5. Focus on a text field, e.g. the title field
6. Press <kbd>Tab</kbd>
7. Focus should move to the next text field.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
