### PR TITLE
Always open Watch In Youtube links in a new tab

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -311,8 +311,8 @@ extension DuckPlayerTabExtension: NavigationResponder {
             return .next
         }
 
-        if shouldOpenInNewTab, shouldOpenDuckPlayerDirectly,
-           let url = webView?.url, !url.isEmpty, !url.isYoutubeVideo {
+        if shouldOpenDuckPlayerDirectly,
+           let url = webView?.url, !url.isEmpty, !url.isYoutubeVideo {            
             webView?.loadInNewWindow(navigationAction.url)
             return .cancel
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204099484721401/1207942134403719/f
Tech Design URL:
CC:

**Description**:
Always Open “Watch in Youtube” links in a new tab.   This fixes a lot of back-forward navigation with DuckPlayer in the same tab, incluiding the task above

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
- [ ] 1.  Go to Settings > DuckPlayer
- [ ] 2. Disable “Open Duck Player in a new tab, whenever possible”
- [ ] 3. Enable “Always open Youtube videos in Duck Player"
- [ ] 4. Go to https://www.youtube.com/@mkbhd
- [ ] 5. Open a Video, which should open in Duck Player and make sure it’s playing
- [ ] 6. Click “Watch in Youtube” button at the bottom.
- [ ] 7. Confirm the video opens in a new tab, and the previous video pauses.
- [ ] 8. Hit the back button, and confirm the newly opened tab is closed and you’re back to the paused video.


<!—
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
—>

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
