### PR TITLE
Daily crash pixel

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -450,6 +450,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         crashCollection.startAttachingCrashLogMessages { pixelParameters, payloads, completion in
             pixelParameters.forEach { parameters in
                 PixelKit.fire(GeneralPixel.crash, withAdditionalParameters: parameters, includeAppVersionParameter: false)
+                PixelKit.fire(GeneralPixel.crashDaily, frequency: .legacyDaily)
             }
 
             guard let lastPayload = payloads.last else {

--- a/DuckDuckGo/CrashReports/Model/CrashReporter.swift
+++ b/DuckDuckGo/CrashReports/Model/CrashReporter.swift
@@ -50,6 +50,7 @@ final class CrashReporter {
         }
 
         PixelKit.fire(GeneralPixel.crash)
+        PixelKit.fire(GeneralPixel.crashDaily, frequency: .legacyDaily)
 
         promptPresenter.showPrompt(for: latest) {
             guard let contentData = latest.contentData else {

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -25,6 +25,7 @@ import Configuration
 enum GeneralPixel: PixelKitEventV2 {
 
     case crash
+    case crashDaily
     case crashOnCrashHandlersSetUp
     case crashReportingSubmissionFailed
     case crashReportCRCIDMissing
@@ -474,6 +475,9 @@ enum GeneralPixel: PixelKitEventV2 {
         switch self {
         case .crash:
             return "m_mac_crash"
+
+        case .crashDaily:
+            return "m_mac_crash_daily"
 
         case .crashOnCrashHandlersSetUp:
             return "m_mac_crash_on_handlers_setup"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1208908529122511/f
Tech Design URL:
CC:

**Description**:

This PR adds a daily crash pixel. This pixel was already triaged in December, but I lost track of it over the break.

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Go to `CrashReporter.swift` and comment out the `if !DEBUG` line so that the crash reporting check runs when debugging
2. Run the app
3. Now, quit the app and open it outside of Xcode - you should be able to find it in the `Applications/DEBUG` directory
4. Use the debug menu to crash it
5. Finally, launch the app via Xcode so that the app has a crash report to pick up, and check that the daily pixel fires

You should see a log like this:

```
[Legacy Daily-Fired] m_mac_crash_daily ["appVersion": "1.123.0", "pixelSource": "browser-dmg"]
```

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
