### PR TITLE
Fix counting blocked trackers and add pixel for reporting NTP exceptions

### DIFF
--- a/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1099,6 +1099,8 @@
 		370C230F2C76A3D600A80A3E /* SettingsGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370C23042C76A31F00A80A3E /* SettingsGrid.swift */; };
 		370C23112C7747E200A80A3E /* ImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370C23102C7747E200A80A3E /* ImageProcessor.swift */; };
 		370C23122C7747E200A80A3E /* ImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370C23102C7747E200A80A3E /* ImageProcessor.swift */; };
+		370DB6E22D521D130055D988 /* NewTabPageConfigurationErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370DB6E12D521D0A0055D988 /* NewTabPageConfigurationErrorHandler.swift */; };
+		370DB6E32D521D130055D988 /* NewTabPageConfigurationErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370DB6E12D521D0A0055D988 /* NewTabPageConfigurationErrorHandler.swift */; };
 		370E70A32D4691560077D4F3 /* RecentActivityProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370E70A22D46914A0077D4F3 /* RecentActivityProviderTests.swift */; };
 		370E70A42D4691560077D4F3 /* RecentActivityProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370E70A22D46914A0077D4F3 /* RecentActivityProviderTests.swift */; };
 		371209212C232E3F003ADF3D /* RemoteMessagingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371209202C232E3F003ADF3D /* RemoteMessagingClient.swift */; };
@@ -3767,6 +3769,7 @@
 		370C23082C76A39900A80A3E /* BackgroundCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundCategoryView.swift; sourceTree = "<group>"; };
 		370C230A2C76A3BC00A80A3E /* BackgroundThumbnailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundThumbnailView.swift; sourceTree = "<group>"; };
 		370C23102C7747E200A80A3E /* ImageProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProcessor.swift; sourceTree = "<group>"; };
+		370DB6E12D521D0A0055D988 /* NewTabPageConfigurationErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageConfigurationErrorHandler.swift; sourceTree = "<group>"; };
 		370E70A22D46914A0077D4F3 /* RecentActivityProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentActivityProviderTests.swift; sourceTree = "<group>"; };
 		371209202C232E3F003ADF3D /* RemoteMessagingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingClient.swift; sourceTree = "<group>"; };
 		371209292C2333A0003ADF3D /* RemoteMessagingDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingDatabase.swift; sourceTree = "<group>"; };
@@ -6238,6 +6241,7 @@
 		379E4D632D439F9A00A901B1 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				370DB6E12D521D0A0055D988 /* NewTabPageConfigurationErrorHandler.swift */,
 				376E8C192D41186200D5D2EC /* DefaultRecentActivityActionsHandler.swift */,
 				37F9AEB02D1316FE007FD19B /* DefaultHomePageSettingsModelNavigator+NewTabPageLinkOpening.swift */,
 				3758A38B2D108229001CEAA1 /* NewTabPageFreemiumDBPBannerProvider.swift */,
@@ -11618,6 +11622,7 @@
 				F1D042A22BFBB4DD00A31506 /* DataBrokerProtectionSettings+Environment.swift in Sources */,
 				370270BD2C78B6D3002E44E4 /* NewTabBackgroundPixel.swift in Sources */,
 				BB7BA64C2D11FC170020B47E /* TabBarRemoteMessagePresenting.swift in Sources */,
+				370DB6E32D521D130055D988 /* NewTabPageConfigurationErrorHandler.swift in Sources */,
 				3706FAA3293F65D500E42796 /* CrashReportPromptViewController.swift in Sources */,
 				BD88A83F2C4F3E4300460A26 /* FeedbackCategoryProviding.swift in Sources */,
 				3706FAA4293F65D500E42796 /* ContextMenuManager.swift in Sources */,
@@ -13774,6 +13779,7 @@
 				316C48F02CC2B232000B08C1 /* AIChatPreferencesStorage.swift in Sources */,
 				B6830961274CDE99004B46BB /* FireproofDomainsContainer.swift in Sources */,
 				85B49AFA2CD1B7C5007FAA2A /* SystemInfo.swift in Sources */,
