### PR TITLE
macOS: Open "Watch in Youtube" links in a new tab

### DIFF
--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -312,7 +312,8 @@ extension DuckPlayerTabExtension: NavigationResponder {
         }
 
         if shouldOpenDuckPlayerDirectly,
-           let url = webView?.url, !url.isEmpty, !url.isYoutubeVideo {            
+           let url = webView?.url, !url.isEmpty, !url.isYoutubeVideo {
+            webView?.stopAllMediaPlayback()
             webView?.loadInNewWindow(navigationAction.url)
             return .cancel
         }

--- a/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
+++ b/DuckDuckGo/Tab/TabExtensions/DuckPlayerTabExtension.swift
@@ -311,8 +311,8 @@ extension DuckPlayerTabExtension: NavigationResponder {
             return .next
         }
 
-        if shouldOpenInNewTab, shouldOpenDuckPlayerDirectly,
-           let url = webView?.url, !url.isEmpty, !url.isYoutubeVideo {
+        if shouldOpenDuckPlayerDirectly,
+           let url = webView?.url, !url.isEmpty, !url.isYoutubeVideo {            
             webView?.loadInNewWindow(navigationAction.url)
             return .cancel
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204099484721401/1209211829036067
Tech Design URL:
CC:

**Description**:
YouTube's internal navigation and redirects changed and are now causing problems with back/forward navigation and navigation history on macOS.

The most common issue is that back/forward navigation from “Watch on Youtube” button often leads to the video loading incorrectly, such as opening in fullscreen. 

This forces all “Watch in Youtube” links to open in a new tab

**Steps to test this PR**:
1. Go to Settings > Duck Player and **disable** “Open Duck Player in a new tab whenever possible"
2. Go to duck://player/Mt5MCfJ5tZQ
3. Click Watch in Youtube
4. Confirm the link opens in a new tab and video plays normally in Youtube
5. Close the newly open tab
6. Confirm the previous DuckPlayer tab is paused 

**Definition of Done**:

* [X] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
