### PR TITLE
Sync: Fire accountRemoved KV store reason when no account

### DIFF
--- a/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -15371,8 +15371,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 230.1.0;
+				branch = "graeme/fix-sync-user-defaults-event";
+				kind = branch;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -15356,8 +15356,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
 			requirement = {
-				branch = "graeme/fix-sync-user-defaults-event";
-				kind = branch;
+				kind = exactVersion;
+				version = 231.1.0;
 			};
 		};
 		9FF521422BAA8FF300B9819B /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "81e09dafb4fe49745e38c7e36609270d3d367839",
-        "version" : "231.0.0"
+        "revision" : "5a37e3ac08af48666d697191118eebad8af424ed",
+        "version" : "231.1.0"
       }
     },
     {

--- a/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "revision" : "2ed8705a2e8a0ba6cb5253ccf3b2f73f98da6bb0",
-        "version" : "230.1.0"
+        "branch" : "graeme/fix-sync-user-defaults-event",
+        "revision" : "a60f4b6d24d826cc9889bb5e6e47672ad0f1a9a1"
       }
     },
     {

--- a/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/BrowserServicesKit",
       "state" : {
-        "branch" : "graeme/fix-sync-user-defaults-event",
-        "revision" : "a60f4b6d24d826cc9889bb5e6e47672ad0f1a9a1"
+        "revision" : "2ed8705a2e8a0ba6cb5253ccf3b2f73f98da6bb0",
+        "version" : "230.1.0"
       }
     },
     {

--- a/LocalPackages/DataBrokerProtection/Package.swift
+++ b/LocalPackages/DataBrokerProtection/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             targets: ["DataBrokerProtection"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.1.0"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../AppKitExtensions"),
         .package(path: "../XPCHelper"),

--- a/LocalPackages/FeatureFlags/Package.swift
+++ b/LocalPackages/FeatureFlags/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["FeatureFlags"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/LocalPackages/HistoryView/Package.swift
+++ b/LocalPackages/HistoryView/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["HistoryView"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.1.0"),
         .package(path: "../WebKitExtensions"),
         .package(path: "../UserScriptActionsManager"),
         .package(path: "../Utilities"),

--- a/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/LocalPackages/NetworkProtectionMac/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "VPNAppLauncher", targets: ["VPNAppLauncher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.1.0"),
         .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.4.3"),
         .package(path: "../AppLauncher"),
         .package(path: "../UDSHelper"),

--- a/LocalPackages/NewTabPage/Package.swift
+++ b/LocalPackages/NewTabPage/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["NewTabPage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.1.0"),
         .package(path: "../WebKitExtensions"),
         .package(path: "../UserScriptActionsManager"),
         .package(path: "../Utilities"),

--- a/LocalPackages/SubscriptionUI/Package.swift
+++ b/LocalPackages/SubscriptionUI/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["SubscriptionUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.1.0"),
         .package(path: "../SwiftUIExtensions"),
         .package(path: "../FeatureFlags")
     ],

--- a/LocalPackages/UserScriptActionsManager/Package.swift
+++ b/LocalPackages/UserScriptActionsManager/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
             targets: ["UserScriptActionsManager"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.1.0"),
     ],
     targets: [
         .target(

--- a/LocalPackages/WebKitExtensions/Package.swift
+++ b/LocalPackages/WebKitExtensions/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "231.1.0"),
         .package(path: "../AppKitExtensions")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202926619870900/1209014391063056/f

**Description**:

As part of [✓ Send pixels for account removal + decoding issues](https://app.asana.com/0/1199230911884351/1208723035104886/f), pixels were added indicating what the reason for the Sync account being removed from the Keychain was.

However, the pixel `sync_account_removed_reason_not-set-on-key-value-store` is being sent even when there was no account stored in the keychain in the first place. This could be obscuring a problem.

To make this Pixel more useful, we should update it so that it's only sent when there was an account stored in the keychain.

**Steps to test this PR**:
Hard to test the pixel itself as reporting on a broken state, but just do a quick smoke test of Sync on both platforms.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
