### PR TITLE
Deduplicate entries in History Menu

### DIFF
--- a/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1175,6 +1175,10 @@
 		37445F9A2A1566420029F789 /* SyncDataProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37445F982A1566420029F789 /* SyncDataProviders.swift */; };
 		37445F9C2A1569F00029F789 /* SyncBookmarksAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37445F9B2A1569F00029F789 /* SyncBookmarksAdapter.swift */; };
 		37445F9D2A1569F00029F789 /* SyncBookmarksAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37445F9B2A1569F00029F789 /* SyncBookmarksAdapter.swift */; };
+		3745DE052D536DCF00024FC8 /* HistoryGroupingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3745DE042D536DCA00024FC8 /* HistoryGroupingProvider.swift */; };
+		3745DE062D536DCF00024FC8 /* HistoryGroupingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3745DE042D536DCA00024FC8 /* HistoryGroupingProvider.swift */; };
+		3745DE082D536EF900024FC8 /* HistoryGroupingProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3745DE072D536EF000024FC8 /* HistoryGroupingProviderTests.swift */; };
+		3745DE092D536EF900024FC8 /* HistoryGroupingProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3745DE072D536EF000024FC8 /* HistoryGroupingProviderTests.swift */; };
 		37479F152891BC8300302FE2 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37479F142891BC8300302FE2 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift */; };
 		374EF08329B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374EF08229B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift */; };
 		374EF08429B7575B003D2E87 /* RecentlyClosedCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374EF08229B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift */; };
@@ -3804,6 +3808,8 @@
 		374286242CC593F900E66323 /* HomePageSettingsVisibilityModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageSettingsVisibilityModelTests.swift; sourceTree = "<group>"; };
 		37445F982A1566420029F789 /* SyncDataProviders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDataProviders.swift; sourceTree = "<group>"; };
 		37445F9B2A1569F00029F789 /* SyncBookmarksAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncBookmarksAdapter.swift; sourceTree = "<group>"; };
+		3745DE042D536DCA00024FC8 /* HistoryGroupingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryGroupingProvider.swift; sourceTree = "<group>"; };
+		3745DE072D536EF000024FC8 /* HistoryGroupingProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryGroupingProviderTests.swift; sourceTree = "<group>"; };
 		37479F142891BC8300302FE2 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabCollectionViewModelTests+WithoutPinnedTabsManager.swift"; sourceTree = "<group>"; };
 		374EF08229B751FC003D2E87 /* RecentlyClosedCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyClosedCoordinatorTests.swift; sourceTree = "<group>"; };
 		374EFDF22D01C99700B30939 /* ActiveRemoteMessageModel+NewTabPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActiveRemoteMessageModel+NewTabPage.swift"; sourceTree = "<group>"; };
@@ -9235,6 +9241,7 @@
 				AAE75278263B046100B973F8 /* History.xcdatamodeld */,
 				AAE7527B263B056C00B973F8 /* EncryptedHistoryStore.swift */,
 				85D0327A2B8E3D090041D1FB /* HistoryCoordinatorExtension.swift */,
+				3745DE042D536DCA00024FC8 /* HistoryGroupingProvider.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -9270,6 +9277,7 @@
 		AAEC74B02642C48B00C2EFBC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				3745DE072D536EF000024FC8 /* HistoryGroupingProviderTests.swift */,
 				AAEC74B52642CC6A00C2EFBC /* HistoryStoringMock.swift */,
 				AAEC74B72642E43800C2EFBC /* HistoryStoreTests.swift */,
 			);
@@ -11707,6 +11715,7 @@
 				1D0DE9422C3BB9CC0037ABC2 /* ReleaseNotesParser.swift in Sources */,
 				EED4D3D92C874AE200C79EEA /* PopoverInfoViewController.swift in Sources */,
 				3707C722294B5D2900682A9F /* WKWebViewExtension.swift in Sources */,