+				370DB6E22D521D130055D988 /* NewTabPageConfigurationErrorHandler.swift in Sources */,
 				B687B7CC2947A1E9001DEA6F /* ExternalAppSchemeHandler.swift in Sources */,
 				B65536AE2685E17200085A79 /* GeolocationService.swift in Sources */,
 				4B02198925E05FAC00ED7DEA /* FireproofingURLExtensions.swift in Sources */,

--- a/DuckDuckGo/NewTabPage/Features/NewTabPageConfigurationErrorHandler.swift
+++ b/DuckDuckGo/NewTabPage/Features/NewTabPageConfigurationErrorHandler.swift
@@ -1,0 +1,37 @@
+//
+//  NewTabPageConfigurationErrorHandler.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import NewTabPage
+import PixelKit
+
+final class NewTabPageConfigurationErrorHandler: EventMapping<NewTabPageConfigurationEvent> {
+
+    init() {
+        super.init { event, _, _, _ in
+            switch event {
+            case .newTabPageError(let message):
+                PixelKit.fire(DebugEvent(NewTabPagePixel.newTabPageExceptionReported(message: message)), frequency: .dailyAndStandard)
+            }
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<NewTabPageConfigurationEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}

--- a/DuckDuckGo/NewTabPage/Features/RecentActivityProvider.swift
+++ b/DuckDuckGo/NewTabPage/Features/RecentActivityProvider.swift
@@ -129,7 +129,7 @@ final class RecentActivityProvider: NewTabPageRecentActivityProviding {
                     return newItemRef
                 }()
 
-                activityItem?.activity.addBlockedEntities(historyEntry.blockedTrackingEntities)
+                activityItem?.activity.addBlockedEntities(from: historyEntry)
                 activityItem?.activity.addPage(fromHistory: historyEntry, dateFormatter: Self.relativeTime)
             }
 
@@ -192,16 +192,14 @@ extension NewTabPageDataModel.DomainActivity {
             favicon: favicon,
             favorite: urlFavoriteStatusProvider.isUrlFavorited(url: rootURL),
             trackersFound: historyEntry.trackersFound,
-            trackingStatus: .init(
-                totalCount: Int64(historyEntry.numberOfTrackersBlocked),
-                trackerCompanies: historyEntry.blockedTrackingEntities.map(NewTabPageDataModel.TrackingStatus.TrackerCompany.init)
-            ),
+            trackingStatus: .init(totalCount: 0, trackerCompanies: []), // keep this empty because it's updated separately
             history: []
         )
     }
 
