### PR TITLE
quick fix for allowlist crash

### DIFF
--- a/DuckDuckGo/ContentBlocker/ContentBlockerRulesLists.swift
+++ b/DuckDuckGo/ContentBlocker/ContentBlockerRulesLists.swift
@@ -36,7 +36,8 @@ final class ContentBlockerRulesLists: DefaultContentBlockerRulesListsSource {
         if adClickAttribution.isEnabled,
            let tdsRulesIndex = result.firstIndex(where: { $0.name == DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName }) {
             let tdsRules = result[tdsRulesIndex]
-            let allowlistedTrackerNames = adClickAttribution.allowlist.map { $0.entity }
+            let allowlist = adClickAttribution.allowlist
+            let allowlistedTrackerNames = allowlist.map { $0.entity }
             let adSplitter = AdClickAttributionRulesSplitter(rulesList: tdsRules, allowlistedTrackerNames: allowlistedTrackerNames)
             if let splitRules = adSplitter.split() {
                 result.remove(at: tdsRulesIndex)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204186595873227/1209345938720177

**Description**: Improves concurrency problems where allowlist is modified or deallocated while in use in the contentBlockerRulesLists getter.
This is a quick fix for the release branch, but we should follow up with making allowlist thread safe in BSK

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