+				3745DE052D536DCF00024FC8 /* HistoryGroupingProvider.swift in Sources */,
 				3706FAD9293F65D500E42796 /* FirefoxFaviconsReader.swift in Sources */,
 				3706FADB293F65D500E42796 /* ContentBlockingRulesUpdateObserver.swift in Sources */,
 				3706FADC293F65D500E42796 /* FirefoxLoginReader.swift in Sources */,
@@ -12737,6 +12746,7 @@
 				56A054002C1AEFA1007D8FAB /* OnboardingManagerTests.swift in Sources */,
 				3706FE36293F661700E42796 /* FirefoxFaviconsReaderTests.swift in Sources */,
 				3706FE37293F661700E42796 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift in Sources */,
+				3745DE092D536EF900024FC8 /* HistoryGroupingProviderTests.swift in Sources */,
 				3706FE38293F661700E42796 /* SuggestionContainerTests.swift in Sources */,
 				3706FE39293F661700E42796 /* TabTests.swift in Sources */,
 				9FAD623E2BD09DE5007F3A65 /* WebsiteInfoTests.swift in Sources */,
@@ -13510,6 +13520,7 @@
 				B684592225C93BE000DC17B6 /* Publisher.asVoid.swift in Sources */,
 				4B9DB01D2A983B24000927DB /* Waitlist.swift in Sources */,
 				BB9BDD4A2D09BAA80069E9EF /* TabBarRemoteMessageViewModel.swift in Sources */,
+				3745DE062D536DCF00024FC8 /* HistoryGroupingProvider.swift in Sources */,
 				AAA0CC33252F181A0079BC96 /* NavigationButtonMenuDelegate.swift in Sources */,
 				1DA84D2F2C11989D0011C80F /* Update.swift in Sources */,
 				AAC30A2A268E239100D2D9CD /* CrashReport.swift in Sources */,
@@ -14505,6 +14516,7 @@
 				5677A93D2C98414900DA7B0A /* ContextualOnboardingStateMachineTests.swift in Sources */,
 				AA652CCE25DD9071009059CC /* BookmarkListTests.swift in Sources */,
 				859E7D6D274548F2009C2B69 /* BookmarksExporterTests.swift in Sources */,
+				3745DE082D536EF900024FC8 /* HistoryGroupingProviderTests.swift in Sources */,
 				B6A5A2A825BAA35500AA7ADA /* WindowManagerStateRestorationTests.swift in Sources */,
 				B6AE39F129373AF200C37AA4 /* EmptyAttributionRulesProver.swift in Sources */,
 				4BB99D1126FE1A84001E4761 /* SafariBookmarksReaderTests.swift in Sources */,

--- a/DuckDuckGo/History/Services/HistoryGroupingProvider.swift
+++ b/DuckDuckGo/History/Services/HistoryGroupingProvider.swift
@@ -1,5 +1,5 @@
 //
-//  HistoryCoordinator+Grouping.swift
+//  HistoryGroupingProvider.swift
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
 //

