### PR TITLE
Implement new launch pixel with ATT and SAD

### DIFF
--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -519,7 +519,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 #if SPARKLE
         PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: DockCustomizer().isAddedToDock)), frequency: .daily)
 #else
-        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: false)), frequency: .daily)
+        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: nil)), frequency: .daily)
 #endif
     }
 

--- a/DuckDuckGo/Application/AppDelegate.swift
+++ b/DuckDuckGo/Application/AppDelegate.swift
@@ -516,7 +516,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         freemiumDBPScanResultPolling = DefaultFreemiumDBPScanResultPolling(dataManager: DataBrokerProtectionManager.shared.dataManager, freemiumDBPUserStateManager: freemiumDBPUserStateManager)
         freemiumDBPScanResultPolling?.startPollingOrObserving()
 
-        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault)))
+#if SPARKLE
+        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: DockCustomizer().isAddedToDock)), frequency: .daily)
+#else
+        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: false)), frequency: .daily)
+#endif
     }
 
     private func fireFailedCompilationsPixelIfNeeded() {

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -31,7 +31,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case crashReportCRCIDMissing
     case compileRulesWait(onboardingShown: OnboardingShown, waitTime: CompileRulesWaitTime, result: WaitResult)
     case launchInitial(cohort: String)
-    case launch(isDefault: Bool, isAddedToDock: Bool)
+    case launch(isDefault: Bool, isAddedToDock: Bool?)
 
     case serp(cohort: String?)
     case serpInitial(cohort: String)
@@ -1197,8 +1197,14 @@ enum GeneralPixel: PixelKitEventV2 {
             return ["loginItemBundleID": loginItemBundleID, "action": action, "buildType": buildType, "macosVersion": osVersion]
 
         case .launch(let isDefault, let isAddedToDock):
-            return ["default_browser": isDefault ? "1" : "0", "dock": isAddedToDock ? "1" : "0"]
+            var params = [String: String]()
+            params["default_browser"] = isDefault ? "1" : "0"
 
+            if let isAddedToDock = isAddedToDock {
+                params["dock"] = isAddedToDock ? "1" : "0"
+            }
+
+            return params
         case .dataImportFailed(source: _, sourceVersion: let version, error: let error):
             var params = error.pixelParameters
 

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -31,7 +31,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case crashReportCRCIDMissing
     case compileRulesWait(onboardingShown: OnboardingShown, waitTime: CompileRulesWaitTime, result: WaitResult)
     case launchInitial(cohort: String)
-    case launch(isDefault: Bool)
+    case launch(isDefault: Bool, isAddedToDock: Bool)
 
     case serp(cohort: String?)
     case serpInitial(cohort: String)
@@ -492,8 +492,8 @@ enum GeneralPixel: PixelKitEventV2 {
         case .compileRulesWait(onboardingShown: let onboardingShown, waitTime: let waitTime, result: let result):
             return "m_mac_cbr-wait_\(onboardingShown)_\(waitTime)_\(result)"
 
-        case .launch(let isDefault):
-            return isDefault ? "ml_mac_app-launch_as-default" : "ml_mac_app-launch_as-nondefault"
+        case .launch:
+            return  "m_mac_daily_active_user"
 
         case .serp:
             return "m_mac_navigation_search"
@@ -1195,6 +1195,9 @@ enum GeneralPixel: PixelKitEventV2 {
         switch self {
         case .loginItemUpdateError(let loginItemBundleID, let action, let buildType, let osVersion):
             return ["loginItemBundleID": loginItemBundleID, "action": action, "buildType": buildType, "macosVersion": osVersion]
+
+        case .launch(let isDefault, let isAddedToDock):
+            return ["default_browser": isDefault ? "1" : "0", "dock": isAddedToDock ? "1" : "0"]
 
         case .dataImportFailed(source: _, sourceVersion: let version, error: let error):
             var params = error.pixelParameters


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1209270803592942/f
Tech Design URL:
CC:

**Description**:
Replace `ml_mac_app-launch_as-default` and `ml_mac_app-launch_as-nondefault` with a new pixel that will have two parameters for ATT (Add to Taskbar/Dock) and SAD (Set As Default).

The new pixel will be fired daily, with a `default_browser` and a `dock` parameter.

**Steps to test this PR**:
1. Run the application
2. Filter the console by the pixel name `m_mac_daily_active_user_d`, check that is being fired
3. Set the debug build as default browser and add it to dock
4. Launchthe app again
5. Both SAD and ATT parameters should be “1”.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
