### PR TITLE
re-enabled new onboarding for old macOS versions

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -795,11 +795,7 @@ protocol NewWindowPolicyDecisionMaker {
             return
         }
 #endif
-        if #available(macOS 13, *) {
-            setContent(PixelExperiment.cohort == .newOnboarding ? .onboarding : .onboardingDeprecated)
-        } else {
-            setContent(.onboardingDeprecated)
-        }
+        setContent(PixelExperiment.cohort == .newOnboarding ? .onboarding : .onboardingDeprecated)
     }
 
     @MainActor(unsafe)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209153206410271/f

**Description**: Re-enable new onboarding on old mac-OS version after fix is available on C-S-S

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. on MainWindowController make shouldShowOnboarding return true and make a review build
2. launch the app a few times on macOS >= 13 and check you can see both onboarding
3. launch the app a few times on macOS < 13 and check you can see both onboarding

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
