### PR TITLE
Fix targeted versions for error banner downloads

### DIFF
--- a/DuckDuckGo/FileDownload/Model/DownloadListViewModel.swift
+++ b/DuckDuckGo/FileDownload/Model/DownloadListViewModel.swift
@@ -87,13 +87,12 @@ final class DownloadListViewModel {
             .store(in: &cancellables)
     }
 
-    /// macOS 15.0.1 and 14.7.x have a bug that affects downloads. Apple fixed the issue on macOS 15.1
+    /// macOS 15.0.x and 14.7.x have a bug that affects downloads. Apple fixed the issue on macOS 15.1
     /// For more information: https://app.asana.com/0/1204006570077678/1208522448255790/f
     private func isAffectedMacOSVersion() -> Bool {
         let currentVersion = AppVersion.shared.osVersion
-        let targetVersions = ["15.0.1"]
 
-        return targetVersions.contains(currentVersion) || currentVersion.hasPrefix("14.7.")
+        return currentVersion.hasPrefix("15.0") || currentVersion.hasPrefix("14.7.")
     }
 
     func cleanupInactiveDownloads() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1209364376915316
Tech Design URL:
CC:

**Description**:
It adds macOS 15.0 to the version pool, showing the download error banner.

**Steps to test this PR**:
1. Hardcode the `currentVersion` to `15.0`
2. In `WebKitDownloadTask.tempDownloadFileCreated`, add some code to throw a `NSError` with code `NSFileReadUnknownError`.
3. Then, try to download a file, it should be fail immediately and show the error banner
4. You can play with different hardcoded macOS versions to check if the banner is being shown.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
