### PR TITLE
Fix some bugs with autocomplete suggestions

### DIFF
--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -1047,7 +1047,7 @@ extension AddressBarTextField: NSTextFieldDelegate {
         if isSuggestionWindowVisible {
             switch commandSelector {
             case #selector(NSResponder.moveRight(_:)):
-                hideSuggestionWindow()
+                suggestionContainerViewModel?.setUserStringValue(stringValueWithoutSuffix, userAppendedStringToTheEnd: false)
                 return false
 
             case #selector(NSResponder.moveDown(_:)):

--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -1046,6 +1046,10 @@ extension AddressBarTextField: NSTextFieldDelegate {
 
         if isSuggestionWindowVisible {
             switch commandSelector {
+            case #selector(NSResponder.moveRight(_:)):
+                hideSuggestionWindow()
+                return false
+
             case #selector(NSResponder.moveDown(_:)):
                 suggestionContainerViewModel?.selectNextIfPossible()
                 return true

--- a/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -1058,14 +1058,11 @@ extension AddressBarTextField: NSTextFieldDelegate {
                 suggestionContainerViewModel?.selectPreviousIfPossible()
                 return true
 
-            case #selector(NSResponder.deleteBackward(_:)),
-                 #selector(NSResponder.deleteForward(_:)),
+            case #selector(NSResponder.deleteForward(_:)),
                  #selector(NSResponder.deleteToMark(_:)),
                  #selector(NSResponder.deleteWordForward(_:)),
-                 #selector(NSResponder.deleteWordBackward(_:)),
                  #selector(NSResponder.deleteToEndOfLine(_:)),
                  #selector(NSResponder.deleteToEndOfParagraph(_:)),
-                 #selector(NSResponder.deleteToBeginningOfLine(_:)),
                  #selector(NSResponder.deleteBackwardByDecomposingPreviousCharacter(_:)):
 
                 suggestionContainerViewModel?.clearSelection()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1209218704563233/f

## Description

Fixes some issues with autofill suggestions.

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

## Testing:

These tests can also be used to see the original issues in our release build.

### Issue 1

1. Type any character in the address bar that will result in an autocompletion suggestion
2. Once the autocompletion suggestion is up press the right arrow
3. Backspace once
4. Ensure only the last character is deleted

### Issue 2:

1. Type any character in the address bar that will result in an autocompletion suggestion
2. Once the autocompletion suggestion is up press backspace once (variants: CMD + backspace, option + Backspace)
3. Ensure only the autocomplete suggestion is deleted

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
