### PR TITLE
Remove trailing whitespace from task URL in PR Task URL workflow

### DIFF
--- a/.github/workflows/macos_pr_task_url.yml
+++ b/.github/workflows/macos_pr_task_url.yml
@@ -29,7 +29,7 @@ jobs:
         task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
           | sed -E 's|.*https://(.*)|\1|' \
           | cut -d '/' -f 4)
-        echo "task_id=$task_id" >> $GITHUB_OUTPUT
+        echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 
     - name: Check App Board Project Membership
       id: check-board-membership


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1209311684037783

**Steps to test this PR**:
Verify that this task is properly added to App Board by automation.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
