### PR TITLE
Add termination reason as underlying error code for webkit termination pixel

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -1275,7 +1275,7 @@ extension Tab/*: NavigationResponder*/ { // to be moved to Tab+Navigation.swift
         let terminationReason = reason?.rawValue ?? -1
 
         let error = WKError(.webContentProcessTerminated, userInfo: [
-            WKProcessTerminationReason.userInfoKey: reason?.rawValue ?? -1,
+            WKProcessTerminationReason.userInfoKey: terminationReason,
             NSLocalizedDescriptionKey: UserText.webProcessCrashPageMessage,
             NSUnderlyingErrorKey: NSError(domain: WKErrorDomain, code: terminationReason)
         ])

--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -1272,9 +1272,12 @@ extension Tab/*: NavigationResponder*/ { // to be moved to Tab+Navigation.swift
     func webContentProcessDidTerminate(with reason: WKProcessTerminationReason?) {
         guard (error?.code.rawValue ?? WKError.Code.unknown.rawValue) != WKError.Code.webContentProcessTerminated.rawValue else { return }
 
+        let terminationReason = reason?.rawValue ?? -1
+
         let error = WKError(.webContentProcessTerminated, userInfo: [
             WKProcessTerminationReason.userInfoKey: reason?.rawValue ?? -1,
-            NSLocalizedDescriptionKey: UserText.webProcessCrashPageMessage
+            NSLocalizedDescriptionKey: UserText.webProcessCrashPageMessage,
+            NSUnderlyingErrorKey: NSError(domain: WKErrorDomain, code: terminationReason)
         ])
 
         let isInternalUser = internalUserDecider?.isInternalUser == true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209290104647426/f

**Description**:
This change adds WKTerminationReason code as underlying error code to webkit termination pixel.

**Steps to test this PR**:
1. Go to Tab.swift and add `webContentProcessDidTerminate(with: .exceededCPULimit)` at the end of init method.
2. Launch the app and verify that `m_mac_debug_webkit_did_terminate` pixel was sent with `"ue": "1"`.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