--- a/DuckDuckGo/History/Services/HistoryGroupingProvider.swift
+++ b/DuckDuckGo/History/Services/HistoryGroupingProvider.swift
@@ -1,0 +1,89 @@
+//
+//  HistoryCoordinator+Grouping.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Common
+import FeatureFlags
+import Foundation
+import History
+import os.log
+
+/**
+ * This protocol describes a data source (history provider) for `HistoryGroupingProvider`.
+ */
+protocol HistoryGroupingDataSource: AnyObject {
+    var history: BrowsingHistory? { get }
+}
+
+extension HistoryCoordinator: HistoryGroupingDataSource {}
+
+/**
+ * This class is responsible for grouping history visits for History Menu.
+ *
+ * When `historyView` feature flag is enabled, visits are deduplicated
+ * to only have the latest visit per URL per day.
+ */
+final class HistoryGroupingProvider {
+    private let featureFlagger: FeatureFlagger
+    private(set) weak var dataSource: HistoryGroupingDataSource?
+
+    init(dataSource: HistoryGroupingDataSource, featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
+        self.featureFlagger = featureFlagger
+        self.dataSource = dataSource
+    }
+
+    /**
+     * Returns visits for a given day.
+     */
+    func getRecentVisits(maxCount: Int) -> [Visit] {
+        removeDuplicatesIfNeeded(from: getSortedArrayOfVisits())
+            .prefix(maxCount)
+            .filter { Calendar.current.isDateInToday($0.date) }
+    }
+
+    /**
+     * Returns history visits bucketed per day.
+     */
+    func getVisitGroupings() -> [HistoryMenu.HistoryGrouping] {
+        Dictionary(grouping: getSortedArrayOfVisits(), by: \.date.startOfDay)
+            .map { date, sortedVisits in
+                HistoryMenu.HistoryGrouping(date: date, visits: removeDuplicatesIfNeeded(from: sortedVisits))
+            }
+            .sorted { $0.date > $1.date }
+    }
+
+    private func removeDuplicatesIfNeeded(from sortedVisits: [Visit]) -> [Visit] {
+        // History View introduces visits deduplication to declutter history.
+        // We don't want to release it before History View, so we're
+        // only deduplicating visits if the feature flag is on.
+        guard featureFlagger.isFeatureOn(.historyView) else {
+            return sortedVisits
+        }
+        // It's so simple because visits array is sorted by timestamp, so removing duplicates would
+        // remove items with older timestamps (as proven by unit tests).
+        return sortedVisits.removingDuplicates(byKey: \.historyEntry?.url)
+    }
+
+    private func getSortedArrayOfVisits() -> [Visit] {
+        guard let history = dataSource?.history else {
+            Logger.general.error("HistoryCoordinator: No history available")
+            return []
+        }
+        return history.flatMap(\.visits).sorted { $0.date > $1.date }
+    }
+}

