### PR TITLE
Fix an issue that caused VPN Tips and the TunnelVision-fix not to be publicly available

### DIFF
--- a/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -109,9 +109,9 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .networkProtectionAppExclusions:
             return .remoteDevelopment(.subfeature(NetworkProtectionSubfeature.appExclusions))
         case .networkProtectionUserTips:
-            return .remoteDevelopment(.subfeature(NetworkProtectionSubfeature.userTips))
+            return .remoteReleasable(.subfeature(NetworkProtectionSubfeature.userTips))
         case .networkProtectionEnforceRoutes:
-            return .remoteDevelopment(.subfeature(NetworkProtectionSubfeature.enforceRoutes))
+            return .remoteReleasable(.subfeature(NetworkProtectionSubfeature.enforceRoutes))
         case .htmlNewTabPage:
             return .remoteReleasable(.subfeature(HTMLNewTabPageSubfeature.isLaunched))
         case .historyView:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1209262365365751/f

## Description

Releases Tips and the TunnelVision fix for macOS

## Testing

### Testing Notes
Between tests, please remove the VPN configuration as keeping an existing one might cause `enforceRoutes` not to be properly set.

Also please note you can fake TunnelVision for testing purposes locally using these commands:

- Enable TunnelVision exploit: `sudo route -n add 34.160.111.145 192.168.0.1` (`sudo route -n <ifconfig.me_ip> <local_gateway>`)
- Disable TunnelVision exploit: `sudo route -n delete 34.160.111.145 192.168.0.1`

### Testing

1. Remove internal user state using the debug menu
2. Remove the VPN configuration from System Settings
3. Enable TunnelVision exploit
4. Start the VPN
5. Open: `ifconfig.me` using the browser and check that the IP is the private one.
6. Optionally: test with another VPN and see that it reports your public IP address.
7. Disable TunnelVision exploit

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
