### PR TITLE
Fix Address bar URL copied from SharePoints 

### DIFF
--- a/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2203,6 +2203,8 @@
 		9F56CFAE2B84326C00BB7F11 /* AddEditBookmarkDialogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56CFAC2B84326C00BB7F11 /* AddEditBookmarkDialogViewModel.swift */; };
 		9F56CFB12B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56CFB02B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift */; };
 		9F56CFB22B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56CFB02B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift */; };
+		9F5E48192D5D867600D2396D /* NSPasteboardExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E48162D5D867600D2396D /* NSPasteboardExtensionTests.swift */; };
+		9F5E481A2D5D867600D2396D /* NSPasteboardExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E48162D5D867600D2396D /* NSPasteboardExtensionTests.swift */; };
 		9F6434612BEC82B700D2D8A0 /* AttributionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6434602BEC82B700D2D8A0 /* AttributionPixelHandler.swift */; };
 		9F6434622BEC82B700D2D8A0 /* AttributionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6434602BEC82B700D2D8A0 /* AttributionPixelHandler.swift */; };
 		9F6434702BECBA2800D2D8A0 /* SubscriptionRedirectManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64346F2BECBA2800D2D8A0 /* SubscriptionRedirectManagerTests.swift */; };
@@ -4412,6 +4414,7 @@
 		9F56CFA82B82DC4300BB7F11 /* AddEditBookmarkFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditBookmarkFolderView.swift; sourceTree = "<group>"; };
 		9F56CFAC2B84326C00BB7F11 /* AddEditBookmarkDialogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditBookmarkDialogViewModel.swift; sourceTree = "<group>"; };
 		9F56CFB02B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksDialogViewFactory.swift; sourceTree = "<group>"; };
+		9F5E48162D5D867600D2396D /* NSPasteboardExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPasteboardExtensionTests.swift; sourceTree = "<group>"; };
 		9F6434602BEC82B700D2D8A0 /* AttributionPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionPixelHandler.swift; sourceTree = "<group>"; };
 		9F64346F2BECBA2800D2D8A0 /* SubscriptionRedirectManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionRedirectManagerTests.swift; sourceTree = "<group>"; };
 		9F872D972B8DA9F800138637 /* Bookmarks+Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmarks+Tab.swift"; sourceTree = "<group>"; };
@@ -7746,6 +7749,7 @@
 				4BBF0924283083EC00EE1418 /* FileSystemDSLTests.swift */,
 				B60C6F8329B1BAD3007BFAA8 /* FileManagerTempDirReplacement.swift */,
 				4B9292C42667104B00AD2C21 /* CoreDataTestUtilities.swift */,
+				9F5E48162D5D867600D2396D /* NSPasteboardExtensionTests.swift */,
 				B683097A274DCFE3004B46BB /* Database */,
 				AAEC74B92642E66600C2EFBC /* Extensions */,
 				4BA1A6CE258BF58C00F6F690 /* FileSystem */,
@@ -12499,6 +12503,7 @@
 				3706FE37293F661700E42796 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift in Sources */,
 				3745DE092D536EF900024FC8 /* HistoryGroupingProviderTests.swift in Sources */,
 				3706FE38293F661700E42796 /* SuggestionContainerTests.swift in Sources */,
+				9F5E48192D5D867600D2396D /* NSPasteboardExtensionTests.swift in Sources */,
 				3706FE39293F661700E42796 /* TabTests.swift in Sources */,
 				9FAD623E2BD09DE5007F3A65 /* WebsiteInfoTests.swift in Sources */,
 				3767319A2C7F36B300EB097B /* UserBackgroundImageTests.swift in Sources */,
@@ -14148,6 +14153,7 @@
 				B63ED0E326B3E7FA00A9DAD1 /* CLLocationManagerMock.swift in Sources */,
 				37CD54BB27F25A4000F1F7B9 /* DownloadsPreferencesTests.swift in Sources */,
 				4BE344EE2B2376DF003FC223 /* UnifiedFeedbackFormViewModelTests.swift in Sources */,
+				9F5E481A2D5D867600D2396D /* NSPasteboardExtensionTests.swift in Sources */,
 				9F872D9D2B9058D000138637 /* Bookmarks+TabTests.swift in Sources */,
 				BBFF355D2C4AF26200DA3289 /* BookmarksSortModeTests.swift in Sources */,
 				9F3910622B68C35600CB5112 /* DownloadsTabExtensionTests.swift in Sources */,

--- a/DuckDuckGo/Common/Extensions/NSPasteboardExtension.swift
+++ b/DuckDuckGo/Common/Extensions/NSPasteboardExtension.swift
@@ -34,10 +34,14 @@ extension NSPasteboard {
     }
 
     var url: URL? {
-        guard let urlString = self.string(forType: .URL) ?? self.string(forType: .fileURL) else { return nil }
-        return URL(string: urlString)
+        if let urlString = self.string(forType: .URL) ?? self.string(forType: .fileURL) {
+            return URL(string: urlString)
+        }
+        if let string = self.string(forType: .string), let url = URL(string: string), url.scheme != nil {
+            return url
+        }
+        return nil
     }
-
 }
 
 extension NSPasteboard.PasteboardType {

--- a/UnitTests/Common/NSPasteboardExtensionTests.swift
+++ b/UnitTests/Common/NSPasteboardExtensionTests.swift
@@ -1,0 +1,68 @@
+//
+//  NSPasteboardExtensionTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+@testable import DuckDuckGo_Privacy_Browser
+
+@Suite("Pasteboard Extensions Unit Tests", .serialized)
+final class NSPasteboardExtensionTests {
+
+    @Test(
+        "Return a URL when pasted data type represents a URL",
+        arguments: [
+            ("https:/www.duckduckgo.com", NSPasteboard.PasteboardType.URL),
+            ("file://Users/username/Documents/example.txt", .fileURL),
+            ("https://duckduckgo-my.sharepoint.com/:x:/r/personal/duckuser", .string),
+        ]
+    )
+    func whenPasteboardDataTypeIsURLThenReturnURL(context: (urlString: String, dataType: NSPasteboard.PasteboardType)) {
+        // GIVEN
+        let pasteboard = NSPasteboard.test()
+        pasteboard.clearContents()
+        pasteboard.declareTypes([context.dataType], owner: nil)
+        pasteboard.setString(context.urlString, forType: context.dataType)
+
+        // WHEN
+        let url = pasteboard.url
+
+        // THEN
+        #expect(url != nil)
+    }
+
+    @Test(
+        "Return nil when pasted data type does not represent a URL",
+        arguments: [
+            "baby ducklings",
+            "how to say duck in spanish"
+        ]
+    )
+    func whenPasteboardDataTypeIsURLThenReturnURL(string: String) {
+        // GIVEN
+        let pasteboard = NSPasteboard.test()
+        pasteboard.clearContents()
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString(string, forType: .string)
+
+        // WHEN
+        let url = pasteboard.url
+
+        // THEN
+        #expect(url == nil)
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1209391769658842

**Description**:

This PR fixes an issue where URLs copied from SharePoint wouldn't paste correctly into the address bar. Pasting the URL elsewhere worked fine.

Solution:
The issue is addressed by checking if the copied string results in a URL with a valid scheme in NSPasteboardExtension `var url:URL?`

**Optional E2E tests**:
- [ ] Run PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**: 
1. go to https://duckduckgo-my.sharepoint.com/
2. copy any document URL.
3. open a new tab.
4. paste that URL.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
