### PR TITLE
fix session restoration ui test

### DIFF
--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo Privacy Browser App Store.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo Privacy Browser App Store.xcscheme
@@ -98,6 +98,9 @@
                   Identifier = "BrokenSiteReportingReferenceTests/testBrokenSiteReporting()">
                </Test>
                <Test
+                  Identifier = "BrowserTabViewControllerOnboardingTests/testWhenNavigationCompletedAndNoDialogTypeThenOnlyWebViewVisible()">
+               </Test>
+               <Test
                   Identifier = "CBRCompileTimeReporterTests">
                </Test>
                <Test

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo Privacy Browser.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo Privacy Browser.xcscheme
@@ -127,6 +127,9 @@
                   Identifier = "BrokenSiteReportingReferenceTests/testBrokenSiteReporting()">
                </Test>
                <Test
+                  Identifier = "BrowserTabViewControllerOnboardingTests/testWhenNavigationCompletedAndNoDialogTypeThenOnlyWebViewVisible()">
+               </Test>
+               <Test
                   Identifier = "CBRCompileTimeReporterTests">
                </Test>
                <Test

--- a/UITests/StateRestorationTests.swift
+++ b/UITests/StateRestorationTests.swift
@@ -79,7 +79,7 @@ class StateRestorationTests: UITestCase {
             "Site didn't load with the expected title in a reasonable timeframe."
         )
 
-        app.terminate()
+        app.typeKey("q", modifierFlags: [.command])
         app.launch()
 
         XCTAssertTrue(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202406491309510/1209193663115526/f

**Description**:
- fix failing test due to session state data not getting to record due to force termination


**Steps to test this PR**:
1. Validate `test_tabStateAtRelaunch_shouldContainTwoSitesVisitedInPreviousSession_whenReopenAllWindowsFromLastSessionIsSet` passes

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
