### PR TITLE
Fix warnings related to @State used inline in Xcode previews

### DIFF
--- a/DuckDuckGo/Bookmarks/View/Dialog/AddEditBookmarkFolderView.swift
+++ b/DuckDuckGo/Bookmarks/View/Dialog/AddEditBookmarkFolderView.swift
@@ -93,9 +93,10 @@ private extension BookmarkDialogButtonsView.ViewState {
     }
 }
 
+@available(macOS 14.0, *)
 #Preview("Compressed") {
-    @State var folderName = ""
-    @State var selectedFolder: BookmarkFolder?
+    @Previewable @State var folderName = ""
+    @Previewable @State var selectedFolder: BookmarkFolder?
 
     return AddEditBookmarkFolderView(
         title: "Test Title",
@@ -112,9 +113,10 @@ private extension BookmarkDialogButtonsView.ViewState {
     )
 }
 
+@available(macOS 14.0, *)
 #Preview("Expanded") {
-    @State var folderName = ""
-    @State var selectedFolder: BookmarkFolder?
+    @Previewable @State var folderName = ""
+    @Previewable @State var selectedFolder: BookmarkFolder?
 
     return AddEditBookmarkFolderView(
         title: "Test Title",

--- a/DuckDuckGo/Bookmarks/View/Dialog/BookmarkDialogFolderManagementView.swift
+++ b/DuckDuckGo/Bookmarks/View/Dialog/BookmarkDialogFolderManagementView.swift
@@ -53,8 +53,9 @@ struct BookmarkDialogFolderManagementView: View {
     }
 }
 
+@available(macOS 14.0, *)
 #Preview {
-    @State var selectedFolder: BookmarkFolder? = BookmarkFolder(id: "1", title: "Nested Folder", children: [])
+    @Previewable @State var selectedFolder: BookmarkFolder? = BookmarkFolder(id: "1", title: "Nested Folder", children: [])
     let folderViewModels: [FolderViewModel] = [
         .init(
             entity: .init(

--- a/DuckDuckGo/Bookmarks/View/Dialog/BookmarkDialogStackedContentView.swift
+++ b/DuckDuckGo/Bookmarks/View/Dialog/BookmarkDialogStackedContentView.swift
@@ -73,10 +73,11 @@ extension BookmarkDialogStackedContentView {
 
 // MARK: - Preview
 
+@available(macOS 14.0, *)
 #Preview {
-    @State var name: String = "DuckDuckGo"
-    @State var url: String = "https://www.duckduckgo.com"
-    @State var selectedFolder: BookmarkFolder?
+    @Previewable @State var name: String = "DuckDuckGo"
+    @Previewable @State var url: String = "https://www.duckduckgo.com"
+    @Previewable @State var selectedFolder: BookmarkFolder?
 
     return BookmarkDialogStackedContentView(
         .init(

--- a/DuckDuckGo/HomePage/View/HomePageSettings/HomePageSettingsView.swift
+++ b/DuckDuckGo/HomePage/View/HomePageSettings/HomePageSettingsView.swift
@@ -233,8 +233,9 @@ extension HomePage.Views.BackgroundCategoryView {
 }
 
 #if DEBUG
+@available(macOS 14.0, *)
 #Preview("including continue set up cards") {
-    @State var isSettingsVisible: Bool = true
+    @Previewable @State var isSettingsVisible: Bool = true
 
     let settingsModel = HomePage.Models.SettingsModel()
     settingsModel.customBackground = .solidColor(.color10)
@@ -262,8 +263,9 @@ extension HomePage.Views.BackgroundCategoryView {
         .environmentObject(HomePage.Models.AddressBarModel(tabCollectionViewModel: TabCollectionViewModel(), privacyConfigurationManager: MockPrivacyConfigurationManager()))
 }
 
+@available(macOS 14.0, *)
 #Preview("no continue set up cards") {
-    @State var isSettingsVisible: Bool = true
+    @Previewable @State var isSettingsVisible: Bool = true
 
     let settingsModel = HomePage.Models.SettingsModel()
     settingsModel.customBackground = .solidColor(.color10)


### PR DESCRIPTION
Task/Issue URL: N/A

**Description**:

- Fix warnings related to `@State` used inline in Xcode previews by adding `@Previewable`. 
- To use `@Previewable` we need to specify `@available(macOS 14.0, *)`. That should be fine as the project is expected to run on the latest version of Xcode (a build script forces Xcode 16.2 which runs on macOS 14.5 or later). 

<img width="1060" alt="Screenshot 2025-01-15 at 16 29 13" src="https://github.com/user-attachments/assets/454b6223-7ed6-496b-9daa-e3122ae1ba85" />


**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