--- a/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/DuckDuckGo/Menus/MainMenuActions.swift
@@ -584,7 +584,7 @@ extension MainViewController {
 
         let dateString = sender.dateString
         let isToday = sender.isToday
-        let visits = sender.getVisits()
+        let visits = sender.getVisits(featureFlagger: featureFlagger)
         let alert = NSAlert.clearHistoryAndDataAlert(dateString: dateString)
         alert.beginSheetModal(for: window, completionHandler: { response in
             guard case .alertFirstButtonReturn = response else {

--- a/UnitTests/History/Services/HistoryGroupingProviderTests.swift
+++ b/UnitTests/History/Services/HistoryGroupingProviderTests.swift
@@ -1,0 +1,483 @@
+//
+//  HistoryGroupingProviderTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import History
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+final class MockHistoryGroupingDataSource: HistoryGroupingDataSource {
+    var history: BrowsingHistory? = []
+}
+
+final class HistoryGroupingProviderTests: XCTestCase {
+    private var dataSource: MockHistoryGroupingDataSource!
+    private var featureFlagger: MockFeatureFlagger!
+    private var provider: HistoryGroupingProvider!
+
+    override func setUp() async throws {
+        dataSource = MockHistoryGroupingDataSource()
+        featureFlagger = MockFeatureFlagger()
+        provider = HistoryGroupingProvider(dataSource: dataSource, featureFlagger: featureFlagger)
+    }
+
+    // MARK: - getRecentVisits with deduplication
+
+    func testWhenHistoryViewIsEnabledThenRecentVisitsAreDeduplicatedLeavingMostRecentVisit() throws {
+        featureFlagger.isFeatureOn = true
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-1)),
+                Visit(date: date.addingTimeInterval(-2)),
+                Visit(date: date.addingTimeInterval(-3))
+            ])
+        ]
+
+        let recentVisits = provider.getRecentVisits(maxCount: 100)
+        let firstRecentVisit = try XCTUnwrap(recentVisits[safe: 0])
+        XCTAssertEqual(recentVisits.count, 1)
+        XCTAssertEqual(firstRecentVisit.date, date.addingTimeInterval(-1))
+    }
+
+    func testWhenHistoryViewIsEnabledThenRecentVisitsAreSortedByMostRecentVisit() throws {
+        featureFlagger.isFeatureOn = true
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3)),
+                Visit(date: date.addingTimeInterval(-5)),
+                Visit(date: date.addingTimeInterval(-10))
+            ]),
+            .make(url: "https://example.com/index2.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-1)),
+                Visit(date: date.addingTimeInterval(-20))
+            ])
+        ]
+
+        let recentVisits = provider.getRecentVisits(maxCount: 100)
+        let firstRecentVisit = try XCTUnwrap(recentVisits[safe: 0])
+        let secondRecentVisit = try XCTUnwrap(recentVisits[safe: 1])
+        XCTAssertEqual(recentVisits.count, 2)
+        XCTAssertEqual(firstRecentVisit.date, date.addingTimeInterval(-1))
+        XCTAssertEqual(secondRecentVisit.date, date.addingTimeInterval(-3))
+    }
+
+    func testWhenHistoryViewIsEnabledThenRecentVisitsAreLimitedToMaxCount() throws {
+        featureFlagger.isFeatureOn = true
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3)),
+            ]),
+            .make(url: "https://example.com/index2.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-1)),
+            ]),
+            .make(url: "https://example.com/index3.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-10)),
+            ]),
+            .make(url: "https://example.com/index4.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-20)),
+            ]),
+            .make(url: "https://example.com/index5.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-6)),
+            ])
+        ]
+
+        let recentVisits = provider.getRecentVisits(maxCount: 3)
+        XCTAssertEqual(recentVisits.count, 3)
+        XCTAssertEqual(recentVisits.map(\.date), [
+            date.addingTimeInterval(-1),
+            date.addingTimeInterval(-3),
+            date.addingTimeInterval(-6)
+        ])
+    }
+
+    func testWhenHistoryViewIsEnabledThenRecentVisitsAreLimitedToCurrentDay() throws {
+        featureFlagger.isFeatureOn = true
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3)),
+            ]),
+            .make(url: "https://example.com/index2.html".url!, visits: [
+                Visit(date: date.daysAgo(1)),
+            ]),
+            .make(url: "https://example.com/index3.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-10)),
+            ]),
+            .make(url: "https://example.com/index4.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-20*3600)),
+            ]),
+            .make(url: "https://example.com/index5.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-6)),
+            ])
+        ]
+
+        let recentVisits = provider.getRecentVisits(maxCount: 100)
+        XCTAssertEqual(recentVisits.count, 3)
+        XCTAssertEqual(recentVisits.map(\.date), [
+            date.addingTimeInterval(-3),
+            date.addingTimeInterval(-6),
+            date.addingTimeInterval(-10)
+        ])
+    }
+
+    // MARK: - getRecentVisits without deduplication
+
+    func testWhenHistoryViewIsDisabledThenRecentVisitsAreNotDeduplicated() throws {
+        featureFlagger.isFeatureOn = false
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-1)),
+                Visit(date: date.addingTimeInterval(-2)),
+                Visit(date: date.addingTimeInterval(-3))
+            ])
+        ]
+
+        let recentVisits = provider.getRecentVisits(maxCount: 100)
+        XCTAssertEqual(recentVisits.count, 3)
+        XCTAssertEqual(recentVisits.map(\.date), [
+            date.addingTimeInterval(-1),
+            date.addingTimeInterval(-2),
+            date.addingTimeInterval(-3)
+        ])
+    }
+
+    func testWhenHistoryViewIsDisabledThenRecentVisitsAreSortedByMostRecentVisit() throws {
+        featureFlagger.isFeatureOn = false
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3)),
+                Visit(date: date.addingTimeInterval(-5)),
+                Visit(date: date.addingTimeInterval(-10))
+            ]),
+            .make(url: "https://example.com/index2.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-1)),
+                Visit(date: date.addingTimeInterval(-20))
+            ])
+        ]
+
+        let recentVisits = provider.getRecentVisits(maxCount: 100)
+        XCTAssertEqual(recentVisits.count, 5)
+        XCTAssertEqual(recentVisits.map(\.historyEntry?.url), [
+            "https://example.com/index2.html".url!,
+            "https://example.com".url!,
+            "https://example.com".url!,
+            "https://example.com".url!,
+            "https://example.com/index2.html".url!
+        ])
+        XCTAssertEqual(recentVisits.map(\.date), [
+            date.addingTimeInterval(-1),
+            date.addingTimeInterval(-3),
+            date.addingTimeInterval(-5),
+            date.addingTimeInterval(-10),
+            date.addingTimeInterval(-20)
+        ])
+    }
+
+    func testWhenHistoryViewIsDisabledThenRecentVisitsAreLimitedToMaxCount() throws {
+        featureFlagger.isFeatureOn = false
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3)),
+                Visit(date: date.addingTimeInterval(-5)),
+                Visit(date: date.addingTimeInterval(-10))
+            ]),
+            .make(url: "https://example.com/index2.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-1)),
+                Visit(date: date.addingTimeInterval(-20))
+            ])
+        ]
+
+        let recentVisits = provider.getRecentVisits(maxCount: 3)
+        XCTAssertEqual(recentVisits.count, 3)
+        XCTAssertEqual(recentVisits.map(\.date), [
+            date.addingTimeInterval(-1),
+            date.addingTimeInterval(-3),
+            date.addingTimeInterval(-5)
+        ])
+    }
+
+    func testWhenHistoryViewIsDisabledThenRecentVisitsAreLimitedToCurrentDay() throws {
+        featureFlagger.isFeatureOn = false
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3)),
+                Visit(date: date.addingTimeInterval(-5000)),
+                Visit(date: date.addingTimeInterval(-20*3600))
+            ]),
+            .make(url: "https://example.com/index2.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3000)),
+                Visit(date: date.daysAgo(1))
+            ])
+        ]
+
+        let recentVisits = provider.getRecentVisits(maxCount: 100)
+        XCTAssertEqual(recentVisits.count, 3)
+        XCTAssertEqual(recentVisits.map(\.date), [
+            date.addingTimeInterval(-3),
+            date.addingTimeInterval(-3000),
+            date.addingTimeInterval(-5000)
+        ])
+    }
+
+    // MARK: - getVisitGroupings with deduplication
+
+    func testWhenHistoryViewIsEnabledThenVisitGroupingsAreDeduplicated() throws {
+        featureFlagger.isFeatureOn = true
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3)),
+                Visit(date: date.addingTimeInterval(-100)),
+                Visit(date: date.daysAgo(1)),
+                Visit(date: date.daysAgo(1).addingTimeInterval(-100)),
+                Visit(date: date.daysAgo(2).addingTimeInterval(-1)),
+                Visit(date: date.daysAgo(2).addingTimeInterval(-100)),
+                Visit(date: date.daysAgo(4)),
+                Visit(date: date.daysAgo(4).addingTimeInterval(-100)),
+                Visit(date: date.daysAgo(5).addingTimeInterval(-1)),
+                Visit(date: date.daysAgo(5).addingTimeInterval(-100))
+            ]),
+            .make(url: "https://example.com/index2.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3000)),
+                Visit(date: date.addingTimeInterval(-5000)),
+                Visit(date: date.daysAgo(1).addingTimeInterval(-1)),
+                Visit(date: date.daysAgo(1).addingTimeInterval(-5000)),
+                Visit(date: date.daysAgo(2)),
+                Visit(date: date.daysAgo(2).addingTimeInterval(-5000)),
+                Visit(date: date.daysAgo(3)),
+                Visit(date: date.daysAgo(3).addingTimeInterval(-5000)),
+                Visit(date: date.daysAgo(5)),
+                Visit(date: date.daysAgo(5).addingTimeInterval(-5000))
+            ])
+        ]
+
+        let groupings = provider.getVisitGroupings()
+
+        XCTAssertEqual(groupings.count, 6)
+        XCTAssertEqual(groupings.map { $0.visits.map(\.date) }, [
+            [
+                date.addingTimeInterval(-3),
+                date.addingTimeInterval(-3000)
+            ],
+            [
+                date.daysAgo(1),
+                date.daysAgo(1).addingTimeInterval(-1)
+            ],
+            [
+                date.daysAgo(2),
+                date.daysAgo(2).addingTimeInterval(-1)
+            ],
+            [
+                date.daysAgo(3)
+            ],
+            [
+                date.daysAgo(4)
+            ],
+            [
+                date.daysAgo(5),
+                date.daysAgo(5).addingTimeInterval(-1)
+            ]
+        ])
+        XCTAssertEqual(groupings.map { $0.visits.map(\.historyEntry?.url) }, [
+            [
+                "https://example.com".url!,
+                "https://example.com/index2.html".url!
+            ],
+            [
+                "https://example.com".url!,
+                "https://example.com/index2.html".url!
+            ],
+            [
+                "https://example.com/index2.html".url!,
+                "https://example.com".url!
+            ],
+            [
+                "https://example.com/index2.html".url!
+            ],
+            [
+                "https://example.com".url!,
+            ],
+            [
+                "https://example.com/index2.html".url!,
+                "https://example.com".url!
+            ]
+        ])
+    }
+
+    // MARK: - getVisitGroupings without deduplication
+
+    func testWhenHistoryViewIsDisabledThenVisitGroupingsAreNotDeduplicated() throws {
+        featureFlagger.isFeatureOn = false
+
+        let date = Date.noonToday
+        dataSource.history = [
+            .make(url: "https://example.com".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3)),
+                Visit(date: date.addingTimeInterval(-100)),
+                Visit(date: date.daysAgo(1)),
+                Visit(date: date.daysAgo(1).addingTimeInterval(-100)),
+                Visit(date: date.daysAgo(2).addingTimeInterval(-1)),
+                Visit(date: date.daysAgo(2).addingTimeInterval(-100)),
+                Visit(date: date.daysAgo(4)),
+                Visit(date: date.daysAgo(4).addingTimeInterval(-100)),
+                Visit(date: date.daysAgo(5).addingTimeInterval(-1)),
+                Visit(date: date.daysAgo(5).addingTimeInterval(-100))
+            ]),
+            .make(url: "https://example.com/index2.html".url!, visits: [
+                Visit(date: date.addingTimeInterval(-3000)),
+                Visit(date: date.addingTimeInterval(-5000)),
+                Visit(date: date.daysAgo(1).addingTimeInterval(-1)),
+                Visit(date: date.daysAgo(1).addingTimeInterval(-5000)),
+                Visit(date: date.daysAgo(2)),
+                Visit(date: date.daysAgo(2).addingTimeInterval(-5000)),
+                Visit(date: date.daysAgo(3)),
+                Visit(date: date.daysAgo(3).addingTimeInterval(-5000)),
+                Visit(date: date.daysAgo(5)),
+                Visit(date: date.daysAgo(5).addingTimeInterval(-5000))
+            ])
+        ]
+
+        let groupings = provider.getVisitGroupings()
+
+        XCTAssertEqual(groupings.count, 6)
+        XCTAssertEqual(groupings.map { $0.visits.map(\.date) }, [
+            [
+                date.addingTimeInterval(-3),
+                date.addingTimeInterval(-100),
+                date.addingTimeInterval(-3000),
+                date.addingTimeInterval(-5000)
+            ],
+            [
+                date.daysAgo(1),
+                date.daysAgo(1).addingTimeInterval(-1),
+                date.daysAgo(1).addingTimeInterval(-100),
+                date.daysAgo(1).addingTimeInterval(-5000)
+            ],
+            [
+                date.daysAgo(2),
+                date.daysAgo(2).addingTimeInterval(-1),
+                date.daysAgo(2).addingTimeInterval(-100),
+                date.daysAgo(2).addingTimeInterval(-5000)
+            ],
+            [
+                date.daysAgo(3),
+                date.daysAgo(3).addingTimeInterval(-5000)
+            ],
+            [
+                date.daysAgo(4),
+                date.daysAgo(4).addingTimeInterval(-100)
+            ],
+            [
+                date.daysAgo(5),
+                date.daysAgo(5).addingTimeInterval(-1),
+                date.daysAgo(5).addingTimeInterval(-100),
+                date.daysAgo(5).addingTimeInterval(-5000)
+            ]
+        ])
+        XCTAssertEqual(groupings.map { $0.visits.map(\.historyEntry?.url) }, [
+            [
+                "https://example.com".url!,
+                "https://example.com".url!,
+                "https://example.com/index2.html".url!,
+                "https://example.com/index2.html".url!
+            ],
+            [
+                "https://example.com".url!,
+                "https://example.com/index2.html".url!,
+                "https://example.com".url!,
+                "https://example.com/index2.html".url!
+            ],
+            [
+                "https://example.com/index2.html".url!,
+                "https://example.com".url!,
+                "https://example.com".url!,
+                "https://example.com/index2.html".url!
+            ],
+            [
+                "https://example.com/index2.html".url!,
+                "https://example.com/index2.html".url!
+            ],
+            [
+                "https://example.com".url!,
+                "https://example.com".url!
+            ],
+            [
+                "https://example.com/index2.html".url!,
+                "https://example.com".url!,
+                "https://example.com".url!,
+                "https://example.com/index2.html".url!
+            ]
+        ])
+    }
+}
+
+private extension Date {
+    /// Useful for date calculations to ensure we're not going into a previous day
+    /// when removing a small time interval.
+    static var noonToday: Date {
+        Date.startOfDayTomorrow.addingTimeInterval(-12*3600)
+    }
+}
+
+private extension HistoryEntry {
+    static func make(
+        identifier: UUID = UUID(),
+        url: URL,
+        title: String? = nil,
+        failedToLoad: Bool = false,
+        numberOfTotalVisits: Int = 1,
+        lastVisit: Date = Date(),
+        visits: Set<Visit>,
+        numberOfTrackersBlocked: Int = 0,
+        blockedTrackingEntities: Set<String> = [],
+        trackersFound: Bool = false
+    ) -> HistoryEntry {
+        let entry = HistoryEntry(
+            identifier: identifier,
+            url: url,
+            title: title,
+            failedToLoad: failedToLoad,
+            numberOfTotalVisits: numberOfTotalVisits,
+            lastVisit: lastVisit,
+            visits: [],
+            numberOfTrackersBlocked: numberOfTrackersBlocked,
+            blockedTrackingEntities: blockedTrackingEntities,
+            trackersFound: trackersFound
+        )
+        entry.visits = Set(visits.map {
+            Visit(date: $0.date, identifier: entry.url, historyEntry: entry)
+        })
+        return entry
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209328755192084/f

**Description**:
This change updates History Menu to only display one item per URL per day,
which is in line with other mainstream browsers. This change remains behind historyView
feature flag and will only be made available when Full History View is released.
The grouping logic was extracted into HistoryGroupingProvider class where
it's made dependent on the feature flag state. Current behavior remains unchanged,
as evidenced by added unit tests.

**Steps to test this PR**:
1. Run the app from Xcode and burn all data.
2. Visit a url (ideally one that doesn't redirect anywhere else).
3. Duplicate a tab a couple of times.
4. Open _Main Menu -> History_ and verify that your URL is present there a couple of times (equal to the number of visits to the URL).
5. Select _Main Menu -> Debug -> Feature Flag Overrides -> historyView_ to enable History View, and verify that the URL is only shown once in History View.
6. Visit some URL (a.k.a. URL A).
7. Visit another URL (a.k.a. URL B).
8. Refresh URL A, refresh URL B, refresh URL A, refresh URL B, etc...
9. Verify that History Menu shows alternating URLs A, B, A, B (with the most recently visited on top).
10. Enable `historyView` feature flag and verify that History Menu only contains 1 item with URL A and 1 item with URL B (with the most recently visited on top).
11. Go to _History Menu -> Today -> Clear This History..._, then confirm removing history and verify that all history from Today is gone (menu is empty).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