-    mutating func addBlockedEntities(_ entities: Set<String>) {
-        let trackerCompanies = Set(entities.map(NewTabPageDataModel.TrackingStatus.TrackerCompany.init))
+    mutating func addBlockedEntities(from entry: HistoryEntry) {
+        let trackerCompanies = Set(entry.blockedTrackingEntities.filter({ !$0.isEmpty }).map(NewTabPageDataModel.TrackingStatus.TrackerCompany.init))
+        trackingStatus.totalCount += Int64(entry.numberOfTrackersBlocked)
         trackingStatus.trackerCompanies = Array(Set(trackingStatus.trackerCompanies).union(trackerCompanies))
     }
 

--- a/DuckDuckGo/NewTabPage/Features/RecentActivityProvider.swift
+++ b/DuckDuckGo/NewTabPage/Features/RecentActivityProvider.swift
@@ -106,8 +106,6 @@ final class RecentActivityProvider: NewTabPageRecentActivityProviding {
         var activityItems = [DomainActivityRef]()
         var activityItemsByDomain = [String: DomainActivityRef]()
 
-        let oneWeekAgo = Date.weekAgo
-
         browsingHistory
             .filter(\.isValidForRecentActivity)
             .sorted(by: { $0.lastVisit > $1.lastVisit })

--- a/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -68,7 +68,8 @@ extension NewTabPageActionsManager {
                 sectionsAvailabilityProvider: NewTabPageModeDecider(),
                 sectionsVisibilityProvider: appearancePreferences,
                 customBackgroundProvider: customizationProvider,
-                linkOpener: DefaultHomePageSettingsModelNavigator()
+                linkOpener: DefaultHomePageSettingsModelNavigator(),
+                eventMapper: NewTabPageConfigurationErrorHandler()
             ),
             NewTabPageCustomBackgroundClient(model: customizationProvider),
             NewTabPageRMFClient(remoteMessageProvider: activeRemoteMessageModel),

--- a/DuckDuckGo/Statistics/NewTabPagePixel.swift
+++ b/DuckDuckGo/Statistics/NewTabPagePixel.swift
@@ -138,6 +138,8 @@ enum NewTabPagePixel: PixelKitEventV2 {
      */
     case privacyStatsDatabaseError
 
+    case newTabPageExceptionReported(message: String)
+
     var name: String {
         switch self {
         case .newTabPageShown: return "m_mac_newtab_shown"
@@ -148,6 +150,7 @@ enum NewTabPagePixel: PixelKitEventV2 {
         case .blockedTrackingAttemptsShowMore: return "m_mac_new-tab-page_blocked-tracking-attempts_show-more"
         case .privacyStatsCouldNotLoadDatabase: return "new-tab-page_privacy-stats_could-not-load-database"
         case .privacyStatsDatabaseError: return "new-tab-page_privacy-stats_database_error"
+        case .newTabPageExceptionReported: return "new-tab-page_exception-reported"
         }
     }
 
@@ -165,6 +168,8 @@ enum NewTabPagePixel: PixelKitEventV2 {
                 parameters["blocked-tracking-attempts"] = String(privacyStats)
             }
             return parameters
+        case .newTabPageExceptionReported(let message):
+            return [PixelKit.Parameters.assertionMessage: message]
         case .favoriteSectionHidden,
                 .recentActivitySectionHidden,
                 .blockedTrackingAttemptsSectionHidden,

--- a/LocalPackages/NewTabPage/Sources/NewTabPage/Configuration/NewTabPageDataModel+Configuration.swift
+++ b/LocalPackages/NewTabPage/Sources/NewTabPage/Configuration/NewTabPageDataModel+Configuration.swift
@@ -43,6 +43,10 @@ extension NewTabPageDataModel {
         }
     }
 
+    struct Exception: Codable, Equatable {
+        let message: String
+    }
+
     struct NewTabPageConfiguration: Encodable {
         var widgets: [Widget]
         var widgetConfigs: [WidgetConfig]

--- a/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/CapturingNewTabPageConfigurationErrorHandler.swift
+++ b/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/CapturingNewTabPageConfigurationErrorHandler.swift
@@ -1,0 +1,43 @@
+//
+//  CapturingNewTabPageConfigurationErrorHandler.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Common
+import NewTabPage
+
+final class CapturingNewTabPageConfigurationEventHandler: EventMapping<NewTabPageConfigurationEvent> {
+    var events: [NewTabPageConfigurationEvent] = []
+
+    init() {
+        let localEvents = PassthroughSubject<NewTabPageConfigurationEvent, Never>()
+        super.init { event, _, _, _ in
+            localEvents.send(event)
+        }
+
+        cancellable = localEvents
+            .sink { [weak self] value in
+                self?.events.append(value)
+            }
+    }
+
+    override init(mapping: @escaping EventMapping<NewTabPageConfigurationEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+
+    private var cancellable: AnyCancellable?
+}

--- a/UITests/BookmarksAndFavoritesTests.swift
+++ b/UITests/BookmarksAndFavoritesTests.swift
@@ -82,7 +82,7 @@ class BookmarksAndFavoritesTests: UITestCase {
         contextualMenuRemoveBookmarkFromFavoritesMenuItem = app.menuItems["ContextualMenu.removeBookmarkFromFavoritesMenuItem"]
         defaultBookmarkDialogButton = app.buttons["BookmarkDialogButtonsView.defaultButton"]
         defaultBookmarkOtherButton = app.buttons["BookmarkDialogButtonsView.otherButton"]
-        favoriteGridAddFavoriteButton = app.staticTexts["HomePage.Models.FavoriteModel.addButton"]
+        favoriteGridAddFavoriteButton = app.buttons["Add Favorite"]
         favoriteThisPageMenuItem = app.menuItems["MainMenu.favoriteThisPage"]
         manageBookmarksMenuItem = app.menuItems["MainMenu.manageBookmarksMenuItem"]
         openBookmarksMenuItem = app.menuItems["MoreOptionsMenu.openBookmarks"]
@@ -297,7 +297,7 @@ class BookmarksAndFavoritesTests: UITestCase {
         let urlForAddFavoriteDialog = try XCTUnwrap(urlForBookmarksBar, "Couldn't unwrap page url")
         app.typeText("\(pageTitleForAddFavoriteDialog)\t")
         app.typeURL(urlForAddFavoriteDialog)
-        let newFavorite = app.otherElements.staticTexts[pageTitleForAddFavoriteDialog]
+        let newFavorite = app.links[pageTitleForAddFavoriteDialog]
 
         XCTAssertTrue(
             newFavorite.waitForExistence(timeout: UITests.Timeouts.elementExistence),
@@ -433,7 +433,7 @@ class BookmarksAndFavoritesTests: UITestCase {
 
         toggleBookmarksBarShowFavoritesOn()
         let unwrappedPageTitle = try XCTUnwrap(pageTitle, "It wasn't possible to unwrap pageTitle")
-        let firstFavoriteInGridMatchingTitle = app.staticTexts["HomePage.Models.FavoriteModel.\(unwrappedPageTitle)"].firstMatch
+        let firstFavoriteInGridMatchingTitle = app.staticTexts[unwrappedPageTitle].firstMatch
 
         XCTAssertTrue(
             firstFavoriteInGridMatchingTitle.waitForExistence(timeout: UITests.Timeouts.elementExistence),
@@ -545,7 +545,7 @@ class BookmarksAndFavoritesTests: UITestCase {
         app.typeKey("n", modifierFlags: .command) // New window
 
         let unwrappedPageTitle = try XCTUnwrap(pageTitle, "It wasn't possible to unwrap pageTitle")
-        let firstFavoriteInGridMatchingTitle = app.staticTexts["HomePage.Models.FavoriteModel.\(unwrappedPageTitle)"].firstMatch
+        let firstFavoriteInGridMatchingTitle = app.links[unwrappedPageTitle].firstMatch
         XCTAssertTrue(
             firstFavoriteInGridMatchingTitle.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "The favorited item in the grid did not become available in a reasonable timeframe."

--- a/UITests/UI Tests.xctestplan
+++ b/UITests/UI Tests.xctestplan
@@ -38,6 +38,7 @@
       "skippedTests" : [
         "BookmarksAndFavoritesTests\/test_bookmarks_canBeAddedTo_byClickingBookmarksButtonInAddressBar()",
         "BookmarksAndFavoritesTests\/test_favorites_canBeAddedTo_byClickingAddFavoriteInAddBookmarkPopover()",
+        "BookmarksAndFavoritesTests\/test_favorites_canBeRemovedFromNewTabViaContextClick()",
         "PermissionsTests"
       ],
       "target" : {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201091620985789/1209319157623402

**Description**:
This change adds a pixel for New Tab Page exceptions and also fixes counting blocked trackers
in Recent Activity widget on the NTP.

**Steps to test this PR**:
1. Launch the app and visit a few websites from the same domain.
2. Open NTP and check the number of blocked trackers.
3. Switch back to native NTP (using _Main Menu -> Debug -> Feature Flag Overrides -> htmlNewTabPage_)
4. Verify that the number of blocked trackers reported by Recent Activity widget is the same on native NTP as on HTML NTP. Note that it's OK if different tracker companies icons are shown on the two, as NTP implementation is broken :)

Testing the pixel is quite tricky, and I've tested it, so that you don't have to:
1. Check out `pr-releases/pr-1463` branch in content-scope-scripts and add it to the Xcode project
2. Run the app
3. On HTML NTP, open customization side panel
4. Check that logs report `m_mac_debug_new-tab-page_exception-reported` being fired.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
