### PR TITLE
Fix Duckplayer handler URL

### DIFF
--- a/DuckDuckGo/Tab/Navigation/DuckURLSchemeHandler.swift
+++ b/DuckDuckGo/Tab/Navigation/DuckURLSchemeHandler.swift
@@ -53,7 +53,7 @@ final class DuckURLSchemeHandler: NSObject, WKURLSchemeHandler {
         case .onboarding, .releaseNotes:
             handleSpecialPages(urlSchemeTask: urlSchemeTask)
         case .duckPlayer:
-            handleDuckPlayer(requestURL: requestURL, urlSchemeTask: urlSchemeTask, webView: webView)
+            handleDuckPlayer(requestURL: webViewURL, urlSchemeTask: urlSchemeTask, webView: webView)
         case .error:
             handleErrorPage(urlSchemeTask: urlSchemeTask)
         case .newTab where isNTPSpecialPageSupported && featureFlagger.isFeatureOn(.htmlNewTabPage):


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1204099484721401/1209111326156032/f
Tech Design URL:
CC:

**Description**:
- Fixes issue causing DuckPlayer to render the same (incorrect) video

**Steps to test this PR**:
1. Go to Settings > DuckPlayer, Check “Always open videos in DuckPlayer"
2. Go to Settings > DuckPlayer, UNCheck “Open DuckPlayer videos in a new tab whenever possible”
3. Go to https://www.youtube.com/@mkbhd
4. Click on a video
5. Confirm it opens in Duck Player
6. Hit ‘back'
7. Click another video
8. Confirm it opens in Duck Player (Previously, the old video was opening) 


###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
