### PR TITLE
Update autoconsent to v12.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "macos-browser",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^12.5.0"
+        "@duckduckgo/autoconsent": "^12.6.0"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-12.5.0.tgz",
-      "integrity": "sha512-6gKVbgaNMMGyn6ArE0yr38Z41o95UpFXnGJMS4IrycR7QW2j3hH22PKfCZ915BoCoRebHZWpS63W+jSG92UkQw==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-12.6.0.tgz",
+      "integrity": "sha512-stjNQKFxERDoOa5bfbjjzKhPfJNldPWTp9NPQK7U3ATQs4pOQBIeoq4h2QEz7nrgspRaHLFCbYQayRmXdatjSA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^12.5.0"
+    "@duckduckgo/autoconsent": "^12.6.0"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1209184566247348/1209184566247348
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v12.6.0


## Description
Updates Autoconsent to version [v12.6.0](https://github.com/duckduckgo/autoconsent/releases/tag/v12.6.0).

### Autoconsent v12.6.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v12.6.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI