### PR TITLE
Cleanup InputFileCheker from outdated logic for DuckDuckGo Privacy Pro

### DIFF
--- a/LocalPackages/BuildToolPlugins/Plugins/InputFilesChecker/InputFilesChecker.swift
+++ b/LocalPackages/BuildToolPlugins/Plugins/InputFilesChecker/InputFilesChecker.swift
@@ -47,8 +47,6 @@ let extraInputFiles: [TargetName: Set<InputFile>] = [
 
     "DuckDuckGo Privacy Browser App Store": [],
 
-    "DuckDuckGo Privacy Pro": nonSandboxedExtraInputFiles,
-
     "Unit Tests": [
         .init("BWEncryptionTests.swift", .source),
         .init("WKWebViewPrivateMethodsAvailabilityTests.swift", .source)
@@ -92,8 +90,6 @@ struct TargetSourcesChecker: BuildToolPlugin, XcodeBuildToolPlugin {
         context.xcodeProject.targets.forEach { target in
             switch target.product?.kind {
             case .application where target.displayName.starts(with: "DuckDuckGo Privacy Browser"):
-                appTargets.append(target)
-            case .application where target.displayName == "DuckDuckGo Privacy Pro": // To be removed after the target is deleted
                 appTargets.append(target)
             case .other("com.apple.product-type.bundle.unit-test"):
                 if target.displayName.starts(with: "Unit Tests") {


### PR DESCRIPTION
Task/Issue URL: N/A

**Description**:

It seems that "DuckDuckGo Privacy Pro" target existed in the past, but it is not there anymore. Let's cleanup the `InputFilesChecker` from outdated logic. 

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
