### PR TITLE
BSK Bump - Defaults internal Privacy Pro links to /subscriptions

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -15365,8 +15365,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 224.6.2;
+				kind = revision;
+				revision = aba14e440b42ade0111da01b7579b28a22c3c027;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -15365,8 +15365,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = aba14e440b42ade0111da01b7579b28a22c3c027;
+				kind = exactVersion;
+				version = 224.7.1;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "aba14e440b42ade0111da01b7579b28a22c3c027"
+        "revision" : "5acb297db5c0edabe13c79efa33b1d0e545d6bff",
+        "version" : "224.7.1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "a2a5a32d111aadac6316db4cc629e5dd635939ba",
-        "version" : "224.6.2"
+        "revision" : "aba14e440b42ade0111da01b7579b28a22c3c027"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.6.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.7.1"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../AppKitExtensions"),
         .package(path: "../XPCHelper"),

--- a/LocalPackages/FeatureFlags/Package.swift
+++ b/LocalPackages/FeatureFlags/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["FeatureFlags"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.6.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.7.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.6.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.7.1"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.3"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/NewTabPage/Package.swift
+++ b/LocalPackages/NewTabPage/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["NewTabPage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.6.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.7.1"),
         .package(path: "../WebKitExtensions"),
         .package(path: "../Utilities"),
     ],

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.6.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.7.1"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../FeatureFlags")
     ],

--- a/LocalPackages/WebKitExtensions/Package.swift
+++ b/LocalPackages/WebKitExtensions/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.6.2"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "224.7.1"),
         .package(path: "../AppKitExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209009315184468/f

**Description**:
Previously, default Privacy Pro links were sent to `/subscriptions/welcome`, and the frontend redirected to `/subscriptions`.

Currently, this will still result in a redirect to `/subscriptions/welcome` for subscribed users—effectively a no-op. After an upcoming frontend release, this will show `/subscriptions` with a link to `/subscriptions/welcome`.

**Steps to test this PR**:
1. TBD

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
