### PR TITLE
Default to expanded favorites NTP section if setting is not present

### DIFF
--- a/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -38,7 +38,7 @@ extension NewTabPageActionsManager {
         let favoritesModel = NewTabPageFavoritesModel(
             actionsHandler: DefaultFavoritesActionsHandler(),
             favoritesPublisher: favoritesPublisher,
-            getLegacyIsViewExpandedSetting: UserDefaultsWrapper<Bool>(key: .homePageShowAllFavorites, defaultValue: false).wrappedValue
+            getLegacyIsViewExpandedSetting: UserDefaultsWrapper<Bool>(key: .homePageShowAllFavorites, defaultValue: true).wrappedValue
         )
 
         let customizationProvider = NewTabPageCustomizationProvider(homePageSettingsModel: settingsModel)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1209373805889971

**Description**:
This change ensures that if a user never updated NTP favorites expanded state setting, they will see
expanded favorites on NTP.

**Steps to test this PR**:
1. Run the app and import bookmarks. Ensure that you have more than 6 favorites.
2. On New Tab Page, collapse favorites section so that it displays only 6 favorites.
3. Close the app.
4. Delete settings:
```
defaults delete com.duckduckgo.macos.browser.debug new-tab-page.favorites.is-view-expanded # new, migrated setting
defaults delete com.duckduckgo.macos.browser.debug home.page.show.all.favorites # old setting
```
5. Run the app and verify that all favorites are displayed.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
