### PR TITLE
Make title bar opaque when in full screen mode without tabs

### DIFF
--- a/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -279,6 +279,7 @@ extension MainWindowController: NSWindowDelegate {
             self?.mainViewController.mainView.webContainerTopConstraintToNavigation.animator().priority = .defaultHigh
             self?.mainViewController.mainView.webContainerTopConstraint.animator().priority = .defaultLow
             self?.moveTabBarView(toTitlebarView: false)
+            self?.window?.titlebarAppearsTransparent = false
             self?.window?.toolbar = nil
         }
     }
@@ -290,6 +291,7 @@ extension MainWindowController: NSWindowDelegate {
             self?.mainViewController.mainView.navigationBarTopConstraint.animator().constant = 38
             self?.mainViewController.mainView.webContainerTopConstraintToNavigation.animator().priority = .defaultLow
             self?.mainViewController.mainView.webContainerTopConstraint.animator().priority = .defaultHigh
+            self?.window?.titlebarAppearsTransparent = true
             self?.setupToolbar()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1209339803211451
Tech Design URL:
CC:

**Description**:

Make title bar opaque when in full screen mode without tabs

| Before | After |
| ------ | ----- |
![before](https://github.com/user-attachments/assets/1eaaf268-2c42-43d0-b04c-cc88a38a375b)|![after](https://github.com/user-attachments/assets/f4e9289a-68b9-4df8-bcfa-be8e404ffd15)

**Steps to test this PR**:
1. Open the browser and open Asana
2. Go to the View menu and deselect `Show Tabs and Bookmarks Bar in Full screen`
3. Enter full screen mode
4. Hover over the top
5. The title bar should be opaque

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

—
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
