### PR TITLE
Sync: Fix broken alerts

### DIFF
--- a/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -771,16 +771,16 @@ extension SyncPreferences: ManagementDialogModelDelegate {
     }
 
     private func handleAccountAlreadyExists(_ recoveryKey: SyncCode.RecoveryKey) {
-        if devices.count > 1 {
-            managementDialogModel.shouldShowSwitchAccountsMessage = true
-            PixelKit.fire(SyncSwitchAccountPixelKitEvent.syncAskUserToSwitchAccount.withoutMacPrefix)
-        } else {
-            Task { @MainActor in
+        Task { @MainActor in
+            if devices.count > 1 {
+                managementDialogModel.showSwitchAccountsMessage()
+                PixelKit.fire(SyncSwitchAccountPixelKitEvent.syncAskUserToSwitchAccount.withoutMacPrefix)
+            } else {
                 await switchAccounts(recoveryKey: recoveryKey)
                 managementDialogModel.endFlow()
             }
+            PixelKit.fire(DebugEvent(GeneralPixel.syncLoginExistingAccountError(error: SyncError.accountAlreadyExists)))
         }
-        PixelKit.fire(DebugEvent(GeneralPixel.syncLoginExistingAccountError(error: SyncError.accountAlreadyExists)))
     }
 
     func userConfirmedSwitchAccounts(recoveryCode: String) {

--- a/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/ManagementDialogModel.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/ManagementDialogModel.swift
@@ -57,6 +57,7 @@ public final class ManagementDialogModel: ObservableObject {
             .sink { [weak self] hasError in
                 self?.shouldShowErrorMessage = hasError
             }
+
     }
 
     @MainActor
@@ -70,6 +71,12 @@ public final class ManagementDialogModel: ObservableObject {
     @MainActor
     public func userConfirmedSwitchAccounts(recoveryCode: String) {
         delegate?.userConfirmedSwitchAccounts(recoveryCode: recoveryCode)
+    }
+
+    @MainActor
+    public func showSwitchAccountsMessage() {
+        shouldShowSwitchAccountsMessage = true
+        shouldShowErrorMessage = true
     }
 
     @MainActor

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/ManagementDialog.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/ManagementDialog.swift
@@ -62,25 +62,26 @@ public struct ManagementDialog: View {
     public var body: some View {
         content
             .alert(isPresented: $model.shouldShowErrorMessage) {
-                Alert(
-                    title: Text(errorTitle),
-                    message: Text(errorDescription),
-                    dismissButton: .default(Text(buttonTitle)) {
-                        model.endFlow()
-                    }
-                )
-            }
-            .alert(isPresented: $model.shouldShowSwitchAccountsMessage) {
-                Alert(
-                    title: Text(UserText.syncAlertSwitchAccountTitle),
-                    message: Text(UserText.syncAlertSwitchAccountMessage),
-                    primaryButton: .default(Text(UserText.syncAlertSwitchAccountButton)) {
-                        model.userConfirmedSwitchAccounts(recoveryCode: recoveryCodeModel.recoveryCode)
-                    },
-                    secondaryButton: .cancel {
-                        model.endFlow()
-                    }
-                )
+                if model.shouldShowSwitchAccountsMessage {
+                    Alert(
+                        title: Text(UserText.syncAlertSwitchAccountTitle),
+                        message: Text(UserText.syncAlertSwitchAccountMessage),
+                        primaryButton: .default(Text(UserText.syncAlertSwitchAccountButton)) {
+                            model.userConfirmedSwitchAccounts(recoveryCode: recoveryCodeModel.recoveryCode)
+                        },
+                        secondaryButton: .cancel {
+                            model.endFlow()
+                        }
+                    )
+                } else {
+                    Alert(
+                        title: Text(errorTitle),
+                        message: Text(errorDescription),
+                        dismissButton: .default(Text(buttonTitle)) {
+                            model.endFlow()
+                        }
+                    )
+                }
             }
     }
 

--- a/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/UnitTests/Sync/SyncPreferencesTests.swift
@@ -346,6 +346,7 @@ final class SyncPreferencesTests: XCTestCase {
 
         await fulfillment(of: [loginCalledExpectation], timeout: 5.0)
 
+        XCTAssert(managementDialogModel.shouldShowErrorMessage)
         XCTAssert(managementDialogModel.shouldShowSwitchAccountsMessage)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1209259008615034/f

**Description**:

As a result of the work merged for the project to [simplify switching sync accounts](https://app.asana.com/0/72649045549333/1208944782348823/f), presentation of error alerts was broken. This was a result of a misunderstanding on my part of how the `.alert` view modifier works.

I've update to only use one modifier, but instead branch on the type of alert.

Ideally I'd refactor to utilise an `alertType` enum, but I want to keep these changes as minimal as possible to reduce risk as it's going onto a release branch.

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Test the account switching feature following these steps: https://app.asana.com/0/72649045549333/1208993297756834/f
2. Run the CriticalPath Sync e2e tests to ensure the error alerts are still working.

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
