### PR TITLE
Add the ability to click actions to fail silently

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/Actions/Click.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/Actions/Click.swift
@@ -71,7 +71,6 @@ struct ClickAction: Action {
         case dataSource
         case choices
         case `default`
-        case failSilently
     }
 
     func encode(to encoder: any Encoder) throws {

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/Actions/Click.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/Actions/Click.swift
@@ -36,7 +36,6 @@ struct ClickAction: Action {
     let dataSource: DataSource?
     let choices: [Choice]?
     let `default`: Default?
-    let failSilently: Bool?
 
     let hasDefault: Bool
 
@@ -44,7 +43,7 @@ struct ClickAction: Action {
         let elements: [PageElement]?
     }
 
-    init(id: String, actionType: ActionType, elements: [PageElement]? = nil, dataSource: DataSource? = nil, choices: [Choice]? = nil, `default`: Default? = nil, hasDefault: Bool = false, failSilently: Bool? = nil) {
+    init(id: String, actionType: ActionType, elements: [PageElement]? = nil, dataSource: DataSource? = nil, choices: [Choice]? = nil, `default`: Default? = nil, hasDefault: Bool = false) {
        self.id = id
        self.actionType = actionType
        self.elements = elements
@@ -52,7 +51,6 @@ struct ClickAction: Action {
        self.choices = choices
        self.default = `default`
        self.hasDefault = `default` != nil
-       self.failSilently = failSilently
    }
 
     init(from decoder: any Decoder) throws {
@@ -64,7 +62,6 @@ struct ClickAction: Action {
         self.choices = try container.decodeIfPresent([Choice].self, forKey: .choices)
         self.default = try container.decodeIfPresent(Default.self, forKey: .default)
         self.hasDefault = container.contains(.default)
-        self.failSilently = try container.decodeIfPresent(Bool.self, forKey: .failSilently)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -84,7 +81,6 @@ struct ClickAction: Action {
         try container.encodeIfPresent(self.elements, forKey: .elements)
         try container.encodeIfPresent(self.dataSource, forKey: .dataSource)
         try container.encodeIfPresent(self.choices, forKey: .choices)
-        try container.encodeIfPresent(self.failSilently, forKey: .failSilently)
 
         if self.hasDefault {
             try container.encode(self.default, forKey: .default)

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/Actions/Click.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/Actions/Click.swift
@@ -64,7 +64,6 @@ struct ClickAction: Action {
         self.choices = try container.decodeIfPresent([Choice].self, forKey: .choices)
         self.default = try container.decodeIfPresent(Default.self, forKey: .default)
         self.hasDefault = container.contains(.default)
-        
         self.failSilently = try container.decodeIfPresent(Bool.self, forKey: .failSilently)
     }
 

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/Actions/Click.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/Actions/Click.swift
@@ -36,6 +36,7 @@ struct ClickAction: Action {
     let dataSource: DataSource?
     let choices: [Choice]?
     let `default`: Default?
+    let failSilently: Bool?
 
     let hasDefault: Bool
 
@@ -43,7 +44,7 @@ struct ClickAction: Action {
         let elements: [PageElement]?
     }
 
-    init(id: String, actionType: ActionType, elements: [PageElement]? = nil, dataSource: DataSource? = nil, choices: [Choice]? = nil, `default`: Default? = nil, hasDefault: Bool = false) {
+    init(id: String, actionType: ActionType, elements: [PageElement]? = nil, dataSource: DataSource? = nil, choices: [Choice]? = nil, `default`: Default? = nil, hasDefault: Bool = false, failSilently: Bool? = nil) {
        self.id = id
        self.actionType = actionType
        self.elements = elements
@@ -51,6 +52,7 @@ struct ClickAction: Action {
        self.choices = choices
        self.default = `default`
        self.hasDefault = `default` != nil
+       self.failSilently = failSilently
    }
 
     init(from decoder: any Decoder) throws {
@@ -62,6 +64,8 @@ struct ClickAction: Action {
         self.choices = try container.decodeIfPresent([Choice].self, forKey: .choices)
         self.default = try container.decodeIfPresent(Default.self, forKey: .default)
         self.hasDefault = container.contains(.default)
+        
+        self.failSilently = try container.decodeIfPresent(Bool.self, forKey: .failSilently)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -71,6 +75,7 @@ struct ClickAction: Action {
         case dataSource
         case choices
         case `default`
+        case failSilently
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -80,6 +85,7 @@ struct ClickAction: Action {
         try container.encodeIfPresent(self.elements, forKey: .elements)
         try container.encodeIfPresent(self.dataSource, forKey: .dataSource)
         try container.encodeIfPresent(self.choices, forKey: .choices)
+        try container.encodeIfPresent(self.failSilently, forKey: .failSilently)
 
         if self.hasDefault {
             try container.encode(self.default, forKey: .default)

--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/PageElement.swift
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Model/PageElement.swift
@@ -24,6 +24,7 @@ struct PageElement: Codable, Sendable {
     let multiple: Bool?
     let min: String?
     let max: String?
+    let failSilently: Bool?
 }
 
 struct ProfileMatch: Codable, Sendable {

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerOperationActionTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerOperationActionTests.swift
@@ -128,7 +128,7 @@ final class DataBrokerOperationActionTests: XCTestCase {
     }
 
     func testWhenActionNeedsEmail_thenExtractedProfileEmailIsSet() async {
-        let fillFormAction = FillFormAction(id: "1", actionType: .fillForm, selector: "#test", elements: [.init(type: "email", selector: "#email", parent: nil, multiple: nil, min: nil, max: nil)], dataSource: nil)
+        let fillFormAction = FillFormAction(id: "1", actionType: .fillForm, selector: "#test", elements: [.init(type: "email", selector: "#email", parent: nil, multiple: nil, min: nil, max: nil, failSilently: nil)], dataSource: nil)
         let step = Step(type: .optOut, actions: [fillFormAction])
         let sut = OptOutJob(
             privacyConfig: PrivacyConfigurationManagingMock(),

--- a/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerOperationActionTests.swift
+++ b/LocalPackages/DataBrokerProtection/Tests/DataBrokerProtectionTests/DataBrokerOperationActionTests.swift
@@ -152,7 +152,7 @@ final class DataBrokerOperationActionTests: XCTestCase {
     }
 
     func testWhenGetEmailServiceFails_thenOperationThrows() async {
-        let fillFormAction = FillFormAction(id: "1", actionType: .fillForm, selector: "#test", elements: [.init(type: "email", selector: "#email", parent: nil, multiple: nil, min: nil, max: nil)], dataSource: nil)
+        let fillFormAction = FillFormAction(id: "1", actionType: .fillForm, selector: "#test", elements: [.init(type: "email", selector: "#email", parent: nil, multiple: nil, min: nil, max: nil, failSilently: nil)], dataSource: nil)
         let step = Step(type: .optOut, actions: [fillFormAction])
         let sut = OptOutJob(
             privacyConfig: PrivacyConfigurationManagingMock(),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209274402556158/f
Tech Design URL:
CC:

**Description**:
Add a “failSilently” directive to click actions to allow them to fail without throwing an error.

**Optional E2E tests**:
- [X] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Run tests
2. Edit an existing broker JSON, changing the selector of a click action to something nonsensical, then run it and see the error pop up.
3. No add `failSilently` to the element where you changed the selector and run it again. This action should not error out.

**Definition of Done**:

* [X] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
