### PR TITLE
Fixes an issue with the data volume in the VPN

### DIFF
--- a/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -382,7 +382,7 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 
     public var session: NETunnelProviderSession? {
         get async {
-            guard let manager = await manager,
+            guard let manager = internalManager,
                   let session = manager.connection as? NETunnelProviderSession else {
 
                 // The active connection is not running, so there's no session, this is acceptable


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1209205827151436/f

## Description:

The `DataVolumeObserver` is reloading all VPN configurations each second.  This is bad because it forces status updates on all observers each second.

## Testing:

1. Make sure you can start / stop the VPN
2. Make sure you can re-create the VPN configuration after manually removing it from System Settings
3. Make sure the data volume is shown correctly

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
