### PR TITLE
Strip patch component from the OS version in Pixel requests User Agent

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -650,6 +650,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let source = "browser-dmg"
 #endif
 
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let trimmedOSVersion = "\(osVersion.majorVersion).\(osVersion.minorVersion)"
+        let userAgent = UserAgent.duckDuckGoUserAgent(systemVersion: trimmedOSVersion)
+
         PixelKit.setUp(dryRun: dryRun,
                        appVersion: AppVersion.shared.versionNumber,
                        source: source,
@@ -657,7 +661,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                        defaults: .netP) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in
 
             let url = URL.pixelUrl(forPixelNamed: pixelName)
-            let apiHeaders = APIRequest.Headers(additionalHeaders: headers)
+            let apiHeaders = APIRequest.Headers(userAgent: userAgent, additionalHeaders: headers)
             let configuration = APIRequest.Configuration(url: url, method: .get, queryParameters: parameters, headers: apiHeaders)
             let request = APIRequest(configuration: configuration)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209268316380789/f

**Description**:
This change updates how we pass OS version in Pixel requests, as agreed in the [Privacy Triage](https://app.asana.com/0/69071770703008/1209176655620013).

**Steps to test this PR**:
1. Update AppDelegate.swift:657 (`PixelKit.setUp`) and set `dryRun` to `false`.
2. Set a breakpoint in AppDelegate.swift:668 (`request.fetch`) and run the app.
3. When stopped at the breakpoint, inspect `request` and verify that the User Agent header only contains OS version without the patch component.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
