### PR TITLE
Fire privacyFeedHistoryLinkOpened pixel from HTML NTP

### DIFF
--- a/DuckDuckGo/HomePage/View/HomePageViewController.swift
+++ b/DuckDuckGo/HomePage/View/HomePageViewController.swift
@@ -162,7 +162,7 @@ final class HomePageViewController: NSViewController {
 
     func createRecentlyVisitedModel() -> HomePage.Models.RecentlyVisitedModel {
         return .init { [weak self] url in
-            PixelKit.fire(GeneralPixel.privacyFeedHistoryLinkOpened, frequency: .dailyAndCount)
+            PixelKit.fire(NewTabPagePixel.privacyFeedHistoryLinkOpened, frequency: .dailyAndCount)
             self?.openUrl(url)
         }
     }

--- a/DuckDuckGo/NewTabPage/Features/DefaultRecentActivityActionsHandler.swift
+++ b/DuckDuckGo/NewTabPage/Features/DefaultRecentActivityActionsHandler.swift
@@ -20,6 +20,7 @@ import Combine
 import Common
 import Foundation
 import NewTabPage
+import PixelKit
 
 protocol URLFireproofStatusProviding: AnyObject {
     func isDomainFireproof(forURL url: URL) -> Bool
@@ -164,6 +165,8 @@ final class DefaultRecentActivityActionsHandler: RecentActivityActionsHandling {
         guard let tabCollectionViewModel else {
             return
         }
+
+        PixelKit.fire(NewTabPagePixel.privacyFeedHistoryLinkOpened, frequency: .dailyAndCount)
 
         if target == .newWindow || NSApplication.shared.isCommandPressed && NSApplication.shared.isOptionPressed {
             WindowsManager.openNewWindow(with: url, source: .bookmark, isBurner: tabCollectionViewModel.isBurner)

--- a/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -145,9 +145,6 @@ enum GeneralPixel: PixelKitEventV2 {
     case duckPlayerYouTubeOverlayNavigationClosed
     case duckPlayerYouTubeNavigationIdle30
 
-    // Temporary Home Page Pixels
-    case privacyFeedHistoryLinkOpened
-
     // Dashboard
     case dashboardProtectionAllowlistAdd(triggerOrigin: String?)
     case dashboardProtectionAllowlistRemove(triggerOrigin: String?)
@@ -702,9 +699,6 @@ enum GeneralPixel: PixelKitEventV2 {
             return "duckplayer_youtube_overlay_navigation_closed"
         case .duckPlayerYouTubeNavigationIdle30:
             return "duckplayer_youtube_overlay_idle-30"
-
-        case .privacyFeedHistoryLinkOpened:
-            return "privacy_feed_history_link_opened"
 
         case .dashboardProtectionAllowlistAdd:
             return "mp_wla"

--- a/DuckDuckGo/Statistics/NewTabPagePixel.swift
+++ b/DuckDuckGo/Statistics/NewTabPagePixel.swift
@@ -53,6 +53,18 @@ enum NewTabPagePixel: PixelKitEventV2 {
     case favoriteSectionHidden
 
     /**
+     * Event Trigger: A link in Privacy Feed (a.k.a. Recent Activity) is activated.
+     *
+     * > Related links:
+     * [Privacy Triage](https://app.asana.com/0/69071770703008/1209316863206567)
+     *
+     * Anomaly Investigation:
+     * - Anomaly in this pixel may mean an increase/drop in app use.
+     * - This pixel is fired from `DefaultRecentActivityActionsHandler` when handling `open` JS message.
+     */
+    case privacyFeedHistoryLinkOpened
+
+    /**
      * Event Trigger: Recent Activity section on NTP is hidden.
      *
      * > Related links:
@@ -144,6 +156,7 @@ enum NewTabPagePixel: PixelKitEventV2 {
         switch self {
         case .newTabPageShown: return "m_mac_newtab_shown"
         case .favoriteSectionHidden: return "m_mac_favorite-section-hidden"
+        case .privacyFeedHistoryLinkOpened: return "m_mac_privacy_feed_history_link_opened"
         case .recentActivitySectionHidden: return "m_mac_recent-activity-section-hidden"
         case .blockedTrackingAttemptsSectionHidden: return "m_mac_blocked-tracking-attempts-section-hidden"
         case .blockedTrackingAttemptsShowLess: return "m_mac_new-tab-page_blocked-tracking-attempts_show-less"
@@ -175,6 +188,7 @@ enum NewTabPagePixel: PixelKitEventV2 {
                 .blockedTrackingAttemptsSectionHidden,
                 .blockedTrackingAttemptsShowLess,
                 .blockedTrackingAttemptsShowMore,
+                .privacyFeedHistoryLinkOpened,
                 .privacyStatsCouldNotLoadDatabase,
                 .privacyStatsDatabaseError:
             return nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209326060139784


**Steps to test this PR**:
1. Run the app from Xcode and filter logs by PixelKit subsystem
2. Visit a website so that privacy feed on NTP is populated
3. Click any link on the privacy feed.
4. Verify that `m_mac_privacy_feed_history_link_opened_daily` and `m_mac_privacy_feed_history_link_opened_count`  pixels are logged.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
