### PR TITLE
Fix PeopleWhiz selector

### DIFF
--- a/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Resources/JSON/peoplewhiz.com.json
+++ b/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Resources/JSON/peoplewhiz.com.json
@@ -21,7 +21,7 @@
           "noResultsSelector": "div[class^=ResultNotFound__NoResults]",
           "profile": {
             "name": {
-              "selector": "[class^='ResultsTable__Name-sc']"
+              "selector": ".//div[contains(@class, 'ResultsTable__Name')]/text()"
             },
             "age": {
               "selector": "[class^='ResultsTable__Age-sc']"
@@ -62,7 +62,7 @@
                   "selector": "[class^='ResultsTable__Record-sc']",
                   "profile": {
                     "name": {
-                      "selector": "[class^='ResultsTable__Name-sc']"
+                      "selector": ".//div[contains(@class, 'ResultsTable__Name')]/text()"
                     },
                     "age": {
                       "selector": "[class^='ResultsTable__Age-sc']"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206873150423133/1209329833070078
Tech Design URL:
CC:

**Description**:
Fixes the PeopleWhiz selector which was appending extra text to the name and causing matches to fail.

**Optional E2E tests**:
- [x] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Load into macOS, test in the debugger

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
