### PR TITLE
Add daily pixel for WebKit terminations

### DIFF
--- a/DuckDuckGo/Tab/Model/Tab.swift
+++ b/DuckDuckGo/Tab/Model/Tab.swift
@@ -1317,7 +1317,7 @@ extension Tab/*: NavigationResponder*/ { // to be moved to Tab+Navigation.swift
             let additionalParameters = await SystemInfo.pixelParameters()
 #endif
 
-            PixelKit.fire(DebugEvent(GeneralPixel.webKitDidTerminate, error: error), withAdditionalParameters: additionalParameters)
+            PixelKit.fire(DebugEvent(GeneralPixel.webKitDidTerminate, error: error), frequency: .dailyAndStandard, withAdditionalParameters: additionalParameters)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/69071770703008/1209322185454642

**Description**:
This change introduces a daily pixel for WebKit terminations (alongside
the existing standard pixel reported for every tab crash).

**Steps to test this PR**:
1. Add the following line in Tab.swift line 305 (at the end of the initializer):
```
webContentProcessDidTerminate(with: .exceededCPULimit)
```
2. Run the app and verify in the logs that both `m_mac_debug_webkit_did_terminate` and `m_mac_debug_webkit_did_terminate_daily` pixels were fired.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
