### PR TITLE
Fire NTP initial pixel from HTML New Tab Page

### DIFF
--- a/DuckDuckGo/NewTabPage/NewTabPageWebViewModel.swift
+++ b/DuckDuckGo/NewTabPage/NewTabPageWebViewModel.swift
@@ -19,6 +19,7 @@
 import BrowserServicesKit
 import Combine
 import NewTabPage
+import PixelKit
 import WebKit
 
 /**
@@ -54,6 +55,9 @@ final class NewTabPageWebViewModel: NSObject {
         webView.publisher(for: \.window)
             .map { $0 != nil }
             .sink { [weak activeRemoteMessageModel] isOnScreen in
+                if isOnScreen && OnboardingViewModel.isOnboardingFinished && AppDelegate.isNewUser {
+                    PixelKit.fire(GeneralPixel.newTabInitial, frequency: .legacyInitial)
+                }
                 activeRemoteMessageModel?.isViewOnScreen = isOnScreen
                 if isOnScreen {
                     NotificationCenter.default.post(name: .newTabPageWebViewDidAppear, object: nil)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201899738287924/1209398104352347

**Description**:
This change brings back the NTP pixel used for tracking Next Steps cards performance.

**Steps to test this PR**:
1. Update MainWindowControler.swift line 83 to `return true`
2. Clean app data and launch the app from Xcode
3. Go through onboarding and verify in the logs that `m_mac_new-tab-opened_initial` pixel was fired.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
