### PR TITLE
fix crash on launch in WKWebView.valueForUndefinedKey(serverTrust)

### DIFF
--- a/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
+++ b/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
@@ -403,6 +403,9 @@ extension WKWebView {
 
     // prevent exception if private API keys go missing
     open override func value(forUndefinedKey key: String) -> Any? {
+        if key == #keyPath(serverTrust) {
+            return self.serverTrust
+        }
         assertionFailure("valueForUndefinedKey: \(key)")
         return nil
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202406491309510/1209123691403049/f

**Description**:
- Fixes crash on assertion on DEBUG build launch without debugger attached by updating the `valueForUndefinedKey:` implementation to match https://github.com/WebKit/WebKit/blob/905c9c9c56c44bdc41639300233ff28b658eec29/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm#L790

**Steps to test this PR**:
1. Build in DEBUG mode
2. Launch the DEBUG app from Finder
3. Validate the app doesn‘t crash

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
